### PR TITLE
Fix misc. fuzzing crashes.

### DIFF
--- a/src/hmn_extras.c
+++ b/src/hmn_extras.c
@@ -111,6 +111,7 @@ void libxmp_hmn_reset_channel_extras(struct channel_data *xc)
 void libxmp_hmn_release_channel_extras(struct channel_data *xc)
 {
 	free(xc->extra);
+	xc->extra = NULL;
 }
 
 int libxmp_hmn_new_module_extras(struct module_data *m)
@@ -126,6 +127,7 @@ int libxmp_hmn_new_module_extras(struct module_data *m)
 void libxmp_hmn_release_module_extras(struct module_data *m)
 {
 	free(m->extra);
+	m->extra = NULL;
 }
 
 void libxmp_hmn_extras_process_fx(struct context_data *ctx, struct channel_data *xc,

--- a/src/load.c
+++ b/src/load.c
@@ -469,8 +469,7 @@ static int load_module(xmp_context opaque, HIO_HANDLE *h)
 #endif
 
 	if (test_result < 0) {
-		free(m->basename);
-		free(m->dirname);
+		xmp_release_module(opaque);
 		return -XMP_ERROR_FORMAT;
 	}
 
@@ -601,6 +600,10 @@ int xmp_load_module(xmp_context opaque, const char *path)
 
 	m->filename = path;	/* For ALM, SSMT, etc */
 	m->size = size;
+#else
+	ctx->m.filename = NULL;
+	ctx->m.dirname = NULL;
+	ctx->m.basename = NULL;
 #endif
 
 	ret = load_module(opaque, h);
@@ -705,6 +708,7 @@ void xmp_release_module(xmp_context opaque)
 			free(mod->xxt[i]);
 		}
 		free(mod->xxt);
+		mod->xxt = NULL;
 	}
 
 	if (mod->xxp != NULL) {
@@ -712,6 +716,7 @@ void xmp_release_module(xmp_context opaque)
 			free(mod->xxp[i]);
 		}
 		free(mod->xxp);
+		mod->xxp = NULL;
 	}
 
 	if (mod->xxi != NULL) {
@@ -720,6 +725,7 @@ void xmp_release_module(xmp_context opaque)
 			free(mod->xxi[i].extra);
 		}
 		free(mod->xxi);
+		mod->xxi = NULL;
 	}
 
 	if (mod->xxs != NULL) {
@@ -728,6 +734,8 @@ void xmp_release_module(xmp_context opaque)
 		}
 		free(mod->xxs);
 		free(m->xtra);
+		mod->xxs = NULL;
+		m->xtra = NULL;
 	}
 
 #ifndef LIBXMP_CORE_DISABLE_IT
@@ -736,16 +744,20 @@ void xmp_release_module(xmp_context opaque)
 			libxmp_free_sample(&m->xsmp[i]);
 		}
 		free(m->xsmp);
+		m->xsmp = NULL;
 	}
 #endif
 
 	libxmp_free_scan(ctx);
 
 	free(m->comment);
+	m->comment = NULL;
 
 	D_("free dirname/basename");
 	free(m->dirname);
 	free(m->basename);
+	m->basename = NULL;
+	m->dirname = NULL;
 }
 
 void xmp_scan_module(xmp_context opaque)

--- a/src/loaders/fnk_load.c
+++ b/src/loaders/fnk_load.c
@@ -137,6 +137,11 @@ static int fnk_load(struct module_data *m, HIO_HANDLE *f, const int start)
     }
     mod->pat++;
 
+    /* Sanity check */
+    if (mod->pat > 128) {
+	return -1;
+    }
+
     mod->len = i;
     memcpy (mod->xxo, ffh.order, mod->len);
 

--- a/src/loaders/it_load.c
+++ b/src/loaders/it_load.c
@@ -521,7 +521,7 @@ static int load_new_it_instrument(struct xmp_instrument *xxi, HIO_HANDLE *f)
 	int inst_map[120], inst_rmap[XMP_MAX_KEYS];
 	struct it_instrument2_header i2h;
 	struct it_envelope env;
-	int dca2nna[] = { 0, 2, 3 };
+	int dca2nna[] = { 0, 2, 3, 3 /* Northern Sky (cj-north.it) has this... */ };
 	int c, k, j;
 	uint8 buf[64];
 

