### PR TITLE
Fix test-dev player, mixer, and libxmp_prepare_scan leaks.

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -416,6 +416,7 @@ struct context_data {
 char	*libxmp_adjust_string	(char *);
 int	libxmp_exclude_match	(const char *);
 int	libxmp_prepare_scan	(struct context_data *);
+void	libxmp_free_scan	(struct context_data *);
 int	libxmp_scan_sequences	(struct context_data *);
 int	libxmp_get_sequence	(struct context_data *, int);
 int	libxmp_set_player_mode	(struct context_data *);

--- a/src/load.c
+++ b/src/load.c
@@ -347,7 +347,7 @@ int xmp_test_module(const char *path, struct xmp_test_info *info)
 			}
 #endif
 
-			fclose(h->handle.file);
+			hio_close(h);
 
 #ifndef LIBXMP_NO_DEPACKERS
 			unlink_temp_file(temp);
@@ -680,11 +680,7 @@ void xmp_release_module(xmp_context opaque)
 	}
 #endif
 
-	if (m->scan_cnt) {
-		for (i = 0; i < mod->len; i++)
-			free(m->scan_cnt[i]);
-		free(m->scan_cnt);
-	}
+	libxmp_free_scan(ctx);
 
 	free(m->comment);
 

--- a/src/load_helpers.c
+++ b/src/load_helpers.c
@@ -344,8 +344,23 @@ int libxmp_prepare_scan(struct context_data *ctx)
 		if (m->scan_cnt[i] == NULL)
 			return -XMP_ERROR_SYSTEM;
 	}
- 
+
 	return 0;
+}
+
+void libxmp_free_scan(struct context_data *ctx)
+{
+	struct module_data *m = &ctx->m;
+	struct xmp_module *mod = &m->mod;
+	int i;
+
+	if (m->scan_cnt) {
+		for (i = 0; i < mod->len; i++)
+			free(m->scan_cnt[i]);
+
+		free(m->scan_cnt);
+		m->scan_cnt = NULL;
+	}
 }
 
 /* Process player personality flags */

--- a/src/smix.c
+++ b/src/smix.c
@@ -25,6 +25,7 @@
 #include "period.h"
 #include "player.h"
 #include "hio.h"
+#include "loaders/loader.h"
 
 
 struct xmp_instrument *libxmp_get_instrument(struct context_data *ctx, int ins)

--- a/test-dev/test_api_prev_position.c
+++ b/test-dev/test_api_prev_position.c
@@ -18,6 +18,7 @@ TEST(test_api_prev_position)
 	fail_unless(ret == -XMP_ERROR_STATE, "state check error");
 
  	create_simple_module(ctx, 2, 2);
+	libxmp_free_scan(ctx);
 	set_order(ctx, 0, 0);
 	set_order(ctx, 1, 1);
 	set_order(ctx, 2, 0);

--- a/test-dev/test_api_set_position.c
+++ b/test-dev/test_api_set_position.c
@@ -18,6 +18,7 @@ TEST(test_api_set_position)
 	fail_unless(ret == -XMP_ERROR_STATE, "state check error");
 
  	create_simple_module(ctx, 2, 2);
+	libxmp_free_scan(ctx);
 	set_order(ctx, 0, 0);
 	set_order(ctx, 1, 1);
 	set_order(ctx, 2, 0);

--- a/test-dev/test_api_set_row.c
+++ b/test-dev/test_api_set_row.c
@@ -18,6 +18,7 @@ TEST(test_api_set_row)
 	fail_unless(ret == -XMP_ERROR_STATE, "state check error");
 
 	create_simple_module(ctx, 1, 1);
+	libxmp_free_scan(ctx);
 	set_order(ctx, 0, 0);
 
 	libxmp_prepare_scan(ctx);

--- a/test-dev/test_mixer_interpolation_default.c
+++ b/test-dev/test_mixer_interpolation_default.c
@@ -10,5 +10,8 @@ TEST(test_mixer_interpolation_default)
 	xmp_start_player(opaque, 8000, XMP_FORMAT_MONO);
 	interp = xmp_get_player(opaque, XMP_PLAYER_INTERP);
 	fail_unless(interp == XMP_INTERP_LINEAR, "default not linear");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_next_order_skip.c
+++ b/test-dev/test_next_order_skip.c
@@ -14,6 +14,7 @@ TEST(test_next_order_skip)
  	create_simple_module(ctx, 2, 2);
 	set_quirk(ctx, QUIRK_MARKER, READ_EVENT_MOD);
 
