### PR TITLE
Emscripten build fix

### DIFF
--- a/include/xmp.h
+++ b/include/xmp.h
@@ -26,9 +26,16 @@ extern "C" {
 #elif defined(__SUNPRO_C) && defined(XMP_LDSCOPE_GLOBAL)
 # define LIBXMP_EXPORT __global
 #elif defined(EMSCRIPTEN)
+# include <emscripten.h>
 # define LIBXMP_EXPORT EMSCRIPTEN_KEEPALIVE
 #else
 # define LIBXMP_EXPORT
+#endif
+
+#if defined(EMSCRIPTEN) /* Don't apply this attribute to extern variables */
+# define LIBXMP_EXPORT_VAR
+#else
+# define LIBXMP_EXPORT_VAR LIBXMP_EXPORT
 #endif
 
 #define XMP_NAME_SIZE		64	/* Size of module name and type */
@@ -317,8 +324,8 @@ struct xmp_frame_info {			/* Current frame information */
 
 typedef char *xmp_context;
 
-LIBXMP_EXPORT extern const char *xmp_version;
-LIBXMP_EXPORT extern const unsigned int xmp_vercode;
+LIBXMP_EXPORT_VAR extern const char *xmp_version;
+LIBXMP_EXPORT_VAR extern const unsigned int xmp_vercode;
 
 LIBXMP_EXPORT xmp_context xmp_create_context  (void);
 LIBXMP_EXPORT void        xmp_free_context    (xmp_context);

--- a/include/xmp.h
+++ b/include/xmp.h
@@ -28,13 +28,12 @@ extern "C" {
 #elif defined(EMSCRIPTEN)
 # include <emscripten.h>
 # define LIBXMP_EXPORT EMSCRIPTEN_KEEPALIVE
+# define LIBXMP_EXPORT_VAR
 #else
 # define LIBXMP_EXPORT
 #endif
 
-#if defined(EMSCRIPTEN) /* Don't apply this attribute to extern variables */
-# define LIBXMP_EXPORT_VAR
-#else
+#if !defined (LIBXMP_EXPORT_VAR)
 # define LIBXMP_EXPORT_VAR LIBXMP_EXPORT
 #endif
 

--- a/src/common.h
+++ b/src/common.h
@@ -6,6 +6,13 @@
 #include <string.h>
 #include "xmp.h"
 
+#undef  LIBXMP_EXPORT_VAR
+#if defined(EMSCRIPTEN)
+#define LIBXMP_EXPORT_VAR EMSCRIPTEN_KEEPALIVE
+#else
+#define LIBXMP_EXPORT_VAR
+#endif
+
 #if defined(__MORPHOS__) || defined(__AROS__) || defined(AMIGAOS) || \
     defined(__amigaos__) || defined(__amigaos4__) ||defined(__amigados__) || \
     defined(AMIGA) || defined(_AMIGA) || defined(__AMIGA__)

--- a/src/common.h
+++ b/src/common.h
@@ -8,6 +8,7 @@
 
 #undef  LIBXMP_EXPORT_VAR
 #if defined(EMSCRIPTEN)
+#include <emscripten.h>
 #define LIBXMP_EXPORT_VAR EMSCRIPTEN_KEEPALIVE
 #else
 #define LIBXMP_EXPORT_VAR

--- a/src/control.c
+++ b/src/control.c
@@ -30,10 +30,10 @@
 #include "virtual.h"
 #include "mixer.h"
 
-const char *xmp_version = XMP_VERSION;
-const unsigned int xmp_vercode = XMP_VERCODE;
+const char *xmp_version LIBXMP_EXPORT_VAR = XMP_VERSION;
+const unsigned int xmp_vercode LIBXMP_EXPORT_VAR = XMP_VERCODE;
 
-xmp_context xmp_create_context()
+xmp_context xmp_create_context(void)
 {
 	struct context_data *ctx;
 


### PR DESCRIPTION
I made this fix at 27'th September 2019 while experimenting
with the Emscripten thing. Unfortunately, external variables don't like
the given export flag. Also, the build fails when emscripten.h wasn't included.