### PR TITLE
loaders,test-dev: address clang warnings

### DIFF
--- a/src/loaders/amf_load.c
+++ b/src/loaders/amf_load.c
@@ -205,13 +205,12 @@ static int amf_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	}
 
 	for (i = 0; i < mod->ins; i++) {
-		/*uint8 b;*/
 		int c2spd;
 
 		if (libxmp_alloc_subinstrument(mod, i, 1) < 0)
 			return -1;
 
-		/*b =*/ hio_read8(f);
+		hio_read8(f);
 
 		hio_read(buf, 1, 32, f);
 		libxmp_instrument_name(mod, i, buf, 32);

--- a/src/loaders/liq_load.c
+++ b/src/loaders/liq_load.c
@@ -612,7 +612,7 @@ next_pattern:
 
 	/* FIXME: LDSS 1.0 have global vol == 0 ? */
 	/* if (li.gvl == 0) */
-	    li.gvl = 0x40;
+	li.gvl = 0x40;
 
 	sub->vol = li.vol;
 	sub->gvl = li.gvl;

--- a/test-dev/util.c
+++ b/test-dev/util.c
@@ -507,7 +507,7 @@ void dump_module(struct xmp_module *mod, FILE *f)
 			MD5Update(&ctx, xxs->data, len);
 		} else if (len > 0) {
 			/* The data file for fracture.stm had this hash for empty samples... */
-			MD5Update(&ctx, "1", 1);
+			MD5Update(&ctx, (unsigned char *)"1", 1);
 		}
 		MD5Final(d, &ctx);
 		fprintf(f, " ");


### PR DESCRIPTION
Address code indent and typecast warnings issued when building with
clang on Ubuntu Groovy.

Signed-off-by: Claudio Matsuoka <cmatsuoka@gmail.com>