### PR TITLE
Fix test-dev new_note, no_note, porta, effect leaks.

### DIFF
--- a/test-dev/test_effect_0_arpeggio.c
+++ b/test-dev/test_effect_0_arpeggio.c
@@ -68,5 +68,8 @@ TEST(test_effect_0_arpeggio)
 	check_arpeggio(opaque, 60, 0x05, 6);
 	check_arpeggio(opaque, 60, 0x50, 6);
 	check_arpeggio(opaque, 60, 0x35, 6);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_1_slide_up.c
+++ b/test-dev/test_effect_1_slide_up.c
@@ -99,5 +99,8 @@ TEST(test_effect_1_slide_up)
 			fail_unless(PERIOD == k - 1, "extra fine slide error");
 		}
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_2_slide_down.c
+++ b/test-dev/test_effect_2_slide_down.c
@@ -97,5 +97,8 @@ TEST(test_effect_2_slide_down)
 			fail_unless(PERIOD == k + 1, "extra fine slide error");
 		}
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_4_vibrato.c
+++ b/test-dev/test_effect_4_vibrato.c
@@ -104,5 +104,8 @@ TEST(test_effect_4_vibrato)
 		xmp_get_frame_info(opaque, &info);
 		fail_unless(PERIOD == vals3[i], "half vibrato error");
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_8_setpan.c
+++ b/test-dev/test_effect_8_setpan.c
@@ -103,5 +103,8 @@ TEST(test_effect_8_setpan)
 		xmp_get_frame_info(opaque, &info);
 		fail_unless(info.channel_info[0].pan == vals_it_dp[i], "pan error");
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_a_volslide.c
+++ b/test-dev/test_effect_a_volslide.c
@@ -112,5 +112,8 @@ TEST(test_effect_a_volslide)
 		xmp_get_frame_info(opaque, &info);
 		fail_unless(info.channel_info[0].volume == vals_pdn[i], "volume slide error");
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_c_volset.c
+++ b/test-dev/test_effect_c_volset.c
@@ -94,5 +94,8 @@ TEST(test_effect_c_volset)
 		xmp_get_frame_info(opaque, &info);
 		fail_unless(info.channel_info[0].volume == vals3[i], "volume set error");
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_e9_retrig.c
+++ b/test-dev/test_effect_e9_retrig.c
@@ -93,5 +93,8 @@ TEST(test_effect_e9_retrig)
 	xmp_play_frame(opaque);
 	fail_unless(vi->note == 61, "row 0 frame 3");
 	fail_unless(vi->pos0 ==  0, "sample position frame 2");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_ed_delay.c
+++ b/test-dev/test_effect_ed_delay.c
@@ -130,5 +130,8 @@ TEST(test_effect_ed_delay)
 	fail_unless(vi->note ==  0, "row 9 frame 1");
 	fail_unless(vi->pos0 ==  0, "sample position");
 	fail_unless(vi->vol  ==  0, "voice volume");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_ef_invert_loop.c
+++ b/test-dev/test_effect_ef_invert_loop.c
@@ -21,7 +21,8 @@ TEST(test_effect_ef_invert_loop)
 	set_quirk(ctx, QUIRK_PROTRACK, READ_EVENT_MOD);
 	h = hio_open("data/sample-square-8bit.raw", "rb");
 	fail_unless(h != NULL, "can't open sample file");
-	
+
+	libxmp_free_sample(&m->mod.xxs[0]);
 	m->mod.xxs[0].len = 40;
 	m->mod.xxs[0].lps = 0;
 	m->mod.xxs[0].lpe = 40;

