### PR TITLE
Fix test-dev sample, depack, prowizard, and api leaks.

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -36,6 +36,7 @@
 #include "list.h"
 #include "hio.h"
 #include "tempfile.h"
+#include "loaders/loader.h"
 
 #ifndef LIBXMP_NO_DEPACKERS
 #if !defined(HAVE_POPEN) && defined(_WIN32)
@@ -664,9 +665,7 @@ void xmp_release_module(xmp_context opaque)
 
 	if (mod->xxs != NULL) {
 		for (i = 0; i < mod->smp; i++) {
-			if (mod->xxs[i].data != NULL) {
-				free(mod->xxs[i].data - 4);
-			}
+			libxmp_free_sample(&mod->xxs[i]);
 		}
 		free(mod->xxs);
 		free(m->xtra);
@@ -675,9 +674,7 @@ void xmp_release_module(xmp_context opaque)
 #ifndef LIBXMP_CORE_DISABLE_IT
 	if (m->xsmp != NULL) {
 		for (i = 0; i < mod->smp; i++) {
-			if (m->xsmp[i].data != NULL) {
-				free(m->xsmp[i].data - 4);
-			}
+			libxmp_free_sample(&m->xsmp[i]);
 		}
 		free(m->xsmp);
 	}

--- a/src/loaders/loader.h
+++ b/src/loaders/loader.h
@@ -48,6 +48,7 @@ void	libxmp_get_instrument_path	(struct module_data *, char *, int);
 void	libxmp_set_type			(struct module_data *, const char *, ...);
 int	libxmp_load_sample		(struct module_data *, HIO_HANDLE *, int,
 					 struct xmp_sample *, const void *);
+void	libxmp_free_sample		(struct xmp_sample *);
 void	libxmp_schism_tracker_string	(char *, size_t, int, int);
 
 extern uint8		libxmp_ord_xlat[];

--- a/src/loaders/sample.c
+++ b/src/loaders/sample.c
@@ -409,9 +409,16 @@ int libxmp_load_sample(struct module_data *m, HIO_HANDLE *f, int flags, struct x
 
 #ifndef LIBXMP_CORE_PLAYER
     err2:
-	free(xxs->data - 4);
-	xxs->data = NULL;	/* prevent double free in PCM load error */
+	libxmp_free_sample(xxs);
 #endif
     err:
 	return -1;
+}
+
+void libxmp_free_sample(struct xmp_sample *s)
+{
+    if (s->data) {
+	free(s->data - 4);
+	s->data = NULL;		/* prevent double free in PCM load error */
+    }
 }

--- a/src/smix.c
+++ b/src/smix.c
@@ -304,9 +304,7 @@ int xmp_smix_release_sample(xmp_context opaque, int num)
 		return -XMP_ERROR_INVALID;
 	}
 
-	if (smix->xxs[num].data != NULL) {
-		free(smix->xxs[num].data - 4);
-	}
+	libxmp_free_sample(&smix->xxs[num]);
 	free(smix->xxi[num].sub);
 
 	smix->xxs[num].data = NULL;

--- a/test-dev/test_api_channel_mute.c
+++ b/test-dev/test_api_channel_mute.c
@@ -64,5 +64,8 @@ TEST(test_api_channel_mute)
 			fail_unless(ret == 0, "unmute channel error");
 		}
 	}
+
+	xmp_release_module(ctx);
+	xmp_free_context(ctx);
 }
 END_TEST

--- a/test-dev/test_api_channel_vol.c
+++ b/test-dev/test_api_channel_vol.c
@@ -36,5 +36,8 @@ TEST(test_api_channel_vol)
 		ret = xmp_channel_vol(ctx, i, -1);
 		fail_unless(ret == i, "channel vol error");
 	}
+
+	xmp_release_module(ctx);
+	xmp_free_context(ctx);
 }
 END_TEST

--- a/test-dev/test_api_create_context.c
+++ b/test-dev/test_api_create_context.c
@@ -10,5 +10,7 @@ TEST(test_api_create_context)
 
 	state = xmp_get_player(ctx, XMP_PLAYER_STATE);
 	fail_unless(state == XMP_STATE_UNLOADED, "state error");
+
+	xmp_free_context(ctx);
 }
 END_TEST

