### PR TITLE
NULL pointers that may be reused after they are freed.

### DIFF
--- a/src/control.c
+++ b/src/control.c
@@ -52,10 +52,12 @@ xmp_context xmp_create_context(void)
 void xmp_free_context(xmp_context opaque)
 {
 	struct context_data *ctx = (struct context_data *)opaque;
+	struct module_data *m = &ctx->m;
 
 	if (ctx->state > XMP_STATE_UNLOADED)
 		xmp_release_module(opaque);
 
+	free(m->instrument_path);
 	free(opaque);
 }
 

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -825,6 +825,7 @@ int libxmp_mixer_on(struct context_data *ctx, int rate, int format, int c4rate)
 
     err1:
 	free(s->buffer);
+	s->buffer = NULL;
     err:
 	return -1;
 }

--- a/src/player.c
+++ b/src/player.c
@@ -1596,9 +1596,11 @@ int xmp_start_player(xmp_context opaque, int rate, int format)
 #ifndef LIBXMP_CORE_PLAYER
     err2:
 	free(p->xc_data);
+	p->xc_data = NULL;
 #endif
     err1:
 	free(f->loop);
+	f->loop = NULL;
     err:
 	return ret;
 }

--- a/src/smix.c
+++ b/src/smix.c
@@ -89,6 +89,7 @@ int xmp_start_smix(xmp_context opaque, int chn, int smp)
 
     err1:
 	free(smix->xxi);
+	smix->xxi = NULL;
     err:
 	return -XMP_ERROR_INTERNAL;
 }
@@ -326,4 +327,6 @@ void xmp_end_smix(xmp_context opaque)
 
 	free(smix->xxs);
 	free(smix->xxi);
+	smix->xxs = NULL;
+	smix->xxi = NULL;
 }

--- a/src/virtual.c
+++ b/src/virtual.c
@@ -150,6 +150,7 @@ int libxmp_virt_on(struct context_data *ctx, int num)
 	}
 #endif
 	free(p->virt.voice_array);
+	p->virt.voice_array = NULL;
       err:
 	return -1;
 }
@@ -177,6 +178,8 @@ void libxmp_virt_off(struct context_data *ctx)
 
 	free(p->virt.voice_array);
 	free(p->virt.virt_channel);
+	p->virt.voice_array = NULL;
+	p->virt.virt_channel = NULL;
 }
 
 void libxmp_virt_reset(struct context_data *ctx)


### PR DESCRIPTION
When any pointer in the xmp_context data structures is freed it should now be cleared afterward to prevent potential double free issues (found most recently in #274 but also in other places before). Also, `module_data::instrument_path` now gets freed when a context is destroyed instead of leaking.

The only thing I noticed that might need to be patched but I did not patch here was that no pointers are ever cleared after freeing in fmopl.c, which could easily cause double free issues if e.g. `OPLCloseTable` is called twice or if `OPLCloseTable` is called after a failed `OPLOpenTable`. As far as I know currently all libxmp OPL code is dead and I don't know if there are any plans to restore it (and if there are, it may be worth considering replacing fmopl.c with Nuked OPL3).