### PR TITLE
Fix uninitialized read in libxmp_copy_name_for_fopen.

### DIFF
--- a/src/loaders/common.c
+++ b/src/loaders/common.c
@@ -297,7 +297,7 @@ int libxmp_copy_name_for_fopen(char *dest, const char *name, int n)
 #endif
 		}
 
-		if (dest[i] == '\\') {
+		if (t == '\\') {
 			dest[i] = '/';
 			continue;
 		}


### PR DESCRIPTION
Fixes an amateurish mistake I added in #180 that thankfully MemorySanitizer caught. ;-(

This is the only MemorySanitizer issue I found locally with test-dev.