--- a/test-dev/test_effect_f_set_speed.c
+++ b/test-dev/test_effect_f_set_speed.c
@@ -48,5 +48,8 @@ TEST(test_effect_f_set_speed)
 		fail_unless(info.bpm == vals[i * 2], "tempo setting error");
 		fail_unless(info.speed == vals[i * 2 + 1], "speed setting error");
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_fine_vibrato.c
+++ b/test-dev/test_effect_fine_vibrato.c
@@ -57,5 +57,8 @@ TEST(test_effect_fine_vibrato)
 		xmp_get_frame_info(opaque, &info);
 		fail_unless(PERIOD == vals[i], "fine vibrato error");
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_globalvol.c
+++ b/test-dev/test_effect_globalvol.c
@@ -39,5 +39,8 @@ TEST(test_effect_globalvol)
 		xmp_get_frame_info(opaque, &info);
 		fail_unless(info.volume == vals[i], "global volume error");
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_gvol_slide.c
+++ b/test-dev/test_effect_gvol_slide.c
@@ -49,5 +49,8 @@ TEST(test_effect_gvol_slide)
 		xmp_get_frame_info(opaque, &info);
 		fail_unless(info.volume == vals[i], "global volume error");
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_it_bpm.c
+++ b/test-dev/test_effect_it_bpm.c
@@ -44,5 +44,8 @@ TEST(test_effect_it_bpm)
 		xmp_get_frame_info(opaque, &info);
 		fail_unless(info.bpm == vals[i], "tempo setting error");
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_it_panslide.c
+++ b/test-dev/test_effect_it_panslide.c
@@ -50,5 +50,8 @@ TEST(test_effect_it_panslide)
 		xmp_get_frame_info(opaque, &info);
 		fail_unless(info.channel_info[0].pan == vals[i], "pan error");
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_it_vcol_g.c
+++ b/test-dev/test_effect_it_vcol_g.c
@@ -112,5 +112,8 @@ TEST(test_effect_it_vcol_g)
 	
 		fail_unless(PERIOD == vals[i], "portamento error");
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_note_slide.c
+++ b/test-dev/test_effect_note_slide.c
@@ -78,5 +78,8 @@ TEST(test_effect_note_slide)
 				fail_unless(vi->pos0 != 0, "sample position");
 		}
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_note_slide_retrig.c
+++ b/test-dev/test_effect_note_slide_retrig.c
@@ -94,5 +94,8 @@ TEST(test_effect_note_slide_retrig)
 				fail_unless(vi->pos0 != 0, "sample position");
 		}
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_okt_arpeggio.c
+++ b/test-dev/test_effect_okt_arpeggio.c
@@ -146,5 +146,8 @@ TEST(test_effect_okt_arpeggio)
 	check_arpeggio_okt5(opaque, 60, 0x05, 6);
 	check_arpeggio_okt5(opaque, 60, 0x50, 6);
 	check_arpeggio_okt5(opaque, 60, 0x35, 6);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_panbrello.c
+++ b/test-dev/test_effect_panbrello.c
@@ -55,5 +55,8 @@ TEST(test_effect_panbrello)
 
 		fail_unless(info.channel_info[0].pan == vals[i], "pan error");
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_pastnote_cut.c
+++ b/test-dev/test_effect_pastnote_cut.c
@@ -69,5 +69,8 @@ TEST(test_effect_pastnote_cut)
 	fail_unless(vi2->note == 49, "not new note");
 	fail_unless(vi2->vol  == 33 * 16, "not new instrument volume");
 	fail_unless(vi2->pos0 ==  0, "sample didn't reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_pastnote_fade.c
+++ b/test-dev/test_effect_pastnote_fade.c
@@ -91,5 +91,8 @@ TEST(test_effect_pastnote_fade)
 	fail_unless(vi->ins  ==  0, "not same instrument");
 	fail_unless(vi->vol / 16 == 16, "not fading out");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_pastnote_off.c
+++ b/test-dev/test_effect_pastnote_off.c
@@ -86,5 +86,8 @@ TEST(test_effect_pastnote_off)
 
 	xmp_play_frame(opaque); /* frame 4 */
 	fail_unless(vi->chn == -1, "didn't end envelope");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_per_slide.c
+++ b/test-dev/test_effect_per_slide.c
@@ -70,5 +70,8 @@ TEST(test_effect_per_slide)
 	j--;
 	xmp_play_frame(opaque);
 	fail_unless(PERIOD == k + j * 2, "slide down error");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_per_toneporta.c
+++ b/test-dev/test_effect_per_toneporta.c
@@ -36,5 +36,8 @@ TEST(test_effect_per_toneporta)
 		xmp_get_frame_info(opaque, &info);
 	}
 	fail_unless(PERIOD == 586, "slide error");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_persistent_slide.c
