### PR TITLE
Use _spawnl() for unit tests on Windows, add unit test Makefile.vc.in.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ test-dev/libxmp-covertest
 test-dev/libxmp-test
 
 # VC++ files
+/.vs
+/.vscode
+*.exp
+*.lib
 *.suo
 *.ncb
 

--- a/test-dev/Makefile.in
+++ b/test-dev/Makefile.in
@@ -596,6 +596,11 @@ dist-test:
 clean:
 	rm -f *.o core *~ $(T_OBJS)
 
+vc-prepare:
+	@echo Generate Makefile.vc
+	@sed -e 's!@SRCS@!$(subst /,\\,$(T_OBJS:.o=.c))!' \
+	     Makefile.vc.in > Makefile.vc
+
 #
 # Utilities
 #

--- a/test-dev/Makefile.vc.in
+++ b/test-dev/Makefile.vc.in
@@ -1,0 +1,26 @@
+CC	= cl
+CFLAGS	= /O2 /W3 /I..\include /I..\src /I..\src\win32 /DWIN32 \
+	  /Dinline=__inline /DPATH_MAX=1024 /D_USE_MATH_DEFINES /D_CRT_SECURE_NO_WARNINGS
+LDFLAGS = /RELEASE /OUT:$(EXE)
+EXE	= libxmp-tests.exe
+
+SOURCES	= @SRCS@
+ALL_SOURCES	= $(SOURCES)
+
+all: $(EXE)
+	$(EXE)
+
+$(EXE): $(ALL_SOURCES) all_tests.c
+	copy ..\libxmp.lib .
+	copy ..\libxmp.dll .
+	$(CC) /MP /nologo $(CFLAGS) $(ALL_SOURCES) /link $(LDFLAGS) libxmp.lib
+
+# FIXME no convincing way to do this here right now.
+all_tests.c: Makefile
+	@make all_tests.c
+
+clean:
+	del libxmp.lib
+	del libxmp.dll
+	del *.obj
+	del $(EXE)

--- a/test-dev/main.c
+++ b/test-dev/main.c
@@ -7,6 +7,7 @@
 #include <sys/wait.h>
 #endif
 #include <unistd.h>
+#include <stdio.h>
 #include "test.h"
 #include "../src/list.h"
 
@@ -120,7 +121,7 @@ int run_test(int num)
 				return 0;
 			}
 		}
-		
+
 		i++;
 	}
 
@@ -155,11 +156,20 @@ int main(int argc, char **argv)
 	}
 
 	for (i = 0; i < num_tests; i++) {
-		snprintf(cmd, 512, "%s %d", argv[0], i);
+#ifdef WIN32
+		snprintf(cmd, sizeof(cmd), "%d", i);
+		if (_spawnl(_P_WAIT, argv[0], argv[0], cmd, NULL)) {
+			fail++;
+		}
+		total++;
+#else
+		/* In the off chance something that isn't Windows needs the non-fork test... */
+		snprintf(cmd, sizeof(cmd), "%s %d", argv[0], i);
 		if (system(cmd) != 0) {
 			fail++;
 		}
 		total++;
+#endif /* !WIN32 */
 	}
 
 	printf("total:%d  passed:%d (%4.1f%%)  failed:%d (%4.1f%%)\n",

--- a/test-dev/main.c
+++ b/test-dev/main.c
@@ -1,6 +1,9 @@
-#ifndef WIN32
+#ifdef WIN32
+#include <process.h> /* _spawnl, _P_WAIT */
+#else
 #define FORK_TEST
 #endif
+
 
 #ifdef FORK_TEST
 #include <sys/types.h>
@@ -42,6 +45,8 @@ void _add_test(char *name, int (*func)(void))
 	num_tests++;
 }
 
+#ifdef FORK_TEST
+
 void init_colors()
 {
 	if (isatty(STDOUT_FILENO)) {
@@ -51,8 +56,6 @@ void init_colors()
 		color_none = "\x1b[0m";
 	}
 }
-
-#ifdef FORK_TEST
 
 int run_tests()
 {


### PR DESCRIPTION
This reduces the time it takes to run libxmp-tests.exe in my local MSYS2 setup from ~15 seconds to about 7 seconds. Considering how much I have been running the tests locally, this is a huge improvement. Presumably this will also be useful for adapting the tests to Visual Studio (#222). Thanks to Lionel Debroux for bringing the _spawn* family of functions to my attention. :)

(Suggestions for improving this are definitely welcome. The _spawn* functions apparently have existed since ~1993 and should be fairly portable.)