### PR TITLE
Enable fine effects for DigiBooster Pro modules.

### DIFF
--- a/src/loaders/dbm_load.c
+++ b/src/loaders/dbm_load.c
@@ -383,6 +383,7 @@ static int dbm_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		return -1;
 
 	m->c4rate = C4_NTSC_RATE;
+	m->quirk |= QUIRK_FINEFX;
 
 	/* IFF chunk IDs */
 	ret = libxmp_iff_register(handle, "INFO", get_info);


### PR DESCRIPTION
DigiBooster Pro modules support fine volume slide and portamento but the quirk to enable that wasn't set in the DigiBooster Pro loader. This fixes multiple instances of loud notes in "Krashan - The Call of Quantum Field.dbm" caused by `AF1` being interpreted as a slide up instead of as a fine slide down (reported in #196).