+++ b/test-dev/test_effect_persistent_slide.c
@@ -58,5 +58,8 @@ TEST(test_effect_persistent_slide)
 			fail_unless(PERIOD == k + j * 2, "slide down error");
 		}
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_persistent_vibrato.c
+++ b/test-dev/test_effect_persistent_vibrato.c
@@ -45,5 +45,8 @@ TEST(test_effect_persistent_vibrato)
 		xmp_get_frame_info(opaque, &info);
 		fail_unless(PERIOD == vals[i], "vibrato error");
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_persistent_vslide.c
+++ b/test-dev/test_effect_persistent_vslide.c
@@ -107,5 +107,8 @@ TEST(test_effect_persistent_vslide)
 			}
 		}
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_s3m_bpm.c
+++ b/test-dev/test_effect_s3m_bpm.c
@@ -42,5 +42,8 @@ TEST(test_effect_s3m_bpm)
 		fail_unless(info.bpm == vals[i], "tempo setting error");
 	}
 	fail_unless(info.total_time == 4431, "total time error");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_set_nna_cont.c
+++ b/test-dev/test_effect_set_nna_cont.c
@@ -88,5 +88,8 @@ TEST(test_effect_set_nna_cont)
 	fail_unless(vi->ins  ==  0, "not same instrument");
 	fail_unless(vi->vol / 16 == 43, "not continuing");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_set_nna_cut.c
+++ b/test-dev/test_effect_set_nna_cut.c
@@ -55,5 +55,8 @@ TEST(test_effect_set_nna_cut)
 	fail_unless(i == p->virt.maxvoc, "used virtual voice");
 
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_set_nna_fade.c
+++ b/test-dev/test_effect_set_nna_fade.c
@@ -88,5 +88,8 @@ TEST(test_effect_set_nna_fade)
 	fail_unless(vi->ins  ==  0, "not same instrument");
 	fail_unless(vi->vol / 16 == 16, "not fading out");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_set_nna_off.c
+++ b/test-dev/test_effect_set_nna_off.c
@@ -85,5 +85,7 @@ TEST(test_effect_set_nna_off)
 	xmp_play_frame(opaque); /* frame 4 */
 	fail_unless(vi->chn == -1, "didn't end envelope");
 
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_track_volslide.c
+++ b/test-dev/test_effect_track_volslide.c
@@ -79,5 +79,8 @@ TEST(test_effect_track_volslide)
 		xmp_get_frame_info(opaque, &info);
 		fail_unless(info.channel_info[0].volume == vals_fine[i], "volume slide error");
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_effect_volslide.c
+++ b/test-dev/test_effect_volslide.c
@@ -66,5 +66,8 @@ TEST(test_effect_volslide)
 		fail_unless(info.channel_info[0].volume == vals[i], "volume slide error");
 
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_new_note_invalid_ins_ft2.c
+++ b/test-dev/test_new_note_invalid_ins_ft2.c
@@ -71,5 +71,8 @@ TEST(test_new_note_invalid_ins_ft2)
 	xmp_play_frame(opaque);
 	fail_unless(vi->vol  ==  0, "didn't cut sample");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_new_note_invalid_ins_it.c
+++ b/test-dev/test_new_note_invalid_ins_it.c
@@ -74,5 +74,8 @@ TEST(test_new_note_invalid_ins_it)
 	fail_unless(vi->vol  == 43 * 16, "changed volume");
 	fail_unless(vi->pos0 !=  0, "reset sample");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_new_note_invalid_ins_mod.c
+++ b/test-dev/test_new_note_invalid_ins_mod.c
@@ -70,5 +70,8 @@ TEST(test_new_note_invalid_ins_mod)
 	xmp_play_frame(opaque);
 	fail_unless(vi->vol  ==  0, "didn't cut sample");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_new_note_invalid_ins_st3.c
+++ b/test-dev/test_new_note_invalid_ins_st3.c
@@ -74,5 +74,8 @@ TEST(test_new_note_invalid_ins_st3)
 	fail_unless(vi->vol  == 43 * 16, "didn't use current volume");
 	fail_unless(vi->pos0 ==  0, "didn't reset sample");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_new_note_no_ins_ft2.c
