### PR TITLE
rewrite umx loader to use the embedded offset, size and object type

### DIFF
--- a/docs/formats/upkg.txt
+++ b/docs/formats/upkg.txt
@@ -1,0 +1,333 @@
+[ Copied from:
+  http://wiki.beyondunreal.com/Legacy:Package_File_Format and
+  http://wiki.beyondunreal.com/Legacy:Package_File_Format/Data_Details
+  License: Attribution-Noncommercial-Share Alike 3.0 ]
+
+
+The Unreal Engine uses a single file format to store all its game
+content. You may have seen many different filetypes, like .utx
+(textures), .unr (maps), .umx (sound) and .u (code), but from a
+technical standpoint there is no difference between those files;
+the different file endings are only used to help organize the
+packages in the directory structure. The following article will
+describe the basic structure of his fileformat. It omits many
+details (such as tons of constants, for example).
+
+
+The Structure of the File
+
+Every package file can be roughly split into three logical parts.
+The header, the three index tables (name-table, import-table and
+export-table) and the data itself. But only the header has a fixed
+position (at offset 0), all other parts can be found anywhere
+within the file without irritating the engine.
+
+Most of the time, although, the layout looks like the following:
+
+ - Header
+ - Name-Table
+ - Import-Table
+ - Data
+ - Export-Table
+
+
+** Header:
+
+This global header can be found at the beginning of the file
+(offset 0). It is the starting point for every operation.
+
+offset  Type    Property        Description
+------  -----   --------------- ---------------------------------------
+0       DWORD   Signature       Always: 0x9E2A83C1; use this to verify
+                                that you indeed try to read an Unreal-
+                                Package
+
+4       WORD    PackageVersion  Version of the file-format; Unreal1
+                                uses mostly 61-63, UT 67-69; However
+                                note that quite a few packages are in
+                                use with UT that have Unreal1 versions.
+
+6       WORD    LicenseMode     This is the license number. Different
+                                for each game.
+
+8       DWORD   Package Flags   Global package flags, i.e. if a package
+                                may be downloaded from a game server
+
+12      DWORD   Name Count      No. Of entries in name-table
+
+16      DWORD   Name Offset     Offset of name-table within the file
+
+20      DWORD   Export Count    No. Of entries in export-table
+
+24      DWORD   Export Offset   Offset of export-table within the file
+
+28      DWORD   Import Count    No. Of entries in import-table
+
+32      DWORD   Import Offset   Offset of import-table within the file
+
+After the ImportOffset, the header differs between the versions. The
+only interesting fact, though, is that for fileformat versions => 68,
+a GUID has been introduced. It can be found right after ImportOffset:
+
+36      16 BYTE GUID            Unique identifier; used for package
+                                downloading from servers
+
+older package versions have a list of GUIDs (pointed to by the same
+form of count/offset pair as above) in a seperate section rather than
+just space for one, tests reveal that ut uses the last one in the
+list when there is more than one but such packages do not seem to be
+seen in the wild.
+
+
+** Index Tables:
+
+The Unreal-Engine introduces two new variable-types. The first one
+is a rather simple string type, called NAME from now on. The second
+one is a bit more tricky, these CompactIndices, or INDEX later on,
+compresses ordinary DWORDs downto one to five BYTEs. Both types, as
+well as the ObjectReference, are described down below under Data
+Details.
+
+
+** Name-Table
+
+The first and most simple one of the three tables is the name-table.
+The name-table can be considered an index of all unique names used
+for objects and references within the file. Later on, you'll often
+find indexes into this table instead of a string containing the
+object-name.
+
+Type    Property        Description
+-----   ------------    -----------------------------------------------
+NAME    Object Name     
+DWORD   Object Flags    Flags for the object
+
+
+** Export-Table
+
+The export-table is an index for all objects within the package.
+Every object in the body of the file has a corresponding entry in
+this table, with information like offset within the file etc.
+
+Type    Property        Description
+-----   --------        -----------------------------------------------
+INDEX   Class           Class of the object, i.e. Texture or Palette
+                        etc; stored as a ObjectReference
+
+INDEX   Super           Object Parent; again a ObjectReference
+
+DWORD   Group           Internal package/group of the object, i.e.
+                        Floor for floor-textures; ObjectReference
+
+INDEX   Object Name     The name of the object; an index into the name-
+                        table
+
+DWORD   Object Flags    Flags for the object
+
+INDEX   Serial Size     Total size of the object
+
+INDEX   Serial Offset   Offset of the object; this field only exists if
+                        the SerialSize is larger 0
+
+
+** Import-Table:
+
+The third table holds references to objects in external packages.
+For example, a texture might have a DetailTexture (which makes for
+the nice structure if have a very close look at a texture). Now,
+these DetailTextures are all stored in a single package (as they
+are used by many different textures in different package files).
+The property of the texture object only needs to store an index
+into the import-table then as the entry in the import-table already
+points to the DetailTexture in the other package.
+
+Type    Property        Description
+-----   -------------   -----------
+INDEX   Class Package   Package file in which the class of the object
+                        is defined; an index into the name-table
+
+INDEX   Class Name      Class of the object, i.e. Texture, Palette,
+                        Package, etc; an index into the name-table
+
+DWORD   Package         Reference where the object resides;
+                        ObjectReference
+
+INDEX   Object Name     The name of the object; an index into the
+                        name-table
+
+
+** Body/Object:
+
+Each object consists of a list of properties at the beginning and
+the actual object itself.
+
+- Object Properties:
+
+When jumping to the offset of an object, you'll first be confronted
+with the object properties before the actual object starts. The
+format is rather straightforward. The first byte is an INDEX-type
+reference into the Name-Table, giving you the property's name. The
+second byte does the magic of telling you what kind of data follows;
+for example 0x02 flags a DWORD sized integer type. Then comes the
+actual property-data. The procedure repeats itself until the
+reference into the Name-Table returns 'None' (case insensitive) as
+the name.
+
+That said, there are some bit-tricks to deal with arrays, booleans
+and such.
+
+- Sample Objects (Texture Class):
+
+After the properties are finished the object starts. It basically
+consists of a predefined set of properties. As an example, the
+texture class (for good old UT) will be explained below. The
+texture class is a native one, which means that it doesn't have a
+generic header in addition to its own data. The layout looks like
+this:
+
+Type    Property        Description
+------- -----------     -----------------------------------------------
+BYTE    MipMapCount     Count of MipMaps in object
+
+The next set of variables repeats itself for each MipMap.
+
+Type    Property        Description
+------- -----------     -----------------------------------------------
+DWORD   WidthOffset     Offset in file; should be the same as
+                        SerialOffset in the Export-Table. Only
+                        if PkgVer >= 63
+
+INDEX   MipMapSize      Size of the image data (in bytes)
+
+n BYTEs MipMapData      Image data; one byte per pixel; n = MipMapSize
+
+DWORD   Width           Texture-width
+
+DWORD   Height          Texture-height
+
+BYTE    BitsWidth       Number of bits of Width
+                        (e.g. 10 for 1024 pixels)
+
+BYTE    BitsHeight      Number of bits of Height
+                        (e.g. 10 for 1024 pixels)
+
+
+** Data Details:
+
+- Integer values:
+
+Integers are stored in low-endian byte order (that means, the
+least significant byte comes first; the standard byte order for
+Intel processors).
+
+- Index/CompactIndex values:
+
+Index values are signed integers stored in a compact format,
+occupying one to five bytes. In the first byte,
+
+  - the most significant bit (bit 7) specifies the sign of the
+    integer value;
+  - the second-most significant bit (bit 6) is set if the value
+    is continued in the next byte;
+  - and the six remaining bits (bits 5 to 0) are the six least
+    significant bits of the resultant integer value.
+
+Each of the three following bytes (if applicable according to bit 6
+of the first byte) contributes seven more bits to the final integer
+value (bits 6 to 0 of each byte), while its most significant bit
+(bit 7) is set if another byte must be read to continue the value.
+The fifth byte contributes full eight bits to the value. No more
+than five bytes are read for a compact index value.
+
+The following chart demonstrates how compact index values are stored.
+The Range column specifies the range of values that can be stored with
+the given representation. s is the signum bit, and x are data bits.
+
+           Byte  0         1         2         3         4
+   Range   Bit   76543210  76543210  76543210  76543210  76543210
+   
+    6 bit        s0xxxxxx
+   13 bit        s1xxxxxx  0xxxxxxx
+   20 bit        s1xxxxxx  1xxxxxxx  0xxxxxxx
+   27 bit        s1xxxxxx  1xxxxxxx  1xxxxxxx  0xxxxxxx
+   35 bit        s1xxxxxx  1xxxxxxx  1xxxxxxx  1xxxxxxx  xxxxxxxx
+
+// Sample C# code (can be easily ported to C/C++/VB/etc.)
+ 
+/// <summary>Reads a compact integer from the FileReader.
+/// Bytes read differs, so do not make assumptions about
+/// physical data being read from the stream. (If you have
+/// to, get the difference of FileReader.BaseStream.Position
+/// before and after this is executed.)</summary>
+/// <returns>An "uncompacted" signed integer.</returns>
+/// <remarks>FileReader is a System.IO.BinaryReader mapped
+/// to a file. Also, there may be better ways to implement
+/// this, but this is fast, and it works.</remarks>
+private int ReadCompactInteger()
+{
+	int output = 0;
+	bool signed = false;
+	for(int i = 0; i < 5; i++)
+	{
+		byte x = FileReader.ReadByte();
+		// First byte
+		if(i == 0)
+		{
+			// Bit: X0000000
+			if((x & 0x80) > 0)
+				signed = true;
+			// Bits: 00XXXXXX
+			output |= (x & 0x3F);
+			// Bit: 0X000000
+			if((x & 0x40) == 0)
+				break;
+		}
+		// Last byte
+		else if(i == 4)
+		{
+			// Bits: 000XXXXX -- the 0 bits are ignored
+			// (hits the 32 bit boundary)
+			output |= (x & 0x1F) << (6 + (3 * 7));
+		}
+		// Middle bytes
+		else
+		{
+			// Bits: 0XXXXXXX
+			output |= (x & 0x7F) << (6 + ((i - 1) * 7));
+			// Bit: X0000000
+			if((x & 0x80) == 0)
+				break;
+		}
+	}
+	// multiply by negative one here, since the first 6+ bits could be 0
+	if(signed)
+		output *= -1;
+	return(output);
+}
+
+
+- Name values:
+
+The Name type is a simple string type. The format does, although,
+differ between the package versions.
+
+Older package versions (<64, original Unreal engine) store the Name
+type as a zero-terminated ASCII string; "UT2k3", for example would
+be stored as: "U" "T" "2" "k" "3" 0x00
+
+Newer packages (>=64, UT engine) prepend the length of the string
+plus the trailing zero. Again, "UT2k3" would be now stored as:
+0x06 "U" "T" "2" "k" "3" 0x00
+
+- Object References:
+
+The last custom type which can be found within package files is the
+ObjectReference. ObjectReferences can be imagined as pointers.
+Technically, they are stored as CompactIndices. Depending on their
+value, however, they can point to different objects.
+
+Value   Type                                    Pointer-Value
+-----   --------------------------------------  -----------------------
+ < 0    pointer to an entry of the ImportTable  entry-id = -value - 1
+ = 0    pointer to NULL                         NULL
+ > 0    pointer to an entry in the ExportTable  entry-id = value - 1

