### PR TITLE
Fix GDM set pan position effect.

### DIFF
--- a/src/loaders/gdm_load.c
+++ b/src/loaders/gdm_load.c
@@ -140,7 +140,14 @@ void fix_effect(uint8 *fxt, uint8 *fxp)
 		*fxt = FX_FINE_VIBRATO;
 		break;
 	case 0x1e:			/* special misc */
-		*fxt = *fxp = 0;
+		switch (MSN(*fxp)) {
+		case 0x8:		/* set pan position */
+			*fxt = FX_EXTENDED;
+			break;
+		default:
+			*fxt = *fxp = 0;
+			break;
+		}
 		break;
 	case 0x1f:
 		*fxt = FX_S3M_BPM;


### PR DESCRIPTION
Adds an extended GDM effect I missed when fixing support for the fine slides. None of the other special extended GDM effects in the MenTaLguY documentation are actually implemented in BWSB, so I think that should be every GDM effect working now.

Test S3M and its converted GDM: [s3m_pan.zip](https://github.com/libxmp/libxmp/files/5551981/s3m_pan.zip)
