### PR TITLE
build: add experimental travis windows build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,15 +39,28 @@ matrix:
             - gcc-mingw-w64-x86-64
             - gcc-mingw-w64
 
-    - os: linux
-      dist: focal
-      compiler: clang
-      env: CFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address"
-      script: autoconf && ./configure && make && make check && (cd test-dev; autoconf && ./configure && make)
+    # windows with visual studio 2017
 
-    - os: linux
-      dist: focal
-      compiler: clang
-      env: CFLAGS="-fsanitize=memory" LDFLAGS="-fsanitize=memory"
-      script: autoconf && ./configure && make && make check && (cd test-dev; autoconf && ./configure && make)
+    - os: windows
+      language: c
+      compiler: cl
+      script:
+        - export PATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\Current\Bin":$PATH
+        - nmake -f Makefile.vc
+        - nmake -f Makefile.vc check
+
+#
+#    #  no need to add LD_PRELOAD=$(clang -print-file-name=libclang_rt.asan-x86_64.so) ?
+
+#    - os: linux
+#      dist: focal
+#      compiler: clang
+#      env: CFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address"
+#      script: autoconf && ./configure && make && make check && (cd test-dev; autoconf && ./configure && make)
+#
+#    - os: linux
+#      dist: focal
+#      compiler: clang
+#      env: CFLAGS="-fsanitize=memory" LDFLAGS="-fsanitize=memory"
+#      script: autoconf && ./configure && make && make check && (cd test-dev; autoconf && ./configure && make)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,19 +39,25 @@ matrix:
             - gcc-mingw-w64-x86-64
             - gcc-mingw-w64
 
-    # windows with visual studio 2017
+    # windows with visual studio 2017, x86 and x64
 
     - os: windows
       language: c
       compiler: cl
       script:
-        - export PATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\Current\Bin":$PATH
-        - nmake -f Makefile.vc
-        - nmake -f Makefile.vc check
+        - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' x86 '&&' nmake -f Makefile.vc
+        - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' x86 '&&' nmake -f Makefile.vc check
 
+    - os: windows
+      language: c
+      compiler: cl
+      script:
+        - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' amd64 '&&' nmake -f Makefile.vc
+        - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' amd64 '&&' nmake -f Makefile.vc check
+
+# FIXME: temporarily disabled
+# no need to add LD_PRELOAD=$(clang -print-file-name=libclang_rt.asan-x86_64.so) ?
 #
-#    #  no need to add LD_PRELOAD=$(clang -print-file-name=libclang_rt.asan-x86_64.so) ?
-
 #    - os: linux
 #      dist: focal
 #      compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,18 +55,16 @@ matrix:
         - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' amd64 '&&' nmake -f Makefile.vc
         - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' amd64 '&&' nmake -f Makefile.vc check
 
-# FIXME: temporarily disabled
-# no need to add LD_PRELOAD=$(clang -print-file-name=libclang_rt.asan-x86_64.so) ?
-#
-#    - os: linux
-#      dist: focal
-#      compiler: clang
-#      env: CFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address"
-#      script: autoconf && ./configure && make && make check && (cd test-dev; autoconf && ./configure && make)
-#
-#    - os: linux
-#      dist: focal
-#      compiler: clang
-#      env: CFLAGS="-fsanitize=memory" LDFLAGS="-fsanitize=memory"
-#      script: autoconf && ./configure && make && make check && (cd test-dev; autoconf && ./configure && make)
+    # clang sanitizers
 
+    - os: linux
+      dist: focal
+      compiler: clang
+      env: CFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address"
+      script: autoconf && ./configure && make && make check && (cd test-dev; autoconf && ./configure && make)
+
+    - os: linux
+      dist: focal
+      compiler: clang
+      env: CFLAGS="-fsanitize=memory" LDFLAGS="-fsanitize=memory"
+      script: autoconf && ./configure && make && make check && (cd test-dev; autoconf && ./configure && make)

--- a/Makefile.vc
+++ b/Makefile.vc
@@ -3,7 +3,7 @@
 USE_DEPACKERS	= 1
 
 CC	= cl
-CFLAGS	= /O2 /Iinclude /Isrc /Isrc\win32 /DBUILDING_DLL /DWIN32 \
+CFLAGS	= /O2 /W3 /Iinclude /Isrc /Isrc\win32 /DBUILDING_DLL /DWIN32 \
 	  /Dinline=__inline /DPATH_MAX=1024 /D_USE_MATH_DEFINES
 LD	= link
 LDFLAGS	= /DLL /RELEASE /OUT:$(DLL)
@@ -23,7 +23,7 @@ ALL_OBJS	= $(ALL_OBJS) $(DEPACKER_OBJS)
 TEST	= test\md5.obj test\test.obj
 
 .c.obj:
-	$(CC) /c $(CFLAGS) /Fo$*.obj $<
+	@$(CC) /c /nologo $(CFLAGS) /Fo$*.obj $<
 
 all: $(DLL)
 

--- a/Makefile.vc.in
+++ b/Makefile.vc.in
@@ -3,7 +3,7 @@
 USE_DEPACKERS	= 1
 
 CC	= cl
-CFLAGS	= /O2 /Iinclude /Isrc /Isrc\win32 /DBUILDING_DLL /DWIN32 \
+CFLAGS	= /O2 /W3 /Iinclude /Isrc /Isrc\win32 /DBUILDING_DLL /DWIN32 \
 	  /Dinline=__inline /DPATH_MAX=1024 /D_USE_MATH_DEFINES
 LD	= link
 LDFLAGS	= /DLL /RELEASE /OUT:$(DLL)
@@ -23,7 +23,7 @@ ALL_OBJS	= $(ALL_OBJS) $(DEPACKER_OBJS)
 TEST	= test\md5.obj test\test.obj
 
 .c.obj:
-	$(CC) /c $(CFLAGS) /Fo$*.obj $<
+	@$(CC) /c /nologo $(CFLAGS) /Fo$*.obj $<
 
 all: $(DLL)
 

--- a/lite/Makefile.vc.in
+++ b/lite/Makefile.vc.in
@@ -1,5 +1,5 @@
 CC	= cl
-CFLAGS	= /O2 /Iinclude\libxmp-lite /Isrc /DBUILDING_DLL /DWIN32 \
+CFLAGS	= /O2 /W3 /Iinclude\libxmp-lite /Isrc /DBUILDING_DLL /DWIN32 \
           /Dinline=__inline /D_USE_MATH_DEFINES /DLIBXMP_CORE_PLAYER /DLIBXMP_NO_DEPACKERS
 LD	= link
 LDFLAGS	= /DLL /RELEASE /OUT:$(DLL)
@@ -10,7 +10,7 @@ OBJS	= @OBJS@
 TEST	= test\md5.obj test\test.obj
 
 .c.obj:
-	$(CC) /c $(CFLAGS) /Fo$*.obj $<
+	$(CC) /c /nologo $(CFLAGS) /Fo$*.obj $<
 
 all: $(DLL)
 


### PR DESCRIPTION
Experimental Windows build on Travis. Documentation is a bit scarce, so
this was written on a trial-and-error basis. Variable substitution and directory
separator slashes/backslashes doesn't seem to work like in regular bash.

Clang sanitizer builds disabled because they failed consistently.

Signed-off-by: Claudio Matsuoka <cmatsuoka@gmail.com>