--- a/test-dev/test_api_create_module.c
+++ b/test-dev/test_api_create_module.c
@@ -31,5 +31,7 @@ TEST(test_api_create_module)
 
 	state = xmp_get_player(ctx, XMP_PLAYER_STATE);
 	fail_unless(state == XMP_STATE_UNLOADED, "state error");
+
+	xmp_free_context(ctx);
 }
 END_TEST

--- a/test-dev/test_api_inject_event.c
+++ b/test-dev/test_api_inject_event.c
@@ -31,5 +31,8 @@ TEST(test_api_inject_event)
 	fail_unless(vi->vol  == 39 * 16, "set volume");
 	fail_unless(p->speed == 3 , "set effect");
 	fail_unless(vi->pos0 == 0 , "sample position");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_api_load_module.c
+++ b/test-dev/test_api_load_module.c
@@ -88,5 +88,7 @@ TEST(test_api_load_module)
 
 	state = xmp_get_player(ctx, XMP_PLAYER_STATE);
 	fail_unless(state == XMP_STATE_UNLOADED, "state error");
+
+	xmp_free_context(ctx);
 }
 END_TEST

--- a/test-dev/test_api_load_module_from_file.c
+++ b/test-dev/test_api_load_module_from_file.c
@@ -25,5 +25,7 @@ TEST(test_api_load_module_from_file)
 
 	state = xmp_get_player(ctx, XMP_PLAYER_STATE);
 	fail_unless(state == XMP_STATE_UNLOADED, "state error");
+
+	xmp_free_context(ctx);
 }
 END_TEST

--- a/test-dev/test_api_load_module_from_memory.c
+++ b/test-dev/test_api_load_module_from_memory.c
@@ -69,6 +69,8 @@ TEST(test_api_load_module_from_memory)
 	xmp_get_frame_info(ctx, &fi);
 	fail_unless(fi.total_time == 235520, "module duration");
 
+	xmp_release_module(ctx);
+	xmp_free_context(ctx);
 	free(buffer);
 }
 END_TEST

--- a/test-dev/test_api_play_buffer.c
+++ b/test-dev/test_api_play_buffer.c
@@ -70,6 +70,7 @@ TEST(test_api_play_buffer)
 	xmp_end_player(opaque);
 	xmp_release_module(opaque);
 	xmp_free_context(opaque);
+	free(ref_buffer);
 	fclose(f);
 }
 END_TEST

--- a/test-dev/test_api_prev_position.c
+++ b/test-dev/test_api_prev_position.c
@@ -41,5 +41,8 @@ TEST(test_api_prev_position)
 	fail_unless(ret == 1, "prev position error");
 	xmp_play_frame(opaque);
 	fail_unless(p->ord == 1, "didn't change to prev position");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_api_restart_module.c
+++ b/test-dev/test_api_restart_module.c
@@ -23,7 +23,8 @@ TEST(test_api_restart_module)
 
 	xmp_get_frame_info(ctx, &info);
 	fail_unless(info.pos == 0, "module restart error");
-	
 
+	xmp_release_module(ctx);
+	xmp_free_context(ctx);
 }
 END_TEST

--- a/test-dev/test_api_scan_module.c
+++ b/test-dev/test_api_scan_module.c
@@ -31,5 +31,7 @@ TEST(test_api_scan_module)
 		xmp_get_frame_info(opaque, &info);
 		fail_unless(info.total_time == 5720, "total time error");
 	}
+
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_api_seek_time.c
+++ b/test-dev/test_api_seek_time.c
@@ -26,5 +26,7 @@ TEST(test_api_seek_time)
 		fail_unless(ret == pos[i], "seek error");
 	}
 
+	xmp_release_module(ctx);
+	xmp_free_context(ctx);
 }
 END_TEST

--- a/test-dev/test_api_set_player.c
+++ b/test-dev/test_api_set_player.c
@@ -164,5 +164,6 @@ TEST(test_api_set_player)
 	ret = xmp_set_player(opaque, XMP_PLAYER_SMIX_VOLUME, 201);
 	fail_unless(ret == -XMP_ERROR_INVALID, "error setting invalid smix volume");
 
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_api_set_position.c
+++ b/test-dev/test_api_set_position.c
@@ -35,5 +35,8 @@ TEST(test_api_set_position)
 
 	ret = xmp_set_position(opaque, 3);
 	fail_unless(ret == -XMP_ERROR_INVALID, "return value error");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_api_set_row.c
