### PR TITLE
configure.ac: add -Wl,--no-undefined to LDFLAGS if supported.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -126,7 +126,7 @@ lib/$(DLL): $(LOBJS)
 
 lib/$(DYLIB): $(LOBJS)
 	@mkdir -p lib
-	@CMD='$(LD) $(LDFLAGS) -dynamiclib -Wl,-headerpad_max_install_names,-undefined,error,$(DYLIB_COMPAT)-current_version,$(VERSION),-install_name,$(prefix)/lib/$(DYLIB) -o $@ $(LOBJS) $(LIBS)'; \
+	@CMD='$(LD) $(LDFLAGS) -dynamiclib -Wl,-headerpad_max_install_names,$(DYLIB_COMPAT)-current_version,$(VERSION),-install_name,$(prefix)/lib/$(DYLIB) -o $@ $(LOBJS) $(LIBS)'; \
 	if [ "$(V)" -gt 0 ]; then echo $$CMD; else echo LD $@ ; fi; \
 	eval $$CMD
 	ln -sf $(DYLIB) lib/libxmp.dylib

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,16 @@ cygwin* | *djgpp | mint* | amigaos* |aros* | morphos*)
   ;;
 esac
 
+case "${host_os}" in
+dnl Skip this on platforms where it is just simply busted.
+openbsd*) ;;
+ darwin*) LDFLAGS="$LDFLAGS -Wl,-undefined,error" ;;
+       *) save_LDFLAGS="$LDFLAGS"
+          LDFLAGS="$LDFLAGS -Wl,--no-undefined"
+          AC_TRY_LINK([],[],[],[LDFLAGS="$save_LDFLAGS"])
+          ;;
+esac
+
 if test "${enable_static}" = yes; then
   AC_SUBST(STATIC,static)
 fi

--- a/lite/Makefile.in.in
+++ b/lite/Makefile.in.in
@@ -118,7 +118,7 @@ lib/$(DLL): $(LOBJS)
 
 lib/$(DYLIB): $(LOBJS)
 	@mkdir -p lib
-	@CMD='$(LD) $(LDFLAGS) -dynamiclib -Wl,-headerpad_max_install_names,-undefined,error,$(DYLIB_COMPAT)-current_version,$(VERSION),-install_name,$(prefix)/lib/$(DYLIB) -o $@ $(LOBJS) $(LIBS)'; \
+	@CMD='$(LD) $(LDFLAGS) -dynamiclib -Wl,-headerpad_max_install_names,$(DYLIB_COMPAT)-current_version,$(VERSION),-install_name,$(prefix)/lib/$(DYLIB) -o $@ $(LOBJS) $(LIBS)'; \
 	if [ "$(V)" -gt 0 ]; then echo $$CMD; else echo LD $@ ; fi; \
 	eval $$CMD
 	ln -sf $(DYLIB) lib/libxmp-lite.dylib


### PR DESCRIPTION
based on SDL configury.  move Darwin -Wl,-undefined,error to configure
for consistency.