### PR TITLE
Fixed linking errors with debug builds at MSVC 2015, 2017, and 2019

### DIFF
--- a/src/win32/debug.c
+++ b/src/win32/debug.c
@@ -6,7 +6,7 @@
 
 #include <stdio.h>
 #include <stdarg.h>
-void _D(const char *format, ...)
+void D_(const char *format, ...)
 {
 	va_list argptr;
 


### PR DESCRIPTION
At my copy, I had to accidentally revert this fix I made a while ago, and the result was caused lots of missing `_D_` symbols in debug builds for MSVC 2015, 2017, and 2019. This happens in an attempt to link the static library to any building application.