+++ b/test-dev/test_api_set_row.c
@@ -33,5 +33,7 @@ TEST(test_api_set_row)
 
 	ret = xmp_set_row(opaque, 64);
 	fail_unless(ret == -XMP_ERROR_INVALID, "return value error");
+
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_api_smix_channel_pan.c
+++ b/test-dev/test_api_smix_channel_pan.c
@@ -53,5 +53,6 @@ TEST(test_api_smix_channel_pan)
 
 	xmp_release_module(opaque);
 	xmp_end_smix(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_api_smix_load_sample.c
+++ b/test-dev/test_api_smix_load_sample.c
@@ -45,5 +45,6 @@ TEST(test_api_smix_load_sample)
 	xmp_smix_release_sample(opaque, 0);
 
 	xmp_end_smix(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_api_smix_play_instrument.c
+++ b/test-dev/test_api_smix_play_instrument.c
@@ -58,5 +58,6 @@ TEST(test_api_smix_play_instrument)
 
 	xmp_release_module(opaque);
 	xmp_end_smix(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_api_smix_play_sample.c
+++ b/test-dev/test_api_smix_play_sample.c
@@ -65,5 +65,6 @@ TEST(test_api_smix_play_sample)
 	xmp_smix_release_sample(opaque, 1);
 
 	xmp_end_smix(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_api_start_player.c
+++ b/test-dev/test_api_start_player.c
@@ -66,5 +66,6 @@ TEST(test_api_start_player)
 
 	/* TODO: Should test internal and system errors too */
 
+	xmp_free_context(ctx);
 }
 END_TEST

--- a/test-dev/test_api_stop_module.c
+++ b/test-dev/test_api_stop_module.c
@@ -19,7 +19,7 @@ TEST(test_api_stop_module)
 
 	ret = xmp_play_frame(ctx);
 	fail_unless(ret == -XMP_END, "module stop error");
-	
 
+	xmp_free_context(ctx);
 }
 END_TEST

--- a/test-dev/test_depack_arc_method2.c
+++ b/test-dev/test_depack_arc_method2.c
@@ -16,5 +16,8 @@ TEST(test_depack_arc_method2)
 
 	ret = compare_md5(info.md5, "b868aef5b8843c0754284561cda5aba9");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_arc_method8.c
+++ b/test-dev/test_depack_arc_method8.c
@@ -16,5 +16,8 @@ TEST(test_depack_arc_method8)
 
 	ret = compare_md5(info.md5, "64d67d1d5d123c6542a8099255ad8ca2");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_arcfs.c
+++ b/test-dev/test_depack_arcfs.c
@@ -16,5 +16,8 @@ TEST(test_depack_arcfs)
 
 	ret = compare_md5(info.md5, "1c41df267ebb8febe5e3d8a7e45bad61");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_bzip2.c
+++ b/test-dev/test_depack_bzip2.c
@@ -16,5 +16,8 @@ TEST(test_depack_bzip2)
 
 	ret = compare_md5(info.md5, "0350baf25b96d6d125f537c63f03e3db");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_compress.c
+++ b/test-dev/test_depack_compress.c
@@ -16,5 +16,8 @@ TEST(test_depack_compress)
 
 	ret = compare_md5(info.md5, "37b8afe62ec42a47b1237b794193e785");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_gzip.c
+++ b/test-dev/test_depack_gzip.c
@@ -16,5 +16,8 @@ TEST(test_depack_gzip)
 
 	ret = compare_md5(info.md5, "0350baf25b96d6d125f537c63f03e3db");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_j2b.c
+++ b/test-dev/test_depack_j2b.c
@@ -16,5 +16,8 @@ TEST(test_depack_j2b)
 
 	ret = compare_md5(info.md5, "166d2a8f5e4fbb466fe15d820ca59265");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_lha_l0_filtered.c
+++ b/test-dev/test_depack_lha_l0_filtered.c
@@ -16,5 +16,8 @@ TEST(test_depack_lha_l0_filtered)
 
 	ret = compare_md5(info.md5, "c993a848f57227660f8b10db1d4d874f");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_lha_l0_lzhuff1.c
+++ b/test-dev/test_depack_lha_l0_lzhuff1.c
@@ -16,5 +16,8 @@ TEST(test_depack_lha_l0_lzhuff1)
 
 	ret = compare_md5(info.md5, "dde7301ad7957daeede383fd561e12df");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_lha_l0_lzhuff5.c
+++ b/test-dev/test_depack_lha_l0_lzhuff5.c
@@ -16,5 +16,8 @@ TEST(test_depack_lha_l0_lzhuff5)
 
 	ret = compare_md5(info.md5, "d62117b9d24b152b225bdb7be24d5c5c");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_lha_l1_filtered.c
+++ b/test-dev/test_depack_lha_l1_filtered.c
@@ -16,5 +16,8 @@ TEST(test_depack_lha_l1_filtered)
 
 	ret = compare_md5(info.md5, "c993a848f57227660f8b10db1d4d874f");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_lha_l1_lzhuff5.c
+++ b/test-dev/test_depack_lha_l1_lzhuff5.c
@@ -16,5 +16,8 @@ TEST(test_depack_lha_l1_lzhuff5)
 
 	ret = compare_md5(info.md5, "c993a848f57227660f8b10db1d4d874f");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_lha_l1_lzhuff6.c
+++ b/test-dev/test_depack_lha_l1_lzhuff6.c
@@ -16,5 +16,8 @@ TEST(test_depack_lha_l1_lzhuff6)
 
 	ret = compare_md5(info.md5, "c993a848f57227660f8b10db1d4d874f");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_lha_l1_lzhuff7.c
+++ b/test-dev/test_depack_lha_l1_lzhuff7.c
@@ -16,5 +16,8 @@ TEST(test_depack_lha_l1_lzhuff7)
 
 	ret = compare_md5(info.md5, "c993a848f57227660f8b10db1d4d874f");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_lha_l2_filtered.c
+++ b/test-dev/test_depack_lha_l2_filtered.c
@@ -16,5 +16,8 @@ TEST(test_depack_lha_l2_filtered)
 
 	ret = compare_md5(info.md5, "c993a848f57227660f8b10db1d4d874f");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_lha_l2_lzhuff7.c
+++ b/test-dev/test_depack_lha_l2_lzhuff7.c
@@ -16,5 +16,8 @@ TEST(test_depack_lha_l2_lzhuff7)
 
 	ret = compare_md5(info.md5, "d1b4a2c15dcd1730244e2334eae30876");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_lzx.c
+++ b/test-dev/test_depack_lzx.c
@@ -16,5 +16,8 @@ TEST(test_depack_lzx)
 
 	ret = compare_md5(info.md5, "6e4226be5a72fe3770550ced7a2022de");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_mmcmp.c
+++ b/test-dev/test_depack_mmcmp.c
@@ -16,5 +16,8 @@ TEST(test_depack_mmcmp)
 
 	ret = compare_md5(info.md5, "2d8b03b2bce0563dfdf89613c7976fe4");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_pp.c
+++ b/test-dev/test_depack_pp.c
@@ -16,5 +16,8 @@ TEST(test_depack_pp)
 
 	ret = compare_md5(info.md5, "80ba11ca20f7ffef184a58c1fc619c18");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_s404.c
+++ b/test-dev/test_depack_s404.c
@@ -16,5 +16,8 @@ TEST(test_depack_s404)
 
 	ret = compare_md5(info.md5, "a9405964cc276b316bba6976f7539f38");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_spark.c
+++ b/test-dev/test_depack_spark.c
@@ -16,5 +16,8 @@ TEST(test_depack_spark)
 
 	ret = compare_md5(info.md5, "1aecc3cbfdae12a76000cd048ba8fcb3");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_sqsh.c
+++ b/test-dev/test_depack_sqsh.c
@@ -16,5 +16,8 @@ TEST(test_depack_sqsh)
 
 	ret = compare_md5(info.md5, "70e931a4c9835cd60493ae3d22b0cea621");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_vorbis.c
+++ b/test-dev/test_depack_vorbis.c
@@ -38,6 +38,8 @@ TEST(test_depack_vorbis)
 			fail_unless(abs(pcm16[i] - buf[i]) <= 1, "data error");
 	}
 
-
+	xmp_release_module(c);
+	xmp_free_context(c);
+	free(buf);
 }
 END_TEST

