### PR TITLE
Fix GDM format name ('General Digital Music', not 'Generic').

### DIFF
--- a/docs/formats.txt
+++ b/docs/formats.txt
@@ -85,7 +85,7 @@ XM		Fast Tracker II		1.02, 1.03, 1.04
 PC packed formats:
 
 AMF		DSMI (DMP)		0.9, 1.0, 1.1, 1.2, 1.3, 1.4
-GDM		Generic Digital Music	1.0
+GDM		General Digital Music	1.0
 STX		ST Music Interface Kit	1.0, 1.1
 
 Game formats:

--- a/src/loaders/gdm_load.c
+++ b/src/loaders/gdm_load.c
@@ -36,7 +36,7 @@ static int gdm_test(HIO_HANDLE *, char *, const int);
 static int gdm_load (struct module_data *, HIO_HANDLE *, const int);
 
 const struct format_loader libxmp_loader_gdm = {
-	"Generic Digital Music",
+	"General Digital Music",
 	gdm_test,
 	gdm_load
 };


### PR DESCRIPTION
This format is called "General Digital Music" but it was incorrectly named in the formats list and in the loader.

Sources:
* [GDMFORM.TXT](https://github.com/libxmp/libxmp/files/5609681/GDMFORM.TXT) packaged with Bells, Whistles, and Sound Boards.
* [MenTaLguY GDM format documentation.](https://github.com/libxmp/libxmp/blob/master/docs/formats/gdm.txt)
* [15 lines above the loader struct...](https://github.com/libxmp/libxmp/blob/master/src/loaders/gdm_load.c#L24)

(I've also seen it referred to as "General DigiMusic" before, but not in any official source...)