### PR TITLE
Check ProTracker song file sample names before opening them.

### DIFF
--- a/src/loaders/loader.h
+++ b/src/loaders/loader.h
@@ -37,6 +37,7 @@ char	*libxmp_instrument_name		(struct xmp_module *, int, uint8 *, int);
 struct xmp_sample* libxmp_realloc_samples(struct xmp_sample *, int *, int);
 
 char	*libxmp_copy_adjust		(char *, uint8 *, int);
+int	libxmp_copy_name_for_fopen	(char *, const char *, int);
 int	libxmp_test_name		(uint8 *, int);
 void	libxmp_read_title		(HIO_HANDLE *, char *, int);
 void	libxmp_set_xxh_defaults		(struct xmp_module *);

--- a/src/loaders/ssmt_load.c
+++ b/src/loaders/ssmt_load.c
@@ -181,16 +181,19 @@ static int mtp_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	D_(D_INFO "Instruments    : %d ", mod->ins);
 
 	for (i = 0; i < mod->ins; i++) {
+		struct xmp_instrument *xxi = &mod->xxi[i];
 		HIO_HANDLE *s;
 		char filename[1024];
+		char tmpname[32];
 
-		if (!mod->xxi[i].name[0])
+		if (!m->dirname) {
+			return -1;
+		}
+
+		if (!xxi->name[0] || libxmp_copy_name_for_fopen(tmpname, xxi->name, 32))
 			continue;
 
-		strncpy(filename, m->dirname, NAME_SIZE);
-		if (*filename)
-			strncat(filename, "/", NAME_SIZE);
-		strncat(filename, (char *)mod->xxi[i].name, NAME_SIZE);
+		snprintf(filename, 1024, "%s%s", m->dirname, tmpname);
 
 		if ((s = hio_open(filename, "rb")) != NULL) {
 			asif_load(m, s, i);


### PR DESCRIPTION
This adds a check to the code that generates ProTracker song sample filenames to make sure there isn't anything suspicious like slashes or ".." (as requested in the comments for https://github.com/cmatsuoka/libxmp/pull/116). I'm reasonably sure this patch is correct but I don't actually have any ProTracker song files to test this with right now, so please don't merge it. edit: I have tested it with a ProTracker song file now, so if you think the behavior of this new function is reasonable, I am OK with it being merged.

edit: also found this being used in the MTP loader, which currently isn't used, but I added this check to it anyway.