### PR TITLE
Fix effects array bounding in LIQ/IMF loaders.

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -77,6 +77,7 @@ typedef signed long long int64;
 } while (0)
 #define MIN(x,y) ((x) < (y) ? (x) : (y))
 #define MAX(x,y) ((x) > (y) ? (x) : (y))
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 
 #define TRACK_NUM(a,c)	m->mod.xxp[a]->index[c]
 #define EVENT(a,c,r)	m->mod.xxt[TRACK_NUM((a),(c))]->event[r]

--- a/src/loaders/669_load.c
+++ b/src/loaders/669_load.c
@@ -80,7 +80,7 @@ struct c669_instrument_header {
 
 /* Effects bug fixed by Miod Vallat <miodrag@multimania.com> */
 
-static const uint8 fx[] = {
+static const uint8 fx[6] = {
     FX_669_PORTA_UP,
     FX_669_PORTA_DN,
     FX_669_TPORTA,
@@ -226,7 +226,7 @@ static int c669_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		event->vol = (LSN(ev[1]) << 2) + 1;
 
 	    if (ev[2] != 0xff) {
-		if (MSN(ev[2]) > 5)
+		if (MSN(ev[2]) >= ARRAY_SIZE(fx))
 		    continue;
 
 		event->fxt = fx[MSN(ev[2])];

--- a/src/loaders/far_load.c
+++ b/src/loaders/far_load.c
@@ -101,7 +101,7 @@ static int far_test(HIO_HANDLE *f, char *t, const int start)
 #define FX_FAR_PORTA_UP		0xf9
 #define FX_FAR_PORTA_DN		0xf8
 
-static const uint8 fx[] = {
+static const uint8 fx[16] = {
     NONE,
     FX_FAR_PORTA_UP,		/* 0x1?  Pitch Adjust */
     FX_FAR_PORTA_DN,		/* 0x2?  Pitch Adjust */

--- a/src/loaders/imf_load.c
+++ b/src/loaders/imf_load.c
@@ -129,7 +129,7 @@ static int imf_test(HIO_HANDLE *f, char *t, const int start)
 
 
 /* Effect conversion table */
-static const uint8 fx[] = {
+static const uint8 fx[36] = {
 	NONE,
 	FX_S3M_SPEED,
 	FX_S3M_BPM,
@@ -173,6 +173,12 @@ static const uint8 fx[] = {
 static void xlat_fx (int c, uint8 *fxt, uint8 *fxp)
 {
     uint8 h = MSN (*fxp), l = LSN (*fxp);
+
+    if (*fxt >= ARRAY_SIZE(fx)) {
+	D_(D_WARN "invalid effect %#02x", *fxt);
+	*fxt = *fxp = 0;
+	return;
+    }
 
     switch (*fxt = fx[*fxt]) {
     case FX_IMF_FPORTA_UP:

--- a/src/loaders/it_load.c
+++ b/src/loaders/it_load.c
@@ -975,7 +975,7 @@ static int load_it_pattern(struct module_data *m, int i, int new_fx,
 		}
 		if (mask[c] & 0x08) {
 			b = hio_read8(f);
-			if (b > 31) {
+			if (b >= ARRAY_SIZE(fx)) {
 				D_(D_WARN "invalid effect %#02x", b);
 				hio_read8(f);
 				

--- a/src/loaders/liq_load.c
+++ b/src/loaders/liq_load.c
@@ -113,7 +113,7 @@ static int liq_test(HIO_HANDLE *f, char *t, const int start)
 #define NONE 0xff
 
 
-static const uint8 fx[] = {
+static const uint8 fx[25] = {
 	FX_ARPEGGIO,
 	FX_S3M_BPM,
 	FX_BREAK,
@@ -146,6 +146,12 @@ static const uint8 fx[] = {
 static void xlat_fx(int c, struct xmp_event *e)
 {
     uint8 h = MSN (e->fxp), l = LSN (e->fxp);
+
+    if (e->fxt >= ARRAY_SIZE(fx)) {
+	D_(D_WARN "invalid effect %#02x", e->fxt);
+	e->fxt = e->fxp = 0;
+	return;
+    }
 
     switch (e->fxt = fx[e->fxt]) {
     case FX_EXTENDED:			/* Extended effects */

--- a/src/loaders/no_load.c
+++ b/src/loaders/no_load.c
@@ -79,7 +79,7 @@ static int no_test(HIO_HANDLE *f, char *t, const int start)
 }
 
 
-static const uint8 fx[] = {
+static const uint8 fx[15] = {
 	FX_ARPEGGIO,
 	0,
 	FX_BREAK,

--- a/src/loaders/okt_load.c
+++ b/src/loaders/okt_load.c
@@ -65,7 +65,7 @@ struct local_data {
 	int sample;
 };
 
-static const int fx[] = {
+static const int fx[32] = {
 	NONE,
 	FX_PORTA_UP,		/*  1 */
 	FX_PORTA_DN,		/*  2 */
@@ -260,7 +260,7 @@ static int get_pbod(struct module_data *m, int size, HIO_HANDLE *f, void *parm)
 		}
 
 		fxt = hio_read8(f);
-		if (fxt >= 32) {
+		if (fxt >= ARRAY_SIZE(fx)) {
 			return -1;
 		}
 		e->fxt = fx[fxt];

--- a/src/loaders/s3m_load.c
+++ b/src/loaders/s3m_load.c
@@ -113,7 +113,7 @@ static int s3m_test(HIO_HANDLE *f, char *t, const int start)
 	} while (0)
 
 /* Effect conversion table */
-static const uint8 fx[] = {
+static const uint8 fx[27] = {
 	NONE,
 	FX_S3M_SPEED,		/* Axx  Set speed to xx (the default is 06) */
 	FX_JUMP,		/* Bxx  Jump to order xx (hexadecimal) */
@@ -148,7 +148,7 @@ static void xlat_fx(int c, struct xmp_event *e)
 {
 	uint8 h = MSN(e->fxp), l = LSN(e->fxp);
 
-	if (e->fxt > 26) {
+	if (e->fxt >= ARRAY_SIZE(fx)) {
 		D_(D_WARN "invalid effect %02x", e->fxt);
 		e->fxt = e->fxp = 0;
 		return;

--- a/src/loaders/stx_load.c
+++ b/src/loaders/stx_load.c
@@ -115,12 +115,17 @@ static int stx_test(HIO_HANDLE * f, char *t, const int start)
 
 #define FX_NONE 0xff
 
-static const uint8 fx[] = {
-	FX_NONE, FX_SPEED,
-	FX_JUMP, FX_BREAK,
-	FX_VOLSLIDE, FX_PORTA_DN,
-	FX_PORTA_UP, FX_TONEPORTA,
-	FX_VIBRATO, FX_TREMOR,
+static const uint8 fx[11] = {
+	FX_NONE,
+	FX_SPEED,
+	FX_JUMP,
+	FX_BREAK,
+	FX_VOLSLIDE,
+	FX_PORTA_DN,
+	FX_PORTA_UP,
+	FX_TONEPORTA,
+	FX_VIBRATO,
+	FX_TREMOR,
 	FX_ARPEGGIO
 };
 
@@ -334,7 +339,7 @@ static int stx_load(struct module_data *m, HIO_HANDLE *f, const int start)
 			if (b & S3M_FX_FOLLOWS) {
 				int t = hio_read8(f);
 				int p = hio_read8(f);
-				if (t <= 10) {
+				if (t < ARRAY_SIZE(fx)) {
 					event->fxt = fx[t];
 					event->fxp = p;
 					switch (event->fxt) {


### PR DESCRIPTION
Fixes some more loader effects bounding issues found in the comments of #247, specifically out-of-bounds reads in `liq_load.c` and `imf_load.c`. I also added added explicit array sizes for most loaders using effects arrays (since in these loaders the array size is a functional part of the loader) and an `ARRAY_SIZE` macro so the relationship between the bounding and the effects array size is more obvious.

I'm not very familiar with Liquid Tracker or Imago Orpheus so if @debrouxl could verify that these loaders are correctly patched now that would be great.