--- a/src/loaders/umx_load.c
+++ b/src/loaders/umx_load.c
@@ -23,6 +23,11 @@
 #include <stddef.h> /* offsetof() */
 #include "loader.h"
 
+#ifdef _WIN32
+#undef strcasecmp
+#define strcasecmp _stricmp
+#endif
+
 extern const struct format_loader libxmp_loader_xm;
 extern const struct format_loader libxmp_loader_it;
 extern const struct format_loader libxmp_loader_s3m;

--- a/src/loaders/umx_load.c
+++ b/src/loaders/umx_load.c
@@ -291,7 +291,7 @@ static int32 probe_header (void *header)
 	/* byte swap the header - all members are 32 bit LE values */
 	p = (unsigned char *) header;
 	swp = (uint32 *) header;
-	for (i = 0; i < (int)sizeof(struct upkg_hdr)/4; i++, p += 4) {
+	for (i = 0; i < UPKG_HDR_SIZE/4; i++, p += 4) {
 		swp[i] = p[0] | (p[1] << 8) | (p[2] << 16) | (p[3] << 24);
 	}
 
@@ -332,9 +332,9 @@ static int32 probe_header (void *header)
 
 static int process_upkg (HIO_HANDLE *f, int32 *ofs, int32 *objsize)
 {
-	char header[64];
+	char header[UPKG_HDR_SIZE];
 
-	if (hio_read(header, 1, 64, f) < 64)
+	if (hio_read(header, 1, UPKG_HDR_SIZE, f) < UPKG_HDR_SIZE)
 		return -1;
 	if (probe_header(header) < 0)
 		return -1;

--- a/src/loaders/umx_load.c
+++ b/src/loaders/umx_load.c
@@ -20,14 +20,8 @@
  * THE SOFTWARE.
  */
 
+#include <stddef.h> /* offsetof() */
 #include "loader.h"
-
-#define TEST_SIZE 1500
-
-#define MAGIC_UMX	MAGIC4(0xc1,0x83,0x2a,0x9e)
-#define MAGIC_IMPM	MAGIC4('I','M','P','M')
-#define MAGIC_SCRM	MAGIC4('S','C','R','M')
-#define MAGIC_M_K_	MAGIC4('M','.','K','.')
 
 extern const struct format_loader libxmp_loader_xm;
 extern const struct format_loader libxmp_loader_it;
@@ -43,97 +37,354 @@ const struct format_loader libxmp_loader_umx = {
 	umx_load
 };
 
-static int umx_test(HIO_HANDLE *f, char *t, const int start)
+/* UPKG parsing partially based on Unreal Media Ripper (UMR) v0.3
+ * by Andy Ward <wardwh@swbell.net>, with additional fixes & updates
+ * by O. Sezer - see git repo at https://github.com/sezero/umr.git
+ */
+typedef int32 fci_t;		/* FCompactIndex */
+
+#define UPKG_HDR_TAG		0x9e2a83c1
+
+struct _genhist {	/* for upkg versions >= 68 */
+	int32 export_count;
+	int32 name_count;
+};
+
+struct upkg_hdr {
+	uint32 tag;	/* UPKG_HDR_TAG */
+	int32 file_version;
+	uint32 pkg_flags;
+	int32 name_count;	/* number of names in name table (>= 0) */
+	int32 name_offset;		/* offset to name table  (>= 0) */
+	int32 export_count;	/* num. exports in export table  (>= 0) */
+	int32 export_offset;		/* offset to export table (>= 0) */
+	int32 import_count;	/* num. imports in export table  (>= 0) */
+	int32 import_offset;		/* offset to import table (>= 0) */
+
+	/* number of GUIDs in heritage table (>= 1) and table's offset:
+	 * only with versions < 68. */
+	int32 heritage_count;
+	int32 heritage_offset;
+	/* with versions >= 68:  a GUID, a dword for generation count
+	 * and export_count and name_count dwords for each generation: */
+	uint32 guid[4];
+	int32 generation_count;
+#define UPKG_HDR_SIZE 64			/* 64 bytes up until here */
+	struct _genhist *gen;
+};
+/* compile time assert for upkg_hdr size */
+typedef int _check_hdrsize[2 * (offsetof(struct upkg_hdr, gen) == UPKG_HDR_SIZE) - 1];
+
+#define UMUSIC_IT	0
+#define UMUSIC_S3M	1
+#define UMUSIC_XM	2
+#define UMUSIC_MOD	3
+#define UMUSIC_WAV	4
+#define UMUSIC_MP2	5
+
+static const char *mustype[] = {
+	"IT", "S3M", "XM", "MOD",
+	"WAV", "MP2", NULL
+};
+
+/* decode an FCompactIndex.
+ * original documentation by Tim Sweeney was at
+ * http://unreal.epicgames.com/Packages.htm
+ * also see Unreal Wiki:
+ * http://wiki.beyondunreal.com/Legacy:Package_File_Format/Data_Details
+ */
+static fci_t get_fci (const char *in, int *pos)
 {
-	int i, offset = -1;
-	uint8 buf[TEST_SIZE], *b = buf;
-	uint32 id;
+	int32 a;
+	int size;
 
-	if (hio_read(buf, 1, TEST_SIZE, f) < TEST_SIZE)
+	size = 1;
+	a = in[0] & 0x3f;
+
+	if (in[0] & 0x40) {
+		size++;
+		a |= (in[1] & 0x7f) << 6;
+
+		if (in[1] & 0x80) {
+			size++;
+			a |= (in[2] & 0x7f) << 13;
+
+			if (in[2] & 0x80) {
+				size++;
+				a |= (in[3] & 0x7f) << 20;
+
+				if (in[3] & 0x80) {
+					size++;
+					a |= (in[4] & 0x3f) << 27;
+				}
+			}
+		}
+	}
+
+	if (in[0] & 0x80)
+		a = -a;
+
+	*pos += size;
+
+	return a;
+}
+
+static int get_objtype (HIO_HANDLE *f, int32 ofs, int type)
+{
+	char sig[16];
+_retry:
+	hio_seek(f, ofs, SEEK_SET);
+	hio_read(sig, 16, 1, f);
+	if (type == UMUSIC_IT) {
+		if (memcmp(sig, "IMPM", 4) == 0)
+			return UMUSIC_IT;
 		return -1;
-;
-	id = readmem32b(b);
+	}
+	if (type == UMUSIC_XM) {
+		if (memcmp(sig, "Extended Module:", 16) != 0)
+			return -1;
+		hio_read(sig, 16, 1, f);
+		if (sig[0] != ' ') return -1;
+		hio_read(sig, 16, 1, f);
+		if (sig[5] != 0x1a) return -1;
+		return UMUSIC_XM;
+	}
+	if (type == UMUSIC_MP2) {
+		unsigned char *p = (unsigned char *)sig;
+		uint16 u = ((p[0] << 8) | p[1]) & 0xFFFE;
+		if (u == 0xFFFC || u == 0xFFF4)
+			return UMUSIC_MP2;
+		return -1;
+	}
+	if (type == UMUSIC_WAV) {
+		if (memcmp(sig, "RIFF", 4) == 0 && memcmp(&sig[8], "WAVE", 4) == 0)
+			return UMUSIC_WAV;
+		return -1;
+	}
 
-	if (id != MAGIC_UMX)
+	hio_seek(f, ofs + 44, SEEK_SET);
+	hio_read(sig, 4, 1, f);
+	if (type == UMUSIC_S3M) {
+		if (memcmp(sig, "SCRM", 4) == 0)
+			return UMUSIC_S3M;
+		/*return -1;*/
+		/* SpaceMarines.umx and Starseek.umx from Return to NaPali
+		 * report as "s3m" whereas the actual music format is "it" */
+		type = UMUSIC_IT;
+		goto _retry;
+	}
+
+	hio_seek(f, ofs + 1080, SEEK_SET);
+	hio_read(sig, 4, 1, f);
+	if (type == UMUSIC_MOD) {
+		if (memcmp(sig, "M.K.", 4) == 0 || memcmp(sig, "M!K!", 4) == 0)
+			return UMUSIC_MOD;
+		return -1;
+	}
+
+	return -1;
+}
+
+static int read_export (HIO_HANDLE *f, const struct upkg_hdr *hdr,
+			int32 *ofs, int32 *objsize)
+{
+	char buf[40];
+	int idx = 0, t;
+
+	hio_seek(f, *ofs, SEEK_SET);
+	if (hio_read(buf, 4, 10, f) < 10)
 		return -1;
 
-	for (i = 0; i < TEST_SIZE; i++, b++) {
-		id = readmem32b(b);
+	if (hdr->file_version < 40) idx += 8;	/* 00 00 00 00 00 00 00 00 */
+	if (hdr->file_version < 60) idx += 16;	/* 81 00 00 00 00 00 FF FF FF FF FF FF FF FF 00 00 */
+	get_fci(&buf[idx], &idx);		/* skip junk */
+	t = get_fci(&buf[idx], &idx);		/* type_name */
+	if (hdr->file_version > 61) idx += 4;	/* skip export size */
+	*objsize = get_fci(&buf[idx], &idx);
+	*ofs += idx;	/* offset for real data */
 
-		if (!memcmp(b, "Extended Module:", 16)) {
-			offset = i;
-			break;
+	return t;	/* return type_name index */
+}
+
+static int read_typname(HIO_HANDLE *f, const struct upkg_hdr *hdr,
+			int idx, char *out)
+{
+	int i, s;
+	long l;
+	char buf[64];
+
+	if (idx >= hdr->name_count) return -1;
+	buf[63] = '\0';
+	for (i = 0, l = 0; i <= idx; i++) {
+		hio_seek(f, hdr->name_offset + l, SEEK_SET);
+		hio_read(buf, 1, 63, f);
+		if (hdr->file_version >= 64) {
+			s = *(signed char *)buf; /* numchars *including* terminator */
+			if (s <= 0 || s > 64) return -1;
+			l += s + 5;	/* 1 for buf[0], 4 for int32 name_flags */
+		} else {
+			l += (long)strlen(buf);
+			l +=  5;	/* 1 for terminator, 4 for int32 name_flags */
 		}
-		if (id == MAGIC_IMPM) { 
-			offset = i;
-			break;
-		}
-		if (i > 44 && id == MAGIC_SCRM) { 
-			offset = i - 44;
-			break;
-		}
-		if (i > 1080 && id == MAGIC_M_K_) { 
-			offset = i - 1080;
+	}
+
+	strcpy(out, (hdr->file_version >= 64)? &buf[1] : buf);
+	return 0;
+}
+
+static int probe_umx   (HIO_HANDLE *f, const struct upkg_hdr *hdr,
+			int32 *ofs, int32 *objsize)
+{
+	int i, idx, t;
+	int32 s, pos;
+	long fsiz;
+	char buf[64];
+
+	idx = 0;
+	fsiz = hio_size(f);
+
+	/* Find the offset and size of the first IT, S3M or XM
+	 * by parsing the exports table. The umx files should
+	 * have only one export. Kran32.umx from Unreal has two,
+	 * but both pointing to the same music. */
+	if (hdr->export_offset >= fsiz) return -1;
+	memset(buf, 0, 64);
+	hio_seek(f, hdr->export_offset, SEEK_SET);
+	hio_read(buf, 1, 64, f);
+
+	get_fci(&buf[idx], &idx);	/* skip class_index */
+	get_fci(&buf[idx], &idx);	/* skip super_index */
+	if (hdr->file_version >= 60) idx += 4; /* skip int32 package_index */
+	get_fci(&buf[idx], &idx);	/* skip object_name */
+	idx += 4;			/* skip int32 object_flags */
+
+	s = get_fci(&buf[idx], &idx);	/* get serial_size */
+	if (s <= 0) return -1;
+	pos = get_fci(&buf[idx],&idx);	/* get serial_offset */
+	if (pos < 0 || pos > fsiz - 40) return -1;
+
+	if ((t = read_export(f, hdr, &pos, &s)) < 0) return -1;
+	if (s <= 0 || s > fsiz - pos) return -1;
+
+	if (read_typname(f, hdr, t, buf) < 0) return -1;
+	for (i = 0; mustype[i] != NULL; i++) {
+		if (!strcasecmp(buf, mustype[i])) {
+			t = i;
 			break;
 		}
 	}
-	
-	if (offset < 0)
+	if (mustype[i] == NULL) return -1;
+	if ((t = get_objtype(f, pos, t)) < 0) return -1;
+
+	*ofs = pos;
+	*objsize = s;
+	return t;
+}
+
+static int32 probe_header (void *header)
+{
+	struct upkg_hdr *hdr;
+	unsigned char *p;
+	uint32 *swp;
+	int i;
+
+	/* byte swap the header - all members are 32 bit LE values */
+	p = (unsigned char *) header;
+	swp = (uint32 *) header;
+	for (i = 0; i < (int)sizeof(struct upkg_hdr)/4; i++, p += 4) {
+		swp[i] = p[0] | (p[1] << 8) | (p[2] << 16) | (p[3] << 24);
+	}
+
+	hdr = (struct upkg_hdr *) header;
+	if (hdr->tag != UPKG_HDR_TAG) {
+		D_(D_INFO "UMX: Unknown header tag 0x%x\n", hdr->tag);
 		return -1;
+	}
+	if (hdr->name_count	< 0	||
+	    hdr->name_offset	< 0	||
+	    hdr->export_count	< 0	||
+	    hdr->export_offset	< 0	||
+	    hdr->import_count	< 0	||
+	    hdr->import_offset	< 0	) {
+		D_(D_INFO "UMX: Negative values in header\n");
+		return -1;
+	}
+
+	switch (hdr->file_version) {
+	case 35: case 37:	/* Unreal beta - */
+	case 40: case 41:				/* 1998 */
+	case 61:/* Unreal */
+	case 62:/* Unreal Tournament */
+	case 63:/* Return to NaPali */
+	case 64:/* Unreal Tournament */
+	case 66:/* Unreal Tournament */
+	case 68:/* Unreal Tournament */
+	case 69:/* Tactical Ops */
+	case 75:/* Harry Potter and the Philosopher's Stone */
+	case 76:			/* mpeg layer II data */
+	case 83:/* Mobile Forces */
+		return 0;
+	}
+
+	D_(D_INFO "UMX: Unknown upkg version %d\n", hdr->file_version);
+	return -1;
+}
+
+static int process_upkg (HIO_HANDLE *f, int32 *ofs, int32 *objsize)
+{
+	char header[64];
+
+	if (hio_read(header, 1, 64, f) < 64)
+		return -1;
+	if (probe_header(header) < 0)
+		return -1;
+
+	return probe_umx(f, (struct upkg_hdr *)header, ofs, objsize);
+}
+
+static int umx_test(HIO_HANDLE *f, char *t, const int start)
+{
+	int32 ofs, size;
+	int type;
+
+	type = process_upkg(f, &ofs, &size);
+	if (type < 0 || type > UMUSIC_MOD) {
+		return -1;
+	}
 
 	return 0;
 }
 
 static int umx_load(struct module_data *m, HIO_HANDLE *f, const int start)
 {
-	int i;
-	uint8 buf[TEST_SIZE], *b = buf;
-	uint32 id;
+	int32 ofs, size;
+	int type;
 
 	LOAD_INIT();
 
 	D_(D_INFO "Container type : Epic Games UMX");
 
-	hio_read(buf, 1, TEST_SIZE, f);
+	ofs = size = 0;
+	type = process_upkg(f, &ofs, &size);
+	hio_error(f); /* clear error */
 
-	for (i = 0; i < TEST_SIZE; i++, b++) {
-		id = readmem32b(b);
-
-		if (!memcmp(b, "Extended Module:", 16)) {
-			if (hio_seek(f, i, SEEK_SET) < 0) {
-				return -1;
-			}
-			return libxmp_loader_xm.loader(m, f, i);
-		}
-
-		if (id == MAGIC_IMPM) {
-			if (hio_seek(f, i, SEEK_SET) < 0) {
-				return -1;
-			}
-			return libxmp_loader_it.loader(m, f, i);
-		}
-
-		if (i > 44 && id == MAGIC_SCRM) {
-			i -= 44;
-			if (hio_seek(f, i, SEEK_SET) < 0) {
-				return -1;
-			}
-			return libxmp_loader_s3m.loader(m, f, i);
-		}
-
-		if (i > 1080 && id == MAGIC_M_K_) {
-			i -= 1080;
-			if (hio_seek(f, i, SEEK_SET) < 0) {
-				return -1;
-			}
-			return libxmp_loader_mod.loader(m, f, i);
-		}
+	if (type < 0) {
+		return -1;
 	}
-	
+
+	D_(D_INFO "UMX: %s data @ 0x%x, %d bytes\n", mustype[type], ofs, size);
+
+	hio_seek(f, ofs, SEEK_SET);
+	switch (type) {
+	case UMUSIC_IT:
+		return libxmp_loader_it.loader(m, f, ofs);
+	case UMUSIC_S3M:
+		return libxmp_loader_s3m.loader(m, f, ofs);
+	case UMUSIC_XM:
+		return libxmp_loader_xm.loader(m, f, ofs);
+	case UMUSIC_MOD:
+		return libxmp_loader_mod.loader(m, f, ofs);
+	}
+
 	return -1;
 }
-
-
-
-
-

--- a/src/loaders/umx_load.c
+++ b/src/loaders/umx_load.c
@@ -353,11 +353,32 @@ static int umx_test(HIO_HANDLE *f, char *t, const int start)
 	int type;
 
 	type = process_upkg(f, &ofs, &size);
-	if (type < 0 || type > UMUSIC_MOD) {
+	(void) hio_error(f);
+	if (type < 0) {
 		return -1;
 	}
 
-	return 0;
+	ofs += start; /** FIXME? **/
+	switch (type) {
+	case UMUSIC_IT:
+		hio_seek(f, ofs + 4, SEEK_SET);
+		libxmp_read_title(f, t, 26);
+		return 0;
+	case UMUSIC_S3M:
+		hio_seek(f, ofs, SEEK_SET);
+		libxmp_read_title(f, t, 28);
+		return 0;
+	case UMUSIC_XM:
+		hio_seek(f, ofs + 17, SEEK_SET);
+		libxmp_read_title(f, t, 20);
+		return 0;
+	case UMUSIC_MOD:
+		hio_seek(f, ofs, SEEK_SET);
+		libxmp_read_title(f, t, 20);
+		return 0;
+	}
+
+	return -1;
 }
 
 static int umx_load(struct module_data *m, HIO_HANDLE *f, const int start)
@@ -369,16 +390,15 @@ static int umx_load(struct module_data *m, HIO_HANDLE *f, const int start)
 
 	D_(D_INFO "Container type : Epic Games UMX");
 
-	ofs = size = 0;
 	type = process_upkg(f, &ofs, &size);
-	hio_error(f); /* clear error */
-
+	(void) hio_error(f);
 	if (type < 0) {
 		return -1;
 	}
 
 	D_(D_INFO "UMX: %s data @ 0x%x, %d bytes\n", mustype[type], ofs, size);
 
+	ofs += start; /** FIXME? **/
 	hio_seek(f, ofs, SEEK_SET);
 	switch (type) {
 	case UMUSIC_IT:


### PR DESCRIPTION
... instead of linear search.

Similar versions are in libmikmod and libmodplug. For the
upkg parser code, see:  https://github.com/sezero/umr.git
