### PR TITLE
build: use configure flag to disable depackers

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -7,16 +7,10 @@ VERSION		= $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_RELEASE)
 # This dylib will support anything linked against COMPAT_VERSION through VERSION
 COMPAT_VERSION	= $(VERSION_MAJOR)
 
-# Module depacker functionality. To disable: make USE_DEPACKERS=0
-USE_DEPACKERS	= 1
-
 CC		= @CC@
 CFLAGS		= -c @CFLAGS@ @DEFS@ -D_REENTRANT
 CFLAGS_SHARED	= @CFLAGS_SHARED@
 CFLAGS_STATIC	= -DBUILDING_STATIC
-ifeq ($(USE_DEPACKERS),0)
-CFLAGS		+= -DLIBXMP_NO_DEPACKERS
-endif
 LD		= @CC@
 LDFLAGS		= @LDFLAGS@
 LIBS		= @LIBS@
@@ -69,10 +63,7 @@ include src/depackers/Makefile
 include src/os2/Makefile
 include src/win32/Makefile
 include test/Makefile
-ALL_OBJS=$(OBJS)
-ifeq ($(USE_DEPACKERS),1)
-ALL_OBJS+= $(DEPACKER_OBJS)
-endif
+ALL_OBJS=$(OBJS) @DEPACKER_OBJS@
 
 LOBJS = $(ALL_OBJS:.o=.lo)
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,8 @@
 dnl AC_CONFIG_AUX_DIR(./scripts)
 AC_INIT
-AC_ARG_ENABLE(static, [  --enable-static         Build static library])
-AC_ARG_ENABLE(shared, [  --disable-shared        Don't build shared library])
+AC_ARG_ENABLE(depackers, [  --disable-depackers     Don't build depackers])
+AC_ARG_ENABLE(static,    [  --enable-static         Build static library])
+AC_ARG_ENABLE(shared,    [  --disable-shared        Don't build shared library])
 AC_SUBST(LD_VERSCRIPT)
 AC_SUBST(DARWIN_VERSION)
 AC_CANONICAL_HOST
@@ -135,6 +136,12 @@ XMP_TRY_COMPILE(whether compiler understands -Warray-bounds,
   -Warray-bounds,[
   int main(void){return 0;}],
   CFLAGS="${CFLAGS} -Wno-array-bounds")  
+
+if test "${enable_depackers}" != no; then
+  AC_SUBST(DEPACKER_OBJS,'$(DEPACKER_OBJS)')
+else
+  CFLAGS="${CFLAGS} -DLIBXMP_NO_DEPACKERS"
+fi
 
 XMP_TRY_COMPILE(whether alloca() needs alloca.h,
   ac_cv_c_flag_w_have_alloca_h,,[


### PR DESCRIPTION
Use a flag to the configure script to enable and disable depackers
instead of editing the variable directly on the makefile in systems
where the Makefile is generated using autoconf.

OS/2 and VC++ makefiles retain USE_DEPACKERS.

Signed-off-by: Claudio Matsuoka <cmatsuoka@gmail.com>