### PR TITLE
Remove Non-ASCII Character Clobbering

### DIFF
--- a/src/loaders/it_load.c
+++ b/src/loaders/it_load.c
@@ -1364,9 +1364,6 @@ static int it_load(struct module_data *m, HIO_HANDLE *f, const int start)
 				int b = hio_read8(f);
 				if (b == '\r') {
 					b = '\n';
-				} else if ((b < 32 || b > 127) && b != '\n'
-					   && b != '\t') {
-					b = '.';
 				}
 				m->comment[j] = b;
 			}


### PR DESCRIPTION
IT.TXT even explicitly mentions the ability to use characters that libxmp currently converts to periods for some reason:

    3) A couple of people have asked about ASCII characters > 128. I'm
       sorry - I can't let you have 'em on anywhere else except the message
       editor.

Furthermore, this comment only pertains to the interface of IT.EXE and not the IT spec.  In other words, instrument names and other strings should not care about character encodings (but I will leave those fixes for other pull requests).