### PR TITLE
fix 'Title underline too short' warning from rst2html

### DIFF
--- a/docs/libxmp.rst
+++ b/docs/libxmp.rst
@@ -234,7 +234,7 @@ const unsigned int xmp_vercode
 .. _xmp_get_format_list():
 
 const char \*const \*xmp_get_format_list()
-``````````````````````````````
+``````````````````````````````````````````
 
   Query the list of supported module formats.
 


### PR DESCRIPTION
warning started after the const return change for xmp_get_format_list()