### PR TITLE
Update .gitignore to ignore config.cache, test-dev misc. files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ AS.*
 *.bz2
 
 # Configuration
+config.cache
 config.log
 config.status
 configure
@@ -62,12 +63,13 @@ depend
 players/xmp/Makefile
 libxmp.pc
 Makefile
-test/all_tests.c
 test/.test
 test/libxmp-covertest
 test/libxmp-tests
 test/test8.raw
-test/write_test
+test-dev/.read_test
+test-dev/all_tests.c
+test-dev/write_test
 coverage/
 docs/libxmp.3
 docs/libxmp.html


### PR DESCRIPTION
Updates the .gitignore file to ignore some miscellaneous files that were laying around my local repository being detected as untracked:

* config.cache
* test-dev/.read_test (not sure how this isn't getting unlinked, oh well)
* test-dev/all_tests.c (.gitignore rule had this in test/)
* test-dev/write_test (.gitignore rule had this in test/)