--- a/test-dev/test_depack_vorbis_8bit.c
+++ b/test-dev/test_depack_vorbis_8bit.c
@@ -35,5 +35,9 @@ TEST(test_depack_vorbis_8bit)
 			printf("%d %d\n", pcm8[i], buf[i]);
 			fail_unless(abs(pcm8[i] - buf[i]) <= 1, "data error");
 	}
+
+	xmp_release_module(c);
+	xmp_free_context(c);
+	free(buf);
 }
 END_TEST

--- a/test-dev/test_depack_xz.c
+++ b/test-dev/test_depack_xz.c
@@ -16,5 +16,8 @@ TEST(test_depack_xz)
 
 	ret = compare_md5(info.md5, "37b8afe62ec42a47b1237b794193e785");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_zip.c
+++ b/test-dev/test_depack_zip.c
@@ -16,11 +16,16 @@ TEST(test_depack_zip)
 	ret = compare_md5(info.md5, "a0b5bedbe15e1053ba6bd5645898e6c5");
 	fail_unless(ret == 0, "MD5 error");
 
+	xmp_release_module(c);
+
 	/* This zip originally crashed our depacker */
 	ret = xmp_load_module(c, "data/feel it dance!.zip");
 	fail_unless(ret == 0, "can't load module");
 	xmp_get_module_info(c, &info);
 	ret = compare_md5(info.md5, "62a80c044abc2d1ecf4c26f2fa48a98b");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_zip_filtered.c
