### PR TITLE
Enable Travis CI clang sanitizer checks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,16 +39,15 @@ matrix:
             - gcc-mingw-w64-x86-64
             - gcc-mingw-w64
 
-    # FIXME:
-    #- os: linux
-    #  dist: focal
-    #  compiler: clang
-    #  env: CFLAGS="-fsanitize=address" LD_LIBRARY_PATH=$(clang -print-file-name=libclang_rt.asan-x86_64.so) 
-    #  script: autoconf && ./configure && make && make check && (cd test-dev; autoconf && ./configure && make)
+    - os: linux
+      dist: focal
+      compiler: clang
+      env: CFLAGS="-fsanitize=address" LDFLAGS="-fsanitize=address"
+      script: autoconf && ./configure && make && make check && (cd test-dev; autoconf && ./configure && make)
 
-    #- os: linux
-    #  dist: focal
-    #  compiler: clang
-    #  env: CFLAGS="-fsanitize=memory"
-    #  script: autoconf && ./configure && make && make check && (cd test-dev; autoconf && ./configure && make)
+    - os: linux
+      dist: focal
+      compiler: clang
+      env: CFLAGS="-fsanitize=memory" LDFLAGS="-fsanitize=memory"
+      script: autoconf && ./configure && make && make check && (cd test-dev; autoconf && ./configure && make)
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -16,7 +16,7 @@ check: $(TEST_PATH)/libxmp-test
 	cd $(TEST_PATH); LD_LIBRARY_PATH=../lib DYLD_LIBRARY_PATH=../lib LIBRARY_PATH=../lib:$$LIBRARY_PATH PATH=$$PATH:../lib ./libxmp-test
 
 $(TEST_PATH)/libxmp-test: $(T_OBJS)
-	@CMD='$(LD) -o $@ $(T_OBJS) $(LIBS) -Llib -lxmp'; \
+	@CMD='$(LD) $(LDFLAGS) -o $@ $(T_OBJS) $(LIBS) -Llib -lxmp'; \
 	if [ "$(V)" -gt 0 ]; then echo $$CMD; else echo LD $@ ; fi; \
 	eval $$CMD
 


### PR DESCRIPTION
~~Just testing the Travis CI sanitizer checks again now that some legitimate issues (and a bunch of false positive spam) have been cleared up. Not expecting anything useful, but...~~ The Travis sanitizer checks work now and I've uncommented them. The last remaining issue in the way of this was a missing `$(LDFLAGS)` in the test Makefile.

Failed attempt 1: https://travis-ci.org/github/libxmp/libxmp/builds/743103830
Both sanitizers passing (verbose): https://travis-ci.org/github/libxmp/libxmp/builds/743117465