### PR TITLE
Ignore files and directories generated by the lite build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,8 @@ docs/libxmp.html
 docs/libxmp.man.rst
 docs/libxmp.pdf
 .test
+libxmp-lite-stagedir/
+lite/Makefile.in
 
 # Other stuff and leftovers
 xmp.out


### PR DESCRIPTION
When do build the lite version, there is a lot of junk getting appears in the git status. Maybe do ignore that?