### PR TITLE
Add emulation of the FT2 pattern loop bug.

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -163,6 +163,7 @@ void __inline CLIB_DECL D_(const char *text, ...) { do {} while (0); }
 #define QUIRK_S3MPMEM	(1 << 28)	/* S3M-style parameter memory */
 #define QUIRK_XMFINE	(1 << 29)	/* XM-style fine tune */
 #define QUIRK_RSTCHN	(1 << 30)	/* Reset channel on sample end */
+#define QUIRK_FT2LOOP	(1 << 31)	/* FT2 pattern loop bug */
 
 #define HAS_QUIRK(x)	(m->quirk & (x))
 
@@ -171,7 +172,7 @@ void __inline CLIB_DECL D_(const char *text, ...) { do {} while (0); }
 #define QUIRKS_ST3		(QUIRK_S3MLOOP | QUIRK_VOLPDN | QUIRK_FINEFX | \
 				 QUIRK_S3MPMEM | QUIRK_S3MRTG | QUIRK_S3MLFO )
 #define QUIRKS_FT2		(QUIRK_RTDELAY | QUIRK_FINEFX | QUIRK_ENVSUS | \
-				 QUIRK_XMFINE  )
+				 QUIRK_XMFINE  | QUIRK_FT2LOOP )
 #define QUIRKS_IT		(QUIRK_S3MLOOP | QUIRK_FINEFX | QUIRK_VIBALL | \
 				 QUIRK_ENVFADE | QUIRK_ITVPOR | QUIRK_KEYOFF | \
 				 QUIRK_VIRTUAL | QUIRK_FILTER | QUIRK_S3MLFO | \

--- a/src/effects.c
+++ b/src/effects.c
@@ -373,6 +373,8 @@ void process_fx(struct context_data *ctx, struct channel_data *xc, int chn,
 			if (fxp == 0) {
 				/* mark start of loop */
 				f->loop[chn].start = p->row;
+				if (HAS_QUIRK(QUIRK_FT2LOOP))
+				  p->flow.jumpline = p->row;
 			} else {
 				/* end of loop */
 				if (f->loop[chn].count) {

--- a/src/scan.c
+++ b/src/scan.c
@@ -391,6 +391,8 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
 			    }
 			} else { 
 			    loop_row[chn] = row;
+			    if (HAS_QUIRK(QUIRK_FT2LOOP))
+				break_row = row;
 			}
 		    }
 		}


### PR DESCRIPTION
One of the most (in)famous FT2 bugs is the E60 bug: When E60 is used on
a pattern row x, the following pattern also starts from row x instead of
the beginning of the pattern. This can be avoided by placing a D00
pattern break on the last row of the pattern where E60 was used.

Described here: http://www.milkytracker.org/docs/MilkyTracker.html#fxE6x

Test tune: http://api.modarchive.org/downloads.php?moduleid=55647#roadblas.xm