+	libxmp_free_scan(ctx);
 	set_order(ctx, 0, 0);
 	set_order(ctx, 1, 0xfe);
 	set_order(ctx, 2, 0);

--- a/test-dev/test_player_dct_note.c
+++ b/test-dev/test_player_dct_note.c
@@ -81,5 +81,8 @@ TEST(test_player_dct_note)
 	fail_unless(vi->chn  == -1, "didn't reset first channel");
 	fail_unless(vi->note ==  0, "didn't reset first channel");
 	fail_unless(vi->vol  ==  0, "didn't reset first channel");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_player_ft2_note_noins_after_invalid_ins.c
+++ b/test-dev/test_player_ft2_note_noins_after_invalid_ins.c
@@ -84,6 +84,7 @@ TEST(test_player_ft2_note_noins_after_invalid_ins)
 	fail_unless(vi->vol  ==  0, "didn't cut sample");
 	xmp_play_frame(opaque);
 
- 
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_player_ft2_note_noins_after_keyoff.c
+++ b/test-dev/test_player_ft2_note_noins_after_keyoff.c
@@ -55,5 +55,8 @@ TEST(test_player_ft2_note_noins_after_keyoff)
 	fail_unless(fi.channel_info[0].note == 49, "set note");
 	fail_unless(fi.channel_info[0].volume == 19, "set volume");
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_player_invalid_mod_channels.c
+++ b/test-dev/test_player_invalid_mod_channels.c
@@ -19,5 +19,8 @@ TEST(test_player_invalid_mod_channels)
 
 	xmp_play_frame(opaque);
 	xmp_get_frame_info(opaque, &info);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_player_invalid_mod_length.c
+++ b/test-dev/test_player_invalid_mod_length.c
@@ -19,5 +19,10 @@ TEST(test_player_invalid_mod_length)
 
 	xmp_play_frame(opaque);
 	xmp_get_frame_info(opaque, &info);
+
+	/* Fix length so the mod is freed correctly. */
+	m->mod.len = 2;
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_player_invalid_period.c
+++ b/test-dev/test_player_invalid_period.c
@@ -50,5 +50,8 @@ TEST(test_player_invalid_period)
 	xmp_get_frame_info(opaque, &info);
 	fail_unless(info.channel_info[0].period == 4096, "period error");
 	fail_unless(info.channel_info[0].volume == 0, "volume error");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_player_nna_cont.c
+++ b/test-dev/test_player_nna_cont.c
@@ -75,5 +75,8 @@ TEST(test_player_nna_cont)
 		fail_unless(vi->ins  ==  0, "first note: not same instrument");
 		fail_unless(vi->vol  == 43 * 16, "first note: not same volume");
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_player_nna_cut.c
+++ b/test-dev/test_player_nna_cut.c
@@ -56,5 +56,8 @@ TEST(test_player_nna_cut)
 	fail_unless(i == p->virt.maxvoc, "used virtual voice");
 
 	xmp_play_frame(opaque);
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_player_nna_fade.c
+++ b/test-dev/test_player_nna_fade.c
@@ -95,5 +95,8 @@ TEST(test_player_nna_fade)
 	fail_unless(vi->ins  ==  0, "not same instrument");
 	fail_unless(vi->vol / 16 == 16, "not fading out");
 	fail_unless(vi->pos0 !=  0, "sample reset");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_player_nna_off.c
+++ b/test-dev/test_player_nna_off.c
@@ -86,5 +86,7 @@ TEST(test_player_nna_off)
 	xmp_play_frame(opaque); /* frame 4 */
 	fail_unless(vi->chn == -1, "didn't end envelope");
 
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_player_note_off_ft2.c
+++ b/test-dev/test_player_note_off_ft2.c
@@ -68,6 +68,8 @@ TEST(test_player_note_off_ft2)
 
 	xmp_play_frame(opaque);
 	fail_unless(vi->vol / 16 == 32, "didn't follow envelope");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
-	
 END_TEST

--- a/test-dev/test_player_note_off_it.c
+++ b/test-dev/test_player_note_off_it.c
@@ -68,6 +68,8 @@ TEST(test_player_note_off_it)
 
 	xmp_play_frame(opaque);
 	fail_unless(vi->vol / 16 == 43, "didn't follow envelope + fadeout");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
-	
 END_TEST

