### PR TITLE
Don't use --no-undefined when linking with -fsanitize.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,13 +54,20 @@ cygwin* | *djgpp | mint* | amigaos* |aros* | morphos*)
   ;;
 esac
 
+AC_CHECK_DEFINED(__clang__)
+
 case "${host_os}" in
 dnl Skip this on platforms where it is just simply busted.
 openbsd*) ;;
  darwin*) LDFLAGS="$LDFLAGS -Wl,-undefined,error" ;;
-       *) save_LDFLAGS="$LDFLAGS"
-          LDFLAGS="$LDFLAGS -Wl,--no-undefined"
-          AC_TRY_LINK([],[],[],[LDFLAGS="$save_LDFLAGS"])
+          dnl For whatever reason, the Clang sanitizers and --no-undefined for
+          dnl shared libraries are incompatible.
+       *) if test "$ac_cv_defined___clang__" = "no" || test "${LDFLAGS#*fsanitize}" = "$LDFLAGS"
+          then
+            save_LDFLAGS="$LDFLAGS"
+            LDFLAGS="$LDFLAGS -Wl,--no-undefined"
+            AC_TRY_LINK([],[],[],[LDFLAGS="$save_LDFLAGS"])
+          fi
           ;;
 esac
 

--- a/test/test.c
+++ b/test/test.c
@@ -110,9 +110,15 @@ int main()
 
 	printf(" pass\n");
 
+	xmp_release_module(c);
+	xmp_free_context(c);
 	exit(0);
 
     err:
 	printf(" fail\n");
+	if (c) {
+		xmp_release_module(c);
+		xmp_free_context(c);
+	}
 	exit(1);
 }


### PR DESCRIPTION
It appears that `--no-undefined` is completely broken when trying to use the sanitizers with clang. I added a check to configure.ac to test for `fsanitize` before trying to add it. (I tried putting various programs in the `AC_TRY_LINK` prior to this but none of them flagged the same issue, probably because it only happens when linking a library.)

This should hopefully fix the new Travis sanitizer issues.