### PR TITLE
Add LDFLAGS to libxmp-tests and utilities rules.

### DIFF
--- a/test-dev/Makefile.in
+++ b/test-dev/Makefile.in
@@ -382,12 +382,12 @@ clean:
 utilities: gen_mixer_data gen_module_data
 
 gen_mixer_data: gen_mixer_data.o
-	@CMD='$(LD) -o $@ gen_mixer_data.o -L../lib -lxmp'; \
+	@CMD='$(LD) $(LDFLAGS) -o $@ gen_mixer_data.o -L../lib -lxmp'; \
 	if [ "$(V)" -gt 0 ]; then echo $$CMD; else echo LD $@ ; fi; \
 	eval $$CMD
 
 gen_module_data: gen_module_data.o util.o md5.o
-	@CMD='$(LD) -o $@ gen_module_data.o util.o md5.o -L../lib -lxmp'; \
+	@CMD='$(LD) $(LDFLAGS) -o $@ gen_module_data.o util.o md5.o -L../lib -lxmp $(LIBS)'; \
 	if [ "$(V)" -gt 0 ]; then echo $$CMD; else echo LD $@ ; fi; \
 	eval $$CMD
 
@@ -399,7 +399,7 @@ check: $(TEST_PATH)/all_tests.c $(TEST_PATH)/libxmp-tests
 	cd $(TEST_PATH); LD_LIBRARY_PATH=../lib DYLD_LIBRARY_PATH=../lib LIBRARY_PATH=../lib:$$LIBRARY_PATH PATH=$$PATH:../lib ./libxmp-tests
 
 $(TEST_PATH)/libxmp-tests: $(T_OBJS)
-	@CMD='$(LD) -o $@ $(T_OBJS) $(LIBS) -L../lib -lxmp'; \
+	@CMD='$(LD) $(LDFLAGS) -o $@ $(T_OBJS) $(LIBS) -L../lib -lxmp'; \
 	if [ "$(V)" -gt 0 ]; then echo $$CMD; else echo LD $@ ; fi; \
 	eval $$CMD
 
@@ -417,7 +417,7 @@ coverclean:
 	@rm -f $(GCOBJS) ../lib/$(GCLIB)
 
 $(TEST_PATH)/libxmp-covertest: $(GCT_OBJS) ../lib/$(GCLIB)
-	@CMD='$(LD) -o $@ $(LDFLAGS) $(GCT_OBJS) ../lib/$(GCLIB) -lgcov $(LIBS)'; \
+	@CMD='$(LD) $(LDFLAGS) -o $@ $(GCT_OBJS) ../lib/$(GCLIB) -lgcov $(LIBS)'; \
 	if [ "$(V)" -gt 0 ]; then echo $$CMD; else echo LD $@ ; fi; \
 	eval $$CMD
 


### PR DESCRIPTION
This adds `$(LDFLAGS)` to the test-dev linking rules that were missing it (`libxmp-tests`, `gen_mixer_data`, and `gen_module_data`). I kept running into issues with this because I've been building with ASan by using `CFLAGS=-fsanitize=address LDFLAGS=-fsanitize=address ./configure` and the lack of `$(LDFLAGS)` on the `libxmp-tests` rule prevents it from linking correctly.

edit: placing `$(LDFLAGS)` after `-o $@` was for consistency with `libxmp-covertest` but I don't really like that and it can be moved to right after `$(LD)` if that's preferable.