### PR TITLE
mkstemp: don't use pid_t for windows builds.

### DIFF
--- a/src/mkstemp.c
+++ b/src/mkstemp.c
@@ -46,7 +46,6 @@
 #include <process.h>
 #define getpid _getpid
 #define open _open
-typedef int pid_t;
 #endif
 
 #ifndef O_BINARY
@@ -56,7 +55,11 @@ typedef int pid_t;
 int mkstemp(char *template)
 {
 	int start, i;
+#ifdef _WIN32
+	int   val;
+#else
 	pid_t val;
+#endif
 
 	val = getpid();
 	start = strlen(template) - 1;


### PR DESCRIPTION
for whatever reason, mingw-w64 defines pid_t as __int64 for WIN64,
but getpid() always returns int.