### PR TITLE
Fix the interaction between FX_JUMP and FX_BREAK in scan_module().

### DIFF
--- a/src/scan.c
+++ b/src/scan.c
@@ -355,6 +355,7 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
 
 		if (f1 == FX_JUMP || f2 == FX_JUMP) {
 		    ord2 = (f1 == FX_JUMP) ? p1 : p2;
+		    break_row = 0;
 		    last_row = 0;
 		}
 


### PR DESCRIPTION
FX_JUMP should set break_row to 0, as it's already doing during playback.
This also has an effect on the FT2 E60 bug -- FX_JUMP resets the starting
row, undoing the effect of the bug.