--- a/test-dev/test_player_pan.c
+++ b/test-dev/test_player_pan.c
@@ -32,7 +32,7 @@ TEST(test_player_pan)
 		new_event(ctx, 0, i, 2, 61, 1, 0, FX_SETPAN, 0x80 + i, 0, 0);
 		new_event(ctx, 0, i, 3, 61, 1, 0, FX_SETPAN, 0xc0 + i, 0, 0);
 	}
-	
+
 	xmp_start_player(opaque, 44100, 0);
 
 	/* set mix to 100% pan separation */
@@ -46,7 +46,7 @@ TEST(test_player_pan)
 		pan1 = info.channel_info[1].pan;
 		pan2 = info.channel_info[2].pan;
 		pan3 = info.channel_info[3].pan;
-		
+
 		fail_unless(pan0 == 0x00 + i, "pan error in channel 0");
 		fail_unless(pan1 == 0x40 + i, "pan error in channel 1");
 		fail_unless(pan2 == 0x80 + i, "pan error in channel 2");
@@ -55,5 +55,8 @@ TEST(test_player_pan)
 		xmp_play_frame(opaque);
 		xmp_play_frame(opaque);
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_player_period_amiga.c
+++ b/test-dev/test_player_period_amiga.c
@@ -35,5 +35,7 @@ TEST(test_player_period_amiga)
 	fscanf(f, "%d %d", &p0, &p1);
 	//fail_unless(feof(f), "not end of data file");
 
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_player_period_mod_range.c
+++ b/test-dev/test_player_period_mod_range.c
@@ -113,5 +113,8 @@ TEST(test_player_period_mod_range)
 		xmp_get_frame_info(opaque, &info);
 		fail_unless(PERIOD >= 108, "Bad upper limit");
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_player_read_event.c
+++ b/test-dev/test_player_read_event.c
@@ -48,5 +48,8 @@ TEST(test_player_read_event)
 	fail_unless(vi->ins  == 0 , "set instrument");
 	fail_unless(vi->vol  == 64 * 16, "set volume");
 	fail_unless(vi->pos0 == 0 , "sample position");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_player_virtual_channel.c
+++ b/test-dev/test_player_virtual_channel.c
@@ -63,5 +63,8 @@ TEST(test_player_virtual_channel)
 		xmp_play_frame(opaque);
 		xmp_play_frame(opaque);
 	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_prev_order_skip.c
+++ b/test-dev/test_prev_order_skip.c
@@ -14,6 +14,7 @@ TEST(test_prev_order_skip)
  	create_simple_module(ctx, 2, 2);
 	set_quirk(ctx, QUIRK_MARKER, READ_EVENT_MOD);
 
+	libxmp_free_scan(ctx);
 	set_order(ctx, 0, 0);
 	set_order(ctx, 1, 0xfe);
 	set_order(ctx, 2, 0);

--- a/test-dev/test_prev_order_start.c
+++ b/test-dev/test_prev_order_start.c
@@ -12,6 +12,7 @@ TEST(test_prev_order_start)
 	p = &ctx->p;
 
  	create_simple_module(ctx, 2, 2);
+	libxmp_free_scan(ctx);
 	set_order(ctx, 0, 0);
 	set_order(ctx, 1, 0xfe);
 	set_order(ctx, 2, 0);

--- a/test-dev/test_prev_order_start_seq.c
+++ b/test-dev/test_prev_order_start_seq.c
@@ -14,6 +14,7 @@ TEST(test_prev_order_start_seq)
  	create_simple_module(ctx, 2, 2);
 	set_quirk(ctx, QUIRKS_ST3, READ_EVENT_ST3);
 
+	libxmp_free_scan(ctx);
 	set_order(ctx, 0, 0);
 	set_order(ctx, 1, 0xfe);
 	set_order(ctx, 2, 0);


### PR DESCRIPTION
Third of ~~four~~ THREE patches. This fixes trivial leaks in the `test_player_*` and `test_mixer_*` tests, as well as the `libxmp_prepare_scan`-related leaks documented in #110. The first two sets were the same `xmp_release_module`/`xmp_free_context` copypaste as everywhere else, but the `libxmp_prepare_scan` fix required a new function.

This should be the last of the patches for trivial leaks in the tests. No promises these patches will get the CI ASan checks working again, but this might significantly reduce the log spam (going off of what I saw in the logs for #109). ~~The only problem left when I run `make devcheck` with ASan enabled is `test_api_test_module` leaking hio handles, which may or may not be related to #178.~~ It was a single wrong function call unrelated to that PR and I amended this patch to also fix it.