### PR TITLE
Fix dist-package check fails due to missing python-pil package.

### DIFF
--- a/.github/workflows/dist-package.yaml
+++ b/.github/workflows/dist-package.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt install docutils-common rst2pdf
+        run: sudo apt update && sudo apt install docutils-common rst2pdf
       - name: Create and run configure script
         run: |
           autoconf

--- a/.github/workflows/emscripten.yaml
+++ b/.github/workflows/emscripten.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt install autoconf
+        run: sudo apt update && sudo apt install autoconf
       - name: Install emscripten
         run: |
           cd ..


### PR DESCRIPTION
The GitHub dist-package check has been failing on my fork branches due to a 404 error when attempting to download the package `python-pil`. The "fix" is to just run `sudo apt update` before attempting to install any packages. I also added this to the emscripten check even though it wasn't having this issue.

edit: [example failed check](https://github.com/AliceLR/libxmp/runs/1745452638).