+++ b/test-dev/test_depack_zip_filtered.c
@@ -16,5 +16,8 @@ TEST(test_depack_zip_filtered)
 
 	ret = compare_md5(info.md5, "c993a848f57227660f8b10db1d4d874f");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_zip_store.c
+++ b/test-dev/test_depack_zip_store.c
@@ -16,5 +16,8 @@ TEST(test_depack_zip_store)
 
 	ret = compare_md5(info.md5, "d5d4b02731591ecc350f6e18d8e61c6a");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_depack_zoo.c
+++ b/test-dev/test_depack_zoo.c
@@ -16,5 +16,8 @@ TEST(test_depack_zoo)
 
 	ret = compare_md5(info.md5, "a3c22f92e1ec5d7d324e975364a775e8");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_prowizard_fuchs.c
+++ b/test-dev/test_prowizard_fuchs.c
@@ -17,5 +17,8 @@ TEST(test_prowizard_fuchs)
 
 	ret = compare_md5(info.md5, "f84629f27737bb62b56ee6f252149c90");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_prowizard_starpack.c
+++ b/test-dev/test_prowizard_starpack.c
@@ -17,5 +17,8 @@ TEST(test_prowizard_starpack)
 
 	ret = compare_md5(info.md5, "f8a1bc8a19e7dfc446664494cd22788a");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_prowizard_zen.c
+++ b/test-dev/test_prowizard_zen.c
@@ -17,5 +17,8 @@ TEST(test_prowizard_zen)
 
 	ret = compare_md5(info.md5, "b774f2f8604f62efc63e1ac14ee01cce");
 	fail_unless(ret == 0, "MD5 error");
+
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST

--- a/test-dev/test_sample_load_16bit.c
+++ b/test-dev/test_sample_load_16bit.c
@@ -5,6 +5,7 @@
   s.len = (x); s.lps = (y); s.lpe = (z); s.flg = (w); s.data = NULL; \
 } while (0)
 