+++ b/test-dev/test_new_note_no_ins_ft2.c
@@ -74,5 +74,8 @@ TEST(test_new_note_no_ins_ft2)
 	fail_unless(vi->vol  == 43 * 16, "not current volume");
 	fail_unless(vi->pos0 ==  0, "sample didn't reset");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_new_note_no_ins_it.c
+++ b/test-dev/test_new_note_no_ins_it.c
@@ -74,5 +74,8 @@ TEST(test_new_note_no_ins_it)
 	fail_unless(vi->vol  == 43 * 16, "not current volume");
 	fail_unless(vi->pos0 ==  0, "sample didn't reset");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_new_note_no_ins_mod.c
+++ b/test-dev/test_new_note_no_ins_mod.c
@@ -73,5 +73,8 @@ TEST(test_new_note_no_ins_mod)
 	fail_unless(vi->vol  == 43 * 16, "not current volume");
 	fail_unless(vi->pos0 ==  0, "sample didn't reset");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_new_note_no_ins_st3.c
+++ b/test-dev/test_new_note_no_ins_st3.c
@@ -74,5 +74,8 @@ TEST(test_new_note_no_ins_st3)
 	fail_unless(vi->vol  == 43 * 16, "not current volume");
 	fail_unless(vi->pos0 ==  0, "sample didn't reset");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_new_note_same_ins_ft2.c
+++ b/test-dev/test_new_note_same_ins_ft2.c
@@ -75,5 +75,8 @@ TEST(test_new_note_same_ins_ft2)
 	fail_unless(vi->vol  == 22 * 16, "not same instrument volume");
 	fail_unless(vi->pos0 ==  0, "sample didn't reset");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_new_note_same_ins_it.c
+++ b/test-dev/test_new_note_same_ins_it.c
@@ -75,5 +75,8 @@ TEST(test_new_note_same_ins_it)
 	fail_unless(vi->vol  == 22 * 16, "not same instrument volume");
 	fail_unless(vi->pos0 ==  0, "sample didn't reset");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_new_note_same_ins_mod.c
+++ b/test-dev/test_new_note_same_ins_mod.c
@@ -74,5 +74,8 @@ TEST(test_new_note_same_ins_mod)
 	fail_unless(vi->vol  == 22 * 16, "not same instrument volume");
 	fail_unless(vi->pos0 ==  0, "sample didn't reset");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_new_note_same_ins_st3.c
+++ b/test-dev/test_new_note_same_ins_st3.c
@@ -75,5 +75,8 @@ TEST(test_new_note_same_ins_st3)
 	fail_unless(vi->vol  == 22 * 16, "not same instrument volume");
 	fail_unless(vi->pos0 ==  0, "sample didn't reset");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_new_note_valid_ins_ft2.c
+++ b/test-dev/test_new_note_valid_ins_ft2.c
@@ -74,5 +74,8 @@ TEST(test_new_note_valid_ins_ft2)
 	fail_unless(vi->vol  == 33 * 16, "not new instrument volume");
 	fail_unless(vi->pos0 ==  0, "sample didn't reset");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_new_note_valid_ins_it.c
+++ b/test-dev/test_new_note_valid_ins_it.c
@@ -74,5 +74,8 @@ TEST(test_new_note_valid_ins_it)
 	fail_unless(vi->vol  == 33 * 16, "not new instrument volume");
 	fail_unless(vi->pos0 ==  0, "sample didn't reset");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_new_note_valid_ins_mod.c
+++ b/test-dev/test_new_note_valid_ins_mod.c
@@ -73,5 +73,8 @@ TEST(test_new_note_valid_ins_mod)
 	fail_unless(vi->vol  == 33 * 16, "not new instrument volume");
 	fail_unless(vi->pos0 ==  0, "sample didn't reset");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_new_note_valid_ins_st3.c
+++ b/test-dev/test_new_note_valid_ins_st3.c
@@ -74,5 +74,8 @@ TEST(test_new_note_valid_ins_st3)
 	fail_unless(vi->vol  == 33 * 16, "not new instrument volume");
 	fail_unless(vi->pos0 ==  0, "sample didn't reset");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_next_order_skip.c
