### PR TITLE
Fix read_event.c out-of-bounds reads due to invalid key values.

### DIFF
--- a/src/read_event.c
+++ b/src/read_event.c
@@ -292,23 +292,23 @@ static int read_event_mod(struct context_data *ctx, struct xmp_event *e, int chn
 		if (e->note == XMP_KEY_OFF) {
 			SET_NOTE(NOTE_RELEASE);
 			use_ins_vol = 0;
-		} else if (!is_toneporta) {
+		} else if (!is_toneporta && is_valid_note(e->note - 1)) {
 			xc->key = e->note - 1;
 			RESET_NOTE(NOTE_END);
-	
+
 			sub = get_subinstrument(ctx, xc->ins, xc->key);
-	
+
 			if (!new_invalid_ins && sub != NULL) {
 				int transp = mod->xxi[xc->ins].map[xc->key].xpo;
 				int smp;
-	
+
 				note = xc->key + sub->xpo + transp;
 				smp = sub->sid;
-	
+
 				if (mod->xxs[smp].len == 0) {
 					smp = -1;
 				}
-	
+
 				if (smp >= 0 && smp < mod->smp) {
 					set_patch(ctx, chn, xc->ins, smp, note);
 					xc->smp = smp;
@@ -813,23 +813,23 @@ static int read_event_st3(struct context_data *ctx, struct xmp_event *e, int chn
 			if (not_same_ins) {
 				xc->offset.val = 0;
 			}
-		} else {
+		} else if (is_valid_note(e->note - 1)) {
 			xc->key = e->note - 1;
 			RESET_NOTE(NOTE_END);
-	
+
 			sub = get_subinstrument(ctx, xc->ins, xc->key);
-	
+
 			if (sub != NULL) {
 				int transp = mod->xxi[xc->ins].map[xc->key].xpo;
 				int smp;
-	
+
 				note = xc->key + sub->xpo + transp;
 				smp = sub->sid;
-	
+
 				if (mod->xxs[smp].len == 0) {
 					smp = -1;
 				}
-	
+
 				if (smp >= 0 && smp < mod->smp) {
 					set_patch(ctx, chn, xc->ins, smp, note);
 					xc->smp = smp;
@@ -1414,12 +1414,12 @@ static int read_event_med(struct context_data *ctx, struct xmp_event *e, int chn
 			SET_NOTE(NOTE_END);
 			xc->period = 0;
 			libxmp_virt_resetchannel(ctx, chn);
-		} else if (!is_toneporta && IS_VALID_INSTRUMENT(xc->ins)) {
+		} else if (!is_toneporta && IS_VALID_INSTRUMENT(xc->ins) && is_valid_note(e->note - 1)) {
 			struct xmp_instrument *xxi = &mod->xxi[xc->ins];
 
 			xc->key = e->note - 1;
 			RESET_NOTE(NOTE_END);
-		
+
 			xc->per_adj = 0.0;
 			if (xxi->nsm > 1 && HAS_MED_INSTRUMENT_EXTRAS(*xxi)) {
 				/* synth or iffoct */
@@ -1429,20 +1429,20 @@ static int read_event_med(struct context_data *ctx, struct xmp_event *e, int chn
 					xc->per_adj = 2.0;
 				}
 			}
-	
+
 			sub = get_subinstrument(ctx, xc->ins, xc->key);
-	
+
 			if (!new_invalid_ins && sub != NULL) {
 				int transp = xxi->map[xc->key].xpo;
 				int smp;
-	
+
 				note = xc->key + sub->xpo + transp;
 				smp = sub->sid;
-	
+
 				if (mod->xxs[smp].len == 0) {
 					smp = -1;
 				}
-	
+
 				if (smp >= 0 && smp < mod->smp) {
 					set_patch(ctx, chn, xc->ins, smp, note);
 					xc->smp = smp;
@@ -1553,11 +1553,12 @@ static int read_event_smix(struct context_data *ctx, struct xmp_event *e, int ch
 			xc->smp = smp;
 		}
 	} else {
-		transp = mod->xxi[xc->ins].map[xc->key].xpo;
-		sub = get_subinstrument(ctx, xc->ins, xc->key);
+		sub = is_valid_note(xc->key) ?
+			get_subinstrument(ctx, xc->ins, xc->key) : NULL;
 		if (sub == NULL) {
 			return 0;
 		}
+		transp = mod->xxi[xc->ins].map[xc->key].xpo;
 		note = xc->key + sub->xpo + transp;
 		smp = sub->sid;
 		if (mod->xxs[smp].len == 0)


### PR DESCRIPTION
This patch makes the MOD, ST3, MED, and SMIX read_event functions ignore invalid note values instead of handling them as new notes. The prior behavior could allow out-of-bounds reads from the instrument keymap in these functions. No changes are required for the FT2 and IT read_event functions since they already check this.

Fixes #118. I will add a test for this when I get a chance.