### PR TITLE
Fix a misspelling in the documentation.

### DIFF
--- a/docs/libxmp.rst
+++ b/docs/libxmp.rst
@@ -425,7 +425,7 @@ int xmp_start_player(xmp_context c, int rate, int format)
   **Parameters:**
     :c: the player context handle.
  
-    :rate: the sampling rate to use, in Hz (tipically 44100). Valid values
+    :rate: the sampling rate to use, in Hz (typically 44100). Valid values
        range from 8kHz to 48kHz.
 
     :flags: bitmapped configurable player flags, one or more of the


### PR DESCRIPTION
Hi,

this change corrects a misspelling in the documentation.

I hereby disclaim any explicit or implicit copyright ownership of this change
and place it under your choice of the public domain / CC-Zero / the MIT X11
licence / the LGPL v2-or-above / the GPL v2-or-above / any other licence
of your choice.

Nevertheless, I would appreciate if you credit me (Shlomi Fish, whose
home page is http://www.shlomifish.org/ ).