+++ b/test-dev/test_next_order_skip.c
@@ -37,5 +37,7 @@ TEST(test_next_order_skip)
 	fail_unless(p->row == 0, "incorrect row");
 	fail_unless(p->frame == 0, "incorrect frame");
 
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_no_note_invalid_ins_ft2.c
+++ b/test-dev/test_no_note_invalid_ins_ft2.c
@@ -89,5 +89,8 @@ TEST(test_no_note_invalid_ins_ft2)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 22 * 16, "not old volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_no_note_invalid_ins_it.c
+++ b/test-dev/test_no_note_invalid_ins_it.c
@@ -88,5 +88,8 @@ TEST(test_no_note_invalid_ins_it)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 43 * 16, "not current volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_no_note_invalid_ins_mod.c
+++ b/test-dev/test_no_note_invalid_ins_mod.c
@@ -85,5 +85,8 @@ TEST(test_no_note_invalid_ins_mod)
 	xmp_play_frame(opaque);
 	fail_unless(vi->ins  ==  0, "not original instrument");
 	fail_unless(vi->vol  ==  0 * 16, "volume not zero");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_no_note_invalid_ins_st3.c
+++ b/test-dev/test_no_note_invalid_ins_st3.c
@@ -88,5 +88,8 @@ TEST(test_no_note_invalid_ins_st3)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 43 * 16, "not current volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_no_note_same_ins_ft2.c
+++ b/test-dev/test_no_note_same_ins_ft2.c
@@ -90,5 +90,8 @@ TEST(test_no_note_same_ins_ft2)
 	fail_unless(vi->vol  == 22 * 16, "not instrument volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_no_note_same_ins_it.c
+++ b/test-dev/test_no_note_same_ins_it.c
@@ -92,5 +92,8 @@ TEST(test_no_note_same_ins_it)
 	fail_unless(vi->vol  == 22 * 16, "not instrument volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_no_note_same_ins_mod.c
+++ b/test-dev/test_no_note_same_ins_mod.c
@@ -89,5 +89,8 @@ TEST(test_no_note_same_ins_mod)
 	fail_unless(vi->vol  == 22 * 16, "not instrument volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_no_note_same_ins_st3.c
+++ b/test-dev/test_no_note_same_ins_st3.c
@@ -90,5 +90,8 @@ TEST(test_no_note_same_ins_st3)
 	fail_unless(vi->vol  == 22 * 16, "not instrument volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_no_note_valid_ins_ft2.c
+++ b/test-dev/test_no_note_valid_ins_ft2.c
@@ -89,5 +89,8 @@ TEST(test_no_note_valid_ins_ft2)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 22 * 16, "not old volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_no_note_valid_ins_it.c
+++ b/test-dev/test_no_note_valid_ins_it.c
@@ -89,5 +89,8 @@ TEST(test_no_note_valid_ins_it)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 33 * 16, "not new volume");
 	fail_unless(vi->pos0 ==  0, "sample didn't reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_no_note_valid_ins_mod.c
+++ b/test-dev/test_no_note_valid_ins_mod.c
@@ -88,5 +88,8 @@ TEST(test_no_note_valid_ins_mod)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 33 * 16, "not new volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_no_note_valid_ins_st3.c
+++ b/test-dev/test_no_note_valid_ins_st3.c
@@ -89,5 +89,8 @@ TEST(test_no_note_valid_ins_st3)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 33 * 16, "not new volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_porta_invalid_ins_ft2.c
+++ b/test-dev/test_porta_invalid_ins_ft2.c
@@ -67,5 +67,8 @@ TEST(test_porta_invalid_ins_ft2)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 22 * 16, "not old volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_porta_invalid_ins_it.c
+++ b/test-dev/test_porta_invalid_ins_it.c
@@ -66,5 +66,8 @@ TEST(test_porta_invalid_ins_it)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 43 * 16, "not same volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_porta_invalid_ins_mod.c
+++ b/test-dev/test_porta_invalid_ins_mod.c
@@ -62,5 +62,8 @@ TEST(test_porta_invalid_ins_mod)
 	 */
 	xmp_play_frame(opaque);
 	fail_unless(vi->vol  ==  0, "didn't cut sample");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_porta_invalid_ins_st3.c
+++ b/test-dev/test_porta_invalid_ins_st3.c
@@ -66,5 +66,8 @@ TEST(test_porta_invalid_ins_st3)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 43 * 16, "not same volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_porta_no_ins_ft2.c
+++ b/test-dev/test_porta_no_ins_ft2.c
@@ -66,5 +66,8 @@ TEST(test_porta_no_ins_ft2)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 43 * 16, "not same volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_porta_no_ins_it.c
+++ b/test-dev/test_porta_no_ins_it.c
@@ -66,5 +66,8 @@ TEST(test_porta_no_ins_it)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 43 * 16, "not same volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_porta_no_ins_mod.c
+++ b/test-dev/test_porta_no_ins_mod.c
@@ -65,5 +65,8 @@ TEST(test_porta_no_ins_mod)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 43 * 16, "not same volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_porta_no_ins_st3.c
+++ b/test-dev/test_porta_no_ins_st3.c
@@ -66,5 +66,8 @@ TEST(test_porta_no_ins_st3)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 43 * 16, "not same volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_porta_same_ins_ft2.c
+++ b/test-dev/test_porta_same_ins_ft2.c
@@ -67,5 +67,8 @@ TEST(test_porta_same_ins_ft2)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 22 * 16, "not old volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_porta_same_ins_it.c
+++ b/test-dev/test_porta_same_ins_it.c
@@ -67,5 +67,8 @@ TEST(test_porta_same_ins_it)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 22 * 16, "not new volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_porta_same_ins_mod.c
+++ b/test-dev/test_porta_same_ins_mod.c
@@ -66,5 +66,8 @@ TEST(test_porta_same_ins_mod)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 22 * 16, "not instrument volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_porta_same_ins_st3.c
+++ b/test-dev/test_porta_same_ins_st3.c
@@ -67,5 +67,8 @@ TEST(test_porta_same_ins_st3)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 22 * 16, "not new volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_porta_valid_ins_ft2.c
+++ b/test-dev/test_porta_valid_ins_ft2.c
@@ -67,5 +67,8 @@ TEST(test_porta_valid_ins_ft2)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 22 * 16, "not old volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_porta_valid_ins_it.c
+++ b/test-dev/test_porta_valid_ins_it.c
@@ -67,5 +67,8 @@ TEST(test_porta_valid_ins_it)
 	fail_unless(vi->note == 49, "not new note");
 	fail_unless(vi->vol  == 33 * 16, "not new volume");
 	fail_unless(vi->pos0 ==  0, "sample didn't reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_porta_valid_ins_mod.c
+++ b/test-dev/test_porta_valid_ins_mod.c
@@ -66,5 +66,8 @@ TEST(test_porta_valid_ins_mod)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 33 * 16, "not new volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_porta_valid_ins_st3.c
+++ b/test-dev/test_porta_valid_ins_st3.c
@@ -67,5 +67,8 @@ TEST(test_porta_valid_ins_st3)
 	fail_unless(vi->note == 59, "not same note");
 	fail_unless(vi->vol  == 33 * 16, "not new volume");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_prev_order_skip.c
+++ b/test-dev/test_prev_order_skip.c
@@ -38,5 +38,7 @@ TEST(test_prev_order_skip)
 	fail_unless(p->row == 0, "incorrect row");
 	fail_unless(p->frame == 0, "incorrect frame");
 
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_prev_order_start.c
+++ b/test-dev/test_prev_order_start.c
@@ -35,5 +35,7 @@ TEST(test_prev_order_start)
 	fail_unless(p->row == 0, "incorrect row");
 	fail_unless(p->frame == 0, "incorrect frame");
 
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_prev_order_start_seq.c
+++ b/test-dev/test_prev_order_start_seq.c
@@ -39,5 +39,7 @@ TEST(test_prev_order_start_seq)
 	fail_unless(p->row == 0, "incorrect row");
 	fail_unless(p->frame == 0, "incorrect frame");
 
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST


### PR DESCRIPTION
Second of several patches. This fixes trivial leaks that cause LeakSanitizer spam in the `test_new_note_*`, `test_no_note_*`, `test_porta_*`, `test_effect_*`, `test_next_*`, and `test_prev_*` tests. The `test_next_*` and `test_prev_*` tests still have leaks as mentioned in #110.