+#define CLEAR() do { libxmp_free_sample(&s); } while (0)
 
 TEST(test_sample_load_16bit)
 {
@@ -39,6 +40,7 @@ TEST(test_sample_load_16bit)
 	fail_unless(s.lps == 0, "didn't fix invalid loop start");
 	fail_unless(s.lpe == 0, "didn't fix invalid loop end");
 	fail_unless(s.flg == XMP_SAMPLE_16BIT, "didn't reset loop flags");
+	CLEAR();
 
 	/* load sample with invalid loop */
 	SET(101, 50, 40, XMP_SAMPLE_16BIT | XMP_SAMPLE_LOOP | XMP_SAMPLE_LOOP_BIDIR);
@@ -48,6 +50,7 @@ TEST(test_sample_load_16bit)
 	fail_unless(s.lps == 0, "didn't fix invalid loop start");
 	fail_unless(s.lpe == 0, "didn't fix invalid loop end");
 	fail_unless(s.flg == XMP_SAMPLE_16BIT, "didn't reset loop flags");
+	CLEAR();
 
 	/* load sample from file */
 	SET(101, 0, 102, XMP_SAMPLE_16BIT);
@@ -60,6 +63,7 @@ TEST(test_sample_load_16bit)
 	fail_unless(s.data[203] == s.data[201], "sample adjust error");
 	fail_unless(s.data[204] == s.data[202], "sample adjust error");
 	fail_unless(s.data[205] == s.data[203], "sample adjust error");
+	CLEAR();
 
 	/* load sample from file w/ loop */
 	SET(101, 20, 80, XMP_SAMPLE_16BIT | XMP_SAMPLE_LOOP);
@@ -70,6 +74,7 @@ TEST(test_sample_load_16bit)
 	fail_unless(s.data[161] == s.data[41], "sample adjust error");
 	fail_unless(s.data[162] == s.data[42], "sample adjust error");
 	fail_unless(s.data[163] == s.data[43], "sample adjust error");
+	CLEAR();
 
 	/* load sample from w/ bidirectional loop */
 	SET(101, 0, 102, XMP_SAMPLE_16BIT | XMP_SAMPLE_LOOP | XMP_SAMPLE_LOOP_BIDIR);
@@ -82,6 +87,8 @@ TEST(test_sample_load_16bit)
 	fail_unless(s.data[405] == s.data[1], "sample adjust error");
 	fail_unless(s.data[406] == s.data[2], "sample adjust error");
 	fail_unless(s.data[407] == s.data[3], "sample adjust error");
+	CLEAR();
 
+	hio_close(f);
 }
 END_TEST

--- a/test-dev/test_sample_load_8bit.c
+++ b/test-dev/test_sample_load_8bit.c
@@ -5,6 +5,7 @@
   s.len = (x); s.lps = (y); s.lpe = (z); s.flg = (w); s.data = NULL; \
 } while (0)
 
+#define CLEAR() do { libxmp_free_sample(&s); } while (0)
 
 TEST(test_sample_load_8bit)
 {
@@ -36,6 +37,7 @@ TEST(test_sample_load_8bit)
 	fail_unless(s.lps == 0, "didn't fix invalid loop start");
 	fail_unless(s.lpe == 0, "didn't fix invalid loop end");
 	fail_unless(s.flg == 0, "didn't reset loop flags");
+	CLEAR();
 
 	/* load sample with invalid loop */
 	SET(101, 50, 40, XMP_SAMPLE_LOOP | XMP_SAMPLE_LOOP_BIDIR);
@@ -45,6 +47,7 @@ TEST(test_sample_load_8bit)
 	fail_unless(s.lps == 0, "didn't fix invalid loop start");
 	fail_unless(s.lpe == 0, "didn't fix invalid loop end");
 	fail_unless(s.flg == 0, "didn't reset loop flags");
+	CLEAR();
 
 	/* load sample from file */
 	SET(101, 0, 102, 0);
@@ -55,6 +58,7 @@ TEST(test_sample_load_8bit)
 	fail_unless(memcmp(s.data, buffer, 101) == 0, "sample data error");
 	fail_unless(s.data[101] == s.data[100], "sample adjust error");
 	fail_unless(s.data[102] == s.data[101], "sample adjust error");
+	CLEAR();
 
 	/* load sample from file w/ loop */
 	SET(101, 20, 80, XMP_SAMPLE_LOOP);
@@ -63,6 +67,7 @@ TEST(test_sample_load_8bit)
 	fail_unless(s.data != NULL, "didn't allocate sample data");
 	fail_unless(s.data[80] == s.data[20], "sample adjust error");
 	fail_unless(s.data[81] == s.data[21], "sample adjust error");
+	CLEAR();
 
 	/* load sample from w/ bidirectional loop */
 	SET(101, 0, 102, XMP_SAMPLE_LOOP | XMP_SAMPLE_LOOP_BIDIR);
@@ -73,6 +78,8 @@ TEST(test_sample_load_8bit)
 	fail_unless(memcmp(s.data, buffer, 202) == 0, "sample unroll error");
 	fail_unless(s.data[202] == s.data[201], "sample adjust error");
 	fail_unless(s.data[203] == s.data[0], "sample adjust error");
+	CLEAR();
 
+	hio_close(f);
 }
 END_TEST

--- a/test-dev/test_sample_load_delta.c
+++ b/test-dev/test_sample_load_delta.c
@@ -20,10 +20,12 @@ TEST(test_sample_load_delta)
 	libxmp_load_sample(&m, NULL, SAMPLE_FLAG_NOLOAD | SAMPLE_FLAG_DIFF, &xxs, buffer0);
 	fail_unless(memcmp(xxs.data, conv_r0, 10) == 0,
 				"Invalid 8-bit conversion");
