### PR TITLE
update travis-ci configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,41 @@ script: autoconf && ./configure && make && make check && (cd test-dev; autoconf 
 
 matrix:
   include:
+    # Linux distributions
+
     - os: linux
-      compiler: i586-mingw32msvc-gcc
-      script: autoconf && ./configure --host=i586-mingw32msvc && make
+      dist: focal
+
     - os: linux
-      dist: xenial
-      compiler: clang
-      env: CFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address"
-      script: autoconf && ./configure && make && make check && (cd test-dev; autoconf && ./configure && make)
+      dist: bionic
+
     - os: linux
-      dist: xenial
-      compiler: clang
-      env: CFLAGS="-fsanitize=memory" LDFLAGS="-fsanitize=memory"
-      script: autoconf && ./configure && make && make check && (cd test-dev; autoconf && ./configure && make)
+      dist: precise
+
+    # mingw32 cross compilation
+
+    - os: linux
+      compiler: x86_64-w64-mingw32-gcc
+      script: autoconf && ./configure --host=x86_64-w64-mingw32 && make
+      dist: focal
+      addons:
+        apt:
+          packages:
+            - gcc-mingw-w64-base
+            - binutils-mingw-w64-x86-64
+            - gcc-mingw-w64-x86-64
+            - gcc-mingw-w64
+
+    # FIXME:
+    #- os: linux
+    #  dist: focal
+    #  compiler: clang
+    #  env: CFLAGS="-fsanitize=address" LD_LIBRARY_PATH=$(clang -print-file-name=libclang_rt.asan-x86_64.so) 
+    #  script: autoconf && ./configure && make && make check && (cd test-dev; autoconf && ./configure && make)
+
+    #- os: linux
+    #  dist: focal
+    #  compiler: clang
+    #  env: CFLAGS="-fsanitize=memory"
+    #  script: autoconf && ./configure && make && make check && (cd test-dev; autoconf && ./configure && make)
 


### PR DESCRIPTION
Change Travis CI configuration so it can be used to test pull requests.
Travis configuration can be improved later to re-enable clang analyzers
and include native Windows builds.

Signed-off-by: Claudio Matsuoka <cmatsuoka@gmail.com>