### PR TITLE
Add xmp_test_module_from_memory and xmp_test_module_from_file.

### DIFF
--- a/docs/Changelog
+++ b/docs/Changelog
@@ -63,6 +63,9 @@ Stable versions
 	- fix mute status on player creation
 	Changes by Cameron Cawley:
 	- fix sanity check in Digital Symphony loader
+	Changes by Ghabry:
+	- add xmp_test_module_from_memory and xmp_test_module_from_file
+	  calls to api
 	Fix problems reported by Ralf Hoffmann:
 	- fix MMD3 instrument type sanity check
 	- fix strictness of MOD pattern data tester

--- a/docs/libxmp.rst
+++ b/docs/libxmp.rst
@@ -314,8 +314,7 @@ int xmp_test_module_from_memory(void \*mem, long size, struct xmp_test_info \*te
 
     :size: the size of the module, or 0 if the size is unknown or not
       specified. If size is set to 0 certain module formats won't be
-      recognized, the MD5 digest will not be set, and module-specific
-      quirks won't be applied.
+      recognized.
 
     :test_info: NULL, or a pointer to a structure used to retrieve the
       module title and format if the memory buffer is a valid module.
@@ -334,22 +333,17 @@ int xmp_test_module_from_memory(void \*mem, long size, struct xmp_test_info \*te
 
 .. xmp_test_module_from_file():
 
-int xmp_test_module_from_file(FILE \*f, long size, struct xmp_test_info \*test_info)
-````````````````````````````````````````````````````````````````````````````````````````
+int xmp_test_module_from_file(FILE \*f, struct xmp_test_info \*test_info)
+`````````````````````````````````````````````````````````````````````````
 
-  *[Added in libxmp 4.5]* Test if a modle from a stream is a valid module.
+  *[Added in libxmp 4.5]* Test if a module from a stream is a valid module.
   Testing streams does not affect the current player context or any
   currently loaded module.
 
   **Parameters:**
     :f: the file stream. Compressed modules that need an external depacker
       can't be tested from a file stream. On return, the stream position is
-      undefined.
-
-    :size: the size of the module, or 0 if the size is unknown or not
-      specified. If size is set to 0 certain module formats won't be
-      recognized, the MD5 digest will not be set, and module-specific
-      quirks won't be applied.
+      undefined. Caller is responsible for closing the file stream.
 
     :test_info: NULL, or a pointer to a structure used to retrieve the
       module title and format if the memory buffer is a valid module.

--- a/docs/libxmp.rst
+++ b/docs/libxmp.rst
@@ -299,6 +299,74 @@ int xmp_test_module(char \*path, struct xmp_test_info \*test_info)
     and uncompression failed, or ``-XMP_ERROR_SYSTEM`` in case of system error
     (the system error code is set in ``errno``).
 
+.. xmp_test_module_from_memory():
+
+int xmp_test_module_from_memory(void \*mem, long size, struct xmp_test_info \*test_info)
+````````````````````````````````````````````````````````````````````````````````````````
+
+  *[Added in libxmp 4.5]* Test if a memory buffer is a valid module. Testing
+  memory does not affect the current player context or any currently loaded
+  module.
+
+  **Parameters:**
+    :mem: a pointer to the module file image in memory. Multi-file modules
+      or compressed modules can't be tested in memory.
+
+    :size: the size of the module, or 0 if the size is unknown or not
+      specified. If size is set to 0 certain module formats won't be
+      recognized, the MD5 digest will not be set, and module-specific
+      quirks won't be applied.
+
+    :test_info: NULL, or a pointer to a structure used to retrieve the
+      module title and format if the memory buffer is a valid module.
+      ``struct xmp_test_info`` is defined as::
+
+        struct xmp_test_info {
+            char name[XMP_NAME_SIZE];      /* Module title */
+            char type[XMP_NAME_SIZE];      /* Module format */
+        };
+
+  **Returns:**
+    0 if the memory buffer is a valid module, or a negative error code
+    in case of error. Error codes can be ``-XMP_ERROR_FORMAT`` in case of an
+    unrecognized file format or ``-XMP_ERROR_SYSTEM`` in case of system error
+    (the system error code is set in ``errno``).
+
+.. xmp_test_module_from_file():
+
+int xmp_test_module_from_file(FILE \*f, long size, struct xmp_test_info \*test_info)
+````````````````````````````````````````````````````````````````````````````````````````
+
+  *[Added in libxmp 4.5]* Test if a modle from a stream is a valid module.
+  Testing streams does not affect the current player context or any
+  currently loaded module.
+
+  **Parameters:**
+    :f: the file stream. Compressed modules that need an external depacker
+      can't be tested from a file stream. On return, the stream position is
+      undefined.
+
+    :size: the size of the module, or 0 if the size is unknown or not
+      specified. If size is set to 0 certain module formats won't be
+      recognized, the MD5 digest will not be set, and module-specific
+      quirks won't be applied.
+
+    :test_info: NULL, or a pointer to a structure used to retrieve the
+      module title and format if the memory buffer is a valid module.
+      ``struct xmp_test_info`` is defined as::
+
+        struct xmp_test_info {
+            char name[XMP_NAME_SIZE];      /* Module title */
+            char type[XMP_NAME_SIZE];      /* Module format */
+        };
+
+  **Returns:**
+    0 if the stream is a valid module, or a negative error code
+    in case of error. Error codes can be ``-XMP_ERROR_FORMAT`` in case of an
+    unrecognized file format, ``-XMP_ERROR_DEPACK`` if the stream is compressed
+    and uncompression failed, or ``-XMP_ERROR_SYSTEM`` in case of system error
+    (the system error code is set in ``errno``).
+
 .. _xmp_load_module():
 
 int xmp_load_module(xmp_context c, char \*path)

--- a/include/xmp.h
+++ b/include/xmp.h
@@ -350,7 +350,7 @@ LIBXMP_EXPORT int         xmp_set_instrument_path (xmp_context, const char *);
 LIBXMP_EXPORT int         xmp_load_module_from_memory (xmp_context, void *, long);
 LIBXMP_EXPORT int         xmp_load_module_from_file (xmp_context, void *, long);
 LIBXMP_EXPORT int         xmp_test_module_from_memory (void *, long, struct xmp_test_info *);
-LIBXMP_EXPORT int         xmp_test_module_from_file (void *, long, struct xmp_test_info *);
+LIBXMP_EXPORT int         xmp_test_module_from_file (void *, struct xmp_test_info *);
 
 /* External sample mixer API */
 LIBXMP_EXPORT int         xmp_start_smix       (xmp_context, int, int);

--- a/include/xmp.h
+++ b/include/xmp.h
@@ -349,6 +349,8 @@ LIBXMP_EXPORT int         xmp_get_player      (xmp_context, int);
 LIBXMP_EXPORT int         xmp_set_instrument_path (xmp_context, const char *);
 LIBXMP_EXPORT int         xmp_load_module_from_memory (xmp_context, void *, long);
 LIBXMP_EXPORT int         xmp_load_module_from_file (xmp_context, void *, long);
+LIBXMP_EXPORT int         xmp_test_module_from_memory (void *, long, struct xmp_test_info *);
+LIBXMP_EXPORT int         xmp_test_module_from_file (void *, long, struct xmp_test_info *);
 
 /* External sample mixer API */
 LIBXMP_EXPORT int         xmp_start_smix       (xmp_context, int, int);

--- a/libxmp.map
+++ b/libxmp.map
@@ -67,4 +67,6 @@ XMP_4.5 {
   global:
     xmp_set_row;
     xmp_set_tempo_factor;
+    xmp_test_module_from_file;
+    xmp_test_module_from_memory;
 } XMP_4.4;

--- a/lite/Changelog
+++ b/lite/Changelog
@@ -19,6 +19,8 @@ Stable versions
 	- add new xmp_set_row() call to skip replay to the given row
 	- add new xmp_set_tempo_factor() call to set the replay tempo
 	  multiplier
+	- add xmp_test_module_from_memory and xmp_test_module_from_file
+	  calls to api
 	- IT: T00 now repeats previous slide
 	- prevent clobbering of muted channels' volumes in IT modules
 	- clamp number of IT envelope nodes at load time

--- a/src/load.c
+++ b/src/load.c
@@ -111,7 +111,7 @@ static int execute_command(const char *cmd, const char *filename, FILE *t)
 	 * indefinitely. _popen works properly in a Console application.
 	 * To create a Windows application that redirects input and output,
 	 * read the section "Creating a Child Process with Redirected Input
-	 * and Output" in the Win32 SDK. -- Mirko 
+	 * and Output" in the Win32 SDK. -- Mirko
 	 */
 	p = popen(line, "rb");
 #else
@@ -195,6 +195,13 @@ static int decrunch(HIO_HANDLE **h, const char *filename, char **temp)
 		return 0;
 	}
 #endif
+
+	/* When the filename is unknown (because it is a stream) don't use
+	 * external helpers
+	 */
+	if (cmd && filename == NULL) {
+		return 0;
+	}
 
 	D_(D_WARN "Depacking file... ");
 
@@ -366,6 +373,136 @@ int xmp_test_module(const char *path, struct xmp_test_info *info)
 	}
 
 #ifndef LIBXMP_NO_DEPACKERS
+    err:
+	hio_close(h);
+	unlink_temp_file(temp);
+#else
+	hio_close(h);
+#endif
+	return ret;
+}
+
+int xmp_test_module_from_memory(void *mem, long size, struct xmp_test_info *info)
+{
+	HIO_HANDLE *h;
+	char buf[XMP_NAME_SIZE];
+	int i;
+	int ret = -XMP_ERROR_FORMAT;
+
+	/* Use size < 0 for unknown/undetermined size */
+	if (size == 0)
+		size--;
+
+	if ((h = hio_open_mem(mem, size)) == NULL)
+		return -XMP_ERROR_SYSTEM;
+
+#ifndef LIBXMP_CORE_PLAYER
+	/* get size */
+	if (hio_size(h) < 256) {	/* set minimum valid module size */
+		ret = -XMP_ERROR_FORMAT;
+		goto err;
+	}
+#endif
+
+	if (info != NULL) {
+		*info->name = 0;	/* reset name prior to testing */
+		*info->type = 0;	/* reset type prior to testing */
+	}
+
+	for (i = 0; format_loader[i] != NULL; i++) {
+		hio_seek(h, 0, SEEK_SET);
+		if (format_loader[i]->test(h, buf, 0) == 0) {
+			int is_prowizard = 0;
+
+#ifndef LIBXMP_CORE_PLAYER
+			if (strcmp(format_loader[i]->name, "prowizard") == 0) {
+				hio_seek(h, 0, SEEK_SET);
+				pw_test_format(h, buf, 0, info);
+				is_prowizard = 1;
+			}
+#endif
+
+			hio_close(h);
+
+			if (info != NULL && !is_prowizard) {
+				strncpy(info->name, buf, XMP_NAME_SIZE - 1);
+				strncpy(info->type, format_loader[i]->name,
+							XMP_NAME_SIZE - 1);
+			}
+			return 0;
+		}
+	}
+
+#ifndef LIBXMP_CORE_PLAYER
+    err:
+	hio_close(h);
+#else
+	hio_close(h);
+#endif
+	return ret;
+}
+
+int xmp_test_module_from_file(void *file, long size, struct xmp_test_info *info)
+{
+	HIO_HANDLE *h;
+	char buf[XMP_NAME_SIZE];
+	int i;
+	int ret = -XMP_ERROR_FORMAT;
+#ifndef LIBXMP_CORE_PLAYER
+	char *temp = NULL;
+#endif
+	FILE *f = fdopen(fileno((FILE *)file), "rb");
+
+	if ((h = hio_open_file(f)) == NULL)
+		return -XMP_ERROR_SYSTEM;
+
+#ifndef LIBXMP_CORE_PLAYER
+	if (decrunch(&h, NULL, &temp) < 0) {
+		ret = -XMP_ERROR_DEPACK;
+		goto err;
+	}
+
+	/* get size after decrunch */
+	if (hio_size(h) < 256) {	/* set minimum valid module size */
+		ret = -XMP_ERROR_FORMAT;
+		goto err;
+	}
+#endif
+
+	if (info != NULL) {
+		*info->name = 0;	/* reset name prior to testing */
+		*info->type = 0;	/* reset type prior to testing */
+	}
+
+	for (i = 0; format_loader[i] != NULL; i++) {
+		hio_seek(h, 0, SEEK_SET);
+		if (format_loader[i]->test(h, buf, 0) == 0) {
+			int is_prowizard = 0;
+
+#ifndef LIBXMP_CORE_PLAYER
+			if (strcmp(format_loader[i]->name, "prowizard") == 0) {
+				hio_seek(h, 0, SEEK_SET);
+				pw_test_format(h, buf, 0, info);
+				is_prowizard = 1;
+			}
+#endif
+
+			fclose(h->handle.file);
+
+#ifndef LIBXMP_CORE_PLAYER
+			unlink_temp_file(temp);
+#endif
+
+			if (info != NULL && !is_prowizard) {
+				strncpy(info->name, buf, XMP_NAME_SIZE - 1);
+				strncpy(info->type, format_loader[i]->name,
+							XMP_NAME_SIZE - 1);
+			}
+			return 0;
+		}
+	}
+
+#ifndef LIBXMP_CORE_PLAYER
     err:
 	hio_close(h);
 	unlink_temp_file(temp);

--- a/test-dev/Makefile.in
+++ b/test-dev/Makefile.in
@@ -51,6 +51,7 @@ EFFECTS		= 0_arpeggio 1_slide_up 2_slide_down \
 API		= get_format_list create_context free_context \
 		  test_module load_module load_module_from_memory \
 		  load_module_from_file \
+		  test_module_from_file test_module_from_memory \
 		  start_player play_buffer \
 		  set_position prev_position set_row \
 		  set_player stop_module restart_module seek_time \

--- a/test-dev/test_api_test_module_from_file.c
+++ b/test-dev/test_api_test_module_from_file.c
@@ -1,0 +1,70 @@
+#include "test.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+
+static int test_module_from_file_helper(const char* filename, struct xmp_test_info *tinfo)
+{
+	FILE *f;
+	int ret;
+
+	f = fopen(filename, "rb");
+	fail_unless(f != NULL, "open file");
+	ret = xmp_test_module_from_file(f, 0, tinfo);
+	fclose(f);
+	return ret;
+}
+
+TEST(test_api_test_module_from_file)
+{
+	struct xmp_test_info tinfo;
+	int ret, err;
+
+	/* unsupported format */
+	ret = test_module_from_file_helper("data/storlek_01.data", &tinfo);
+	fail_unless(ret == -XMP_ERROR_FORMAT, "unsupported format fail");
+
+	/* corrupted compressed file */
+	ret = test_module_from_file_helper("data/corrupted.gz", &tinfo);
+	fail_unless(ret == -XMP_ERROR_DEPACK, "depack error fail");
+
+	/* file too small */
+	ret = test_module_from_file_helper("data/sample-16bit.raw", &tinfo);
+	fail_unless(ret == -XMP_ERROR_FORMAT, "small file fail");
+
+	/* null info */
+	ret = test_module_from_file_helper("data/storlek_05.it", NULL);
+	fail_unless(ret == 0, "null info test fail");
+
+	/* XM */
+	ret = test_module_from_file_helper("data/test.mmcmp", &tinfo);
+	fail_unless(ret == 0, "XM test module fail");
+	fail_unless(strcmp(tinfo.name, "playboy") == 0, "XM module name fail");
+	fail_unless(strcmp(tinfo.type, "Fast Tracker II") == 0, "XM module type fail");
+
+	/* MOD */
+	ret = test_module_from_file_helper("data/ode2ptk.mod", &tinfo);
+	fail_unless(ret == 0, "MOD test module fail");
+	fail_unless(strcmp(tinfo.name, "Ode to Protracker") == 0, "MOD module name fail");
+	fail_unless(strcmp(tinfo.type, "Amiga Protracker/Compatible") == 0, "MOD module type fail");
+
+	/* IT */
+	ret = test_module_from_file_helper("data/storlek_01.it", &tinfo);
+	fail_unless(ret == 0, "IT test module fail");
+	fail_unless(strcmp(tinfo.name, "arpeggio + pitch slide") == 0, "IT module name fail");
+	fail_unless(strcmp(tinfo.type, "Impulse Tracker") == 0, "IT module type fail");
+
+	/* S3M */
+	ret = test_module_from_file_helper("data/xzdata", &tinfo);
+	fail_unless(ret == 0, "S3M test module fail");
+	fail_unless(strcmp(tinfo.name, "Inspiration") == 0, "S3M module name fail");
+	fail_unless(strcmp(tinfo.type, "Scream Tracker 3") == 0, "S3M module type fail");
+
+	/* Prowizard */
+	ret = test_module_from_file_helper("data/PRU1.intro-electro", &tinfo);
+	fail_unless(ret == 0, "Prowizard test module fail");
+	fail_unless(strcmp(tinfo.name, "intro-electro") == 0, "Prowizard module name fail");
+	fail_unless(strcmp(tinfo.type, "Prorunner 1.0") == 0, "Prowizard module type fail");
+}
+END_TEST

--- a/test-dev/test_api_test_module_from_file.c
+++ b/test-dev/test_api_test_module_from_file.c
@@ -11,7 +11,7 @@ static int test_module_from_file_helper(const char* filename, struct xmp_test_in
 
 	f = fopen(filename, "rb");
 	fail_unless(f != NULL, "open file");
-	ret = xmp_test_module_from_file(f, 0, tinfo);
+	ret = xmp_test_module_from_file(f, tinfo);
 	fclose(f);
 	return ret;
 }

--- a/test-dev/test_api_test_module_from_memory.c
+++ b/test-dev/test_api_test_module_from_memory.c
@@ -1,0 +1,66 @@
+#include "test.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+
+static int test_module_from_memory_helper(const char* filename, struct xmp_test_info *tinfo, char* buf)
+{
+	FILE *f;
+	int ret;
+	size_t bread;
+
+	f = fopen(filename, "rb");
+	fail_unless(f != NULL, "open file");
+	bread = fread(buf, 1, 64 * 1024, f);
+	fclose(f);
+	ret = xmp_test_module_from_memory(buf, bread, tinfo);
+	return ret;
+}
+
+TEST(test_api_test_module_from_memory)
+{
+	struct xmp_test_info tinfo;
+	int ret, err;
+	char* buf;
+
+	/* Sufficient to hold all file buffers */
+	buf = malloc(64 * 1024);
+	fail_unless(buf != NULL, "allocation error");
+
+	/* unsupported format */
+	ret = test_module_from_memory_helper("data/storlek_01.data", &tinfo, buf);
+	fail_unless(ret == -XMP_ERROR_FORMAT, "unsupported format fail");
+
+	/* file too small */
+	ret = test_module_from_memory_helper("data/sample-16bit.raw", &tinfo, buf);
+	fail_unless(ret == -XMP_ERROR_FORMAT, "small file fail");
+
+	/* null info */
+	ret = test_module_from_memory_helper("data/storlek_05.it", NULL, buf);
+	fail_unless(ret == 0, "null info test fail");
+
+	/* XM */
+	ret = test_module_from_memory_helper("data/xm_portamento_target.xm", &tinfo, buf);
+	fail_unless(ret == 0, "XM test module fail");
+	fail_unless(strcmp(tinfo.type, "Fast Tracker II") == 0, "XM module type fail");
+
+	/* MOD */
+	ret = test_module_from_memory_helper("data/ode2ptk.mod", &tinfo, buf);
+	fail_unless(ret == 0, "MOD test module fail");
+	fail_unless(strcmp(tinfo.name, "Ode to Protracker") == 0, "MOD module name fail");
+	fail_unless(strcmp(tinfo.type, "Amiga Protracker/Compatible") == 0, "MOD module type fail");
+
+	/* IT */
+	ret = test_module_from_memory_helper("data/storlek_01.it", &tinfo, buf);
+	fail_unless(ret == 0, "IT test module fail");
+	fail_unless(strcmp(tinfo.name, "arpeggio + pitch slide") == 0, "IT module name fail");
+	fail_unless(strcmp(tinfo.type, "Impulse Tracker") == 0, "IT module type fail");
+
+	/* S3M (no unpacker for memory) */
+	ret = test_module_from_memory_helper("data/xzdata", &tinfo, buf);
+	fail_unless(ret == -XMP_ERROR_FORMAT, "S3M test module compressed fail");
+
+	free(buf);
+}
+END_TEST


### PR DESCRIPTION
Adds new xmp_test_module variant functions for use in conjunction with `xmp_load_module_from_memory` and `xmp_load_module_from_file`. Identical to #134 by @Ghabry but with some cleanup of duplicate code, an unused variable removed, and some other tweaks.