--- a/src/loaders/mdl_load.c
+++ b/src/loaders/mdl_load.c
@@ -370,6 +370,11 @@ static int get_chunk_in(struct module_data *m, int size, HIO_HANDLE *f, void *pa
     struct xmp_module *mod = &m->mod;
     int i;
 
+    /* Sanity check */
+    if (mod->len) {
+	return -1;
+    }
+
     hio_read(mod->name, 1, 32, f);
     hio_seek(f, 20, SEEK_CUR);
 
@@ -474,6 +479,11 @@ static int get_chunk_tr(struct module_data *m, int size, HIO_HANDLE *f, void *pa
     struct xmp_module *mod = &m->mod;
     int i, j, k, row, len, max_trk;
     struct xmp_track *track;
+
+    /* Sanity check */
+    if (mod->trk) {
+	return -1;
+    }
 
     mod->trk = hio_read16l(f) + 1;
 
@@ -608,6 +618,11 @@ static int get_chunk_ii(struct module_data *m, int size, HIO_HANDLE *f, void *pa
     int map, last_map;
     char buf[40];
 
+    /* Sanity check */
+    if (mod->ins) {
+	return -1;
+    }
+
     mod->ins = hio_read8(f);
     D_(D_INFO "Instruments: %d", mod->ins);
 
@@ -690,6 +705,11 @@ static int get_chunk_is(struct module_data *m, int size, HIO_HANDLE *f, void *pa
     char buf[64];
     uint8 x;
 
+    /* Sanity check */
+    if (mod->smp) {
+	return -1;
+    }
+
     mod->smp = hio_read8(f);
     if ((mod->xxs = calloc(sizeof (struct xmp_sample), mod->smp)) == NULL)
 	return -1;
@@ -754,6 +774,11 @@ static int get_chunk_i0(struct module_data *m, int size, HIO_HANDLE *f, void *pa
     int i;
     char buf[64];
     uint8 x;
+
+    /* Sanity check */
+    if (mod->smp || mod->ins) {
+	return -1;
+    }
 
     mod->ins = mod->smp = hio_read8(f);
 
@@ -894,6 +919,11 @@ static int get_chunk_ve(struct module_data *m, int size, HIO_HANDLE *f, void *pa
     struct local_data *data = (struct local_data *)parm;
     int i;
 
+    /* Sanity check */
+    if (data->v_env) {
+	return -1;
+    }
+
     if ((data->v_envnum = hio_read8(f)) == 0)
 	return 0;
 
@@ -916,6 +946,11 @@ static int get_chunk_pe(struct module_data *m, int size, HIO_HANDLE *f, void *pa
     struct local_data *data = (struct local_data *)parm;
     int i;
 
+    /* Sanity check */
+    if (data->p_env) {
+	return -1;
+    }
+
     if ((data->p_envnum = hio_read8(f)) == 0)
 	return 0;
 
@@ -937,6 +972,11 @@ static int get_chunk_fe(struct module_data *m, int size, HIO_HANDLE *f, void *pa
 {
     struct local_data *data = (struct local_data *)parm;
     int i;
+
+    /* Sanity check */
+    if (data->f_env) {
+	return -1;
+    }
 
     if ((data->f_envnum = hio_read8(f)) == 0)
 	return 0;

--- a/src/loaders/med4_load.c
+++ b/src/loaders/med4_load.c
@@ -237,7 +237,7 @@ static int med4_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	num_ins = 0;
 	memset(temp_inst, 0, sizeof(temp_inst));
 	for (i = 0; mask != 0 && i < 64; i++, mask <<= 1) {
-		uint8 c, size, buf[40];
+		uint8 c, size;
 		uint16 loop_len = 0;
 
 		if ((int64)mask > 0)

--- a/src/loaders/mtm_load.c
+++ b/src/loaders/mtm_load.c
@@ -102,7 +102,7 @@ static int mtm_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		return -1;
 
 	mfh.channels = hio_read8(f);	/* Number of tracks per pattern */
-	if (mfh.channels > XMP_MAX_CHANNELS) {
+	if (mfh.channels > MIN(32, XMP_MAX_CHANNELS)) {
 		return -1;
 	}
 

--- a/src/loaders/prowizard/di.c
+++ b/src/loaders/prowizard/di.c
@@ -101,6 +101,11 @@ static int depack_di(HIO_HANDLE *in, FILE *out)
 			max = ptable[i];
 	}
 
+	/* Sanity check */
+	if (max >= 128) {
+		return -1;
+	}
+
 	write32b(out, PW_MOD_MAGIC);
 
 	hio_seek(in, pos, SEEK_SET);

--- a/src/loaders/prowizard/pha.c
+++ b/src/loaders/prowizard/pha.c
@@ -134,9 +134,14 @@ restart:
 	for (i = 0; i < 120; i++) {
 		paddr1[j] = paddr2[i];
 		j += 1;
+		if (j >= 128)
+			break;
+
 		if ((paddr2[i + 1] - paddr2[i]) > 1024) {
 			paddr1[j] = paddr2[i] + 1024;
 			j += 1;
+			if (j >= 128)
+				break;
 		}
 	}
 

--- a/src/loaders/prowizard/tp3.c
+++ b/src/loaders/prowizard/tp3.c
@@ -73,6 +73,11 @@ static int depack_tp23(HIO_HANDLE *in, FILE *out, int ver)
 			npat = pnum[i];
 	}
 
+	/* Sanity check */
+	if (npat >= 128) {
+		return -1;
+	}
+
 	/* read tracks addresses */
 	/* bypass 4 bytes or not ?!? */
 	/* Here, I choose not :) */

--- a/src/loaders/psm_load.c
+++ b/src/loaders/psm_load.c
@@ -55,7 +55,7 @@ static int psm_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	struct xmp_event *event;
 	uint8 buf[1024];
 	uint32 p_ord, p_chn, p_pat, p_ins;
-	uint32 p_smp[64];
+	uint32 p_smp[256];
 	int type, ver /*, mode*/;
 
 	LOAD_INIT();

--- a/src/loaders/ult_load.c
+++ b/src/loaders/ult_load.c
@@ -237,6 +237,11 @@ static int ult_load(struct module_data *m, HIO_HANDLE *f, const int start)
     mod->bpm = 125;
     mod->trk = mod->chn * mod->pat;
 
+    /* Sanity check */
+    if (mod->chn > XMP_MAX_CHANNELS) {
+	return -1;
+    }
+
     for (i = 0; i < mod->chn; i++) {
 	if (ver >= 3) {
 	    x8 = hio_read8(f);

--- a/src/loaders/ult_load.c
+++ b/src/loaders/ult_load.c
@@ -277,6 +277,11 @@ static int ult_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	    if (cnt == 0)
 		cnt++;
 
+	    if (j + cnt > 64 * mod->pat) {
+		D_(D_WARN "invalid track data packing");
+		return -1;
+	    }
+
 	    for (k = 0; k < cnt; k++, j++) {
 		event = &EVENT (j >> 6, i , j & 0x3f);
 		memset(event, 0, sizeof (struct xmp_event));

--- a/src/med_extras.c
+++ b/src/med_extras.c
@@ -371,6 +371,7 @@ void libxmp_med_reset_channel_extras(struct channel_data *xc)
 void libxmp_med_release_channel_extras(struct channel_data *xc)
 {
 	free(xc->extra);
+	xc->extra = NULL;
 }
 
 int libxmp_med_new_module_extras(struct module_data *m)
@@ -416,6 +417,7 @@ void libxmp_med_release_module_extras(struct module_data *m)
         }
 
 	free(m->extra);
+	m->extra = NULL;
 }
 
 void libxmp_med_extras_process_fx(struct context_data *ctx, struct channel_data *xc,

--- a/test-dev/test_api_load_module.c
+++ b/test-dev/test_api_load_module.c
@@ -89,6 +89,12 @@ TEST(test_api_load_module)
 	state = xmp_get_player(ctx, XMP_PLAYER_STATE);
 	fail_unless(state == XMP_STATE_UNLOADED, "state error");
 
+	/* double release should be safe. */
+	xmp_release_module(ctx);
+
+	state = xmp_get_player(ctx, XMP_PLAYER_STATE);
+	fail_unless(state == XMP_STATE_UNLOADED, "state error");
+
 	xmp_free_context(ctx);
 }
 END_TEST


### PR DESCRIPTION
Fixes the following bugs found in #251:
* The FNK loader could attempt to load more than 128 patterns despite having a fixed maximum pattern count of 128.
* The IT loader allows duplicate check actions in the range 0 to 3 but the array to convert DCAs to NNAs was only size 3.
* The MDL loader was missing checks to prevent loading modules with duplicate chunks.
* The MED4 loader could attempt to load instrument names of up to length 255 into an array of size 40.
* The MTM loader could attempt to load more than 32 channels despite having a fixed maximum channel count of 32.
* The PSM loader allows up to 255 samples but the sample offsets array was only size 64.
* The ULT loader was missing bounds checks on the channel count and track RLE unpacking.
* The ProWizard DI, Pha, and TP2/3 unpackers could attempt to load more than 128 patterns despite having fixed size arrays of 128.

Also fixes the following bugs I found while fixing those:
* Fix double frees when `xmp_release_module` is called twice due to dangling pointers in the xmp context not being cleared after they are freed.