+	libxmp_free_sample(&xxs);
 
 	xxs.flg = XMP_SAMPLE_16BIT;
 	libxmp_load_sample(&m, NULL, SAMPLE_FLAG_NOLOAD | SAMPLE_FLAG_DIFF, &xxs, buffer1);
 	fail_unless(memcmp(xxs.data, conv_r1, 20) == 0,
 				"Invalid 16-bit conversion");
+	libxmp_free_sample(&xxs);
 }
 END_TEST

--- a/test-dev/test_sample_load_endian.c
+++ b/test-dev/test_sample_load_endian.c
@@ -1,10 +1,9 @@
 #include "test.h"
 #include "../src/loaders/loader.h"
 
-struct xmp_sample xxs;
-
 TEST(test_sample_load_endian)
 {
+	static struct xmp_sample xxs;
 	int8 conv_r0[10] = { 1, 0, 3, 2, 5, 4, -7,  6, -29,   8 };
 	int8 conv_r1[10] = { 0, 1, 2, 3, 4, 5,  6, -7,   8, -29 };
 	struct module_data m;
@@ -24,6 +23,7 @@ TEST(test_sample_load_endian)
 		fail_unless(memcmp(xxs.data, conv_r1, 10) == 0,
 					"Invalid conversion from big-endian");
 	}
+	libxmp_free_sample(&xxs);
 
 	/* Now the sample is little-endian */
 	libxmp_load_sample(&m, NULL, SAMPLE_FLAG_NOLOAD, &xxs, conv_r0);
@@ -34,5 +34,6 @@ TEST(test_sample_load_endian)
 		fail_unless(memcmp(xxs.data, conv_r0, 10) == 0,
 					"Invalid conversion from little-endian");
 	}
+	libxmp_free_sample(&xxs);
 }
 END_TEST

--- a/test-dev/test_sample_load_signal.c
+++ b/test-dev/test_sample_load_signal.c
@@ -28,10 +28,12 @@ TEST(test_sample_load_signal)
 	libxmp_load_sample(&m, NULL, SAMPLE_FLAG_NOLOAD | SAMPLE_FLAG_UNS, &xxs, buffer0);
 	fail_unless(memcmp(xxs.data, conv_r0, 10) == 0,
 				"Invalid 8-bit conversion");
+	libxmp_free_sample(&xxs);
 
 	xxs.flg = XMP_SAMPLE_16BIT;
 	libxmp_load_sample(&m, NULL, SAMPLE_FLAG_NOLOAD | SAMPLE_FLAG_UNS, &xxs, buffer1);
 	fail_unless(memcmp(xxs.data, conv_r1, 20) == 0,
 				"Invalid 16-bit conversion");
+	libxmp_free_sample(&xxs);
 }
 END_TEST

--- a/test-dev/test_sample_load_skip.c
+++ b/test-dev/test_sample_load_skip.c
@@ -5,6 +5,7 @@
   s.len = (x); s.lps = (y); s.lpe = (z); s.flg = (w); s.data = NULL; \
 } while (0)
 
+#define CLEAR() do { libxmp_free_sample(&s); } while (0)
 
 TEST(test_sample_load_skip)
 {
@@ -34,6 +35,7 @@ TEST(test_sample_load_skip)
 	fail_unless(s.data != NULL, "didn't allocate sample data");
 	fail_unless(s.lpe == 101, "didn't fix invalid loop end");
 	fail_unless(memcmp(s.data, buffer, 202) == 0, "sample data error");
+	CLEAR();
 
 	/* disable sample load */
 	SET(101, 0, 102, XMP_SAMPLE_16BIT);
@@ -41,5 +43,7 @@ TEST(test_sample_load_skip)
 	m.smpctl |= XMP_SMPCTL_SKIP;
 	libxmp_load_sample(&m, f, 0, &s, NULL);
 	fail_unless(s.data == NULL, "didn't skip sample load");
+
+	hio_close(f);
 }
 END_TEST


### PR DESCRIPTION
First of many. Fixes any trivial leaks in the test_sample_\*, test_depack_\*, test_prowizard_\*, and test_api_\* test files. There are some test_api_* leaks that this doesn't fix (see #110) but since those may be actual bugs they should probably be handled separately.