### PR TITLE
it_load: handle cases where name field of header is not nul-terminated.

### DIFF
--- a/src/loaders/it_load.c
+++ b/src/loaders/it_load.c
@@ -1060,7 +1060,9 @@ static int it_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	hio_read(&ifh.chpan, 64, 1, f);
 	hio_read(&ifh.chvol, 64, 1, f);
 
-	strncpy(mod->name, (char *)ifh.name, XMP_NAME_SIZE);
+	memcpy(mod->name, ifh.name, sizeof(ifh.name));
+	/* sizeof(ifh.name) == 26, sizeof(mod->name) == 64. */
+	mod->name[sizeof(ifh.name)] = '\0';
 	mod->len = ifh.ordnum;
 	mod->ins = ifh.insnum;
 	mod->smp = ifh.smpnum;


### PR DESCRIPTION
Fixes #297.