### PR TITLE
remove support for size <= 0:

### DIFF
--- a/docs/libxmp.rst
+++ b/docs/libxmp.rst
@@ -312,9 +312,7 @@ int xmp_test_module_from_memory(const void \*mem, long size, struct xmp_test_inf
     :mem: a pointer to the module file image in memory. Multi-file modules
       or compressed modules can't be tested in memory.
 
-    :size: the size of the module, or 0 if the size is unknown or not
-      specified. If size is set to 0 certain module formats won't be
-      recognized.
+    :size: the size of the module.
 
     :test_info: NULL, or a pointer to a structure used to retrieve the
       module title and format if the memory buffer is a valid module.
@@ -397,10 +395,7 @@ int xmp_load_module_from_memory(xmp_context c, const void \*mem, long size)
     :mem: a pointer to the module file image in memory. Multi-file modules
       or compressed modules can't be loaded from memory.
 
-    :size: the size of the module, or 0 if the size is unknown or not
-      specified. If size is set to 0 certain module formats won't be
-      recognized, the MD5 digest will not be set, and module-specific
-      quirks won't be applied.
+    :size: the size of the module.
 
   **Returns:**
     0 if successful, or a negative error code in case of error.
@@ -423,10 +418,7 @@ int xmp_load_module_from_file(xmp_context c, FILE \*f, long size)
     :f: the file stream. On return, the stream position is undefined.
       Caller is responsible for closing the file stream.
 
-    :size: the size of the module, or 0 if the size is unknown or not
-      specified. If size is set to 0 certain module formats won't be
-      recognized, the MD5 digest will not be set, and module-specific
-      quirks won't be applied.
+    :size: the size of the module (ignored.)
 
   **Returns:**
     0 if successful, or a negative error code in case of error.

--- a/src/hio.c
+++ b/src/hio.c
@@ -346,10 +346,11 @@ HIO_HANDLE *hio_open_mem(const void *ptr, long size)
 {
 	HIO_HANDLE *h;
 
+	if (size <= 0) return NULL;
 	h = (HIO_HANDLE *)calloc(1, sizeof (HIO_HANDLE));
 	if (h == NULL)
 		return NULL;
-	
+
 	h->type = HIO_HANDLE_TYPE_MEMORY;
 	h->handle.mem = mopen(ptr, size);
 	h->size = size;
@@ -364,7 +365,7 @@ HIO_HANDLE *hio_open_file(FILE *f)
 	h = (HIO_HANDLE *)calloc(1, sizeof (HIO_HANDLE));
 	if (h == NULL)
 		return NULL;
-	
+
 	h->noclose = 1;
 	h->type = HIO_HANDLE_TYPE_FILE;
 	h->handle.file = f;

--- a/src/load.c
+++ b/src/load.c
@@ -250,11 +250,6 @@ static void set_md5sum(HIO_HANDLE *f, unsigned char *digest)
 	MD5_CTX ctx;
 	int bytes_read;
 
-	if (hio_size(f) <= 0) {
-		memset(digest, 0, 16);
-		return;
-	}
-
 	hio_seek(f, 0, SEEK_SET);
 
 	MD5Init(&ctx);
@@ -386,9 +381,9 @@ int xmp_test_module_from_memory(const void *mem, long size, struct xmp_test_info
 	HIO_HANDLE *h;
 	int ret;
 
-	/* Use size < 0 for unknown/undetermined size */
-	if (size == 0)
-		size--;
+	if (size <= 0) {
+		return -XMP_ERROR_INVALID;
+	}
 
 	if ((h = hio_open_mem(mem, size)) == NULL)
 		return -XMP_ERROR_SYSTEM;
@@ -632,9 +627,9 @@ int xmp_load_module_from_memory(xmp_context opaque, const void *mem, long size)
 	HIO_HANDLE *h;
 	int ret;
 
-	/* Use size < 0 for unknown/undetermined size */
-	if (size == 0)
-		size--;
+	if (size <= 0) {
+		return -XMP_ERROR_INVALID;
+	}
 
 	if ((h = hio_open_mem(mem, size)) == NULL)
 		return -XMP_ERROR_SYSTEM;

--- a/src/loaders/sample.c
+++ b/src/loaders/sample.c
@@ -234,12 +234,12 @@ int libxmp_load_sample(struct module_data *m, HIO_HANDLE *f, int flags, struct x
 		}
 		file_pos = hio_tell(f);
 		file_len = hio_size(f);
-		if (file_len >= 0 && file_pos >= file_len) {
+		if (file_pos >= file_len) {
 			D_(D_WARN "ignoring sample at EOF");
 			return 0;
 		}
 		/* If this sample goes past EOF, truncate it. */
-		if (file_len >= 0 && file_pos + xxs->len > file_len && (~flags & SAMPLE_FLAG_ADPCM)) {
+		if (file_pos + xxs->len > file_len && (~flags & SAMPLE_FLAG_ADPCM)) {
 			D_(D_WARN "sample would extend %ld bytes past EOF; truncating to %ld",
 				file_pos + xxs->len - file_len, file_len - file_pos);
 			xxs->len = file_len - file_pos;

--- a/src/memio.c
+++ b/src/memio.c
@@ -32,10 +32,7 @@
 
 static inline ptrdiff_t CAN_READ(MFILE *m)
 {
-	if (m->size >= 0)
-		return m->pos >= 0 ? m->size - m->pos : 0;
-
-	return INT_MAX;
+	return m->pos >= 0 ? m->size - m->pos : 0;
 }
 
 
@@ -43,25 +40,24 @@ int mgetc(MFILE *m)
 {
 	if (CAN_READ(m) >= 1)
 		return *(uint8 *)(m->start + m->pos++);
-	else
-		return EOF;
+	return EOF;
 }
 
 size_t mread(void *buf, size_t size, size_t num, MFILE *m)
 {
- 	size_t should_read = size * num;
- 	ptrdiff_t can_read = CAN_READ(m);
+	size_t should_read = size * num;
+	ptrdiff_t can_read = CAN_READ(m);
 
- 	if (!size || !num || can_read <= 0) {
- 		return 0;
+	if (!size || !num || can_read <= 0) {
+		return 0;
 	}
 
 	if (should_read > can_read) {
- 		should_read = can_read;
+		should_read = can_read;
 	}
 
 	memcpy(buf, m->start + m->pos, should_read);
- 	m->pos += should_read;
+	m->pos += should_read;
 
 	return should_read / size;
 }
@@ -78,18 +74,14 @@ int mseek(MFILE *m, long offset, int whence)
 		ofs += m->pos;
 		break;
 	case SEEK_END:
-		if (m->size < 0)
-			return -1;
 		ofs += m->size;
 		break;
 	default:
 		return -1;
 	}
-	if (m->size >= 0) {
-		if (ofs < 0) return -1;
-		if (ofs > m->size)
-			ofs = m->size;
-	}
+	if (ofs < 0) return -1;
+	if (ofs > m->size)
+		ofs = m->size;
 	m->pos = ofs;
 	return 0;
 }
@@ -101,10 +93,7 @@ long mtell(MFILE *m)
 
 int meof(MFILE *m)
 {
-	if (m->size <= 0)
-		return 0;
-	else
-		return CAN_READ(m) <= 0;
+	return CAN_READ(m) <= 0;
 }
 
 MFILE *mopen(const void *ptr, long size)
@@ -114,7 +103,7 @@ MFILE *mopen(const void *ptr, long size)
 	m = (MFILE *)malloc(sizeof (MFILE));
 	if (m == NULL)
 		return NULL;
-	
+
 	m->start = ptr;
 	m->pos = 0;
 	m->size = size;

--- a/test-dev/test_read_mem_hio_nosize.c
+++ b/test-dev/test_read_mem_hio_nosize.c
@@ -5,70 +5,13 @@
 
 TEST(test_read_mem_hio_nosize)
 {
-	uint8 mem[100], mem2[100];
-	int i;
-	unsigned int x;
 	HIO_HANDLE *h;
+	char mem;
 
-	for (i = 0; i < 100; i++)
-		mem[i] = i;
+	h = hio_open_mem(&mem, -1);
+	fail_unless(h == NULL, "hio_open");
 
-	h = hio_open_mem(mem, -1);
-	fail_unless(h != NULL, "hio_open");
-
-	x = hio_size(h);
-	fail_unless(x == -1, "hio_size");
-
-	x = hio_read8(h);
-	fail_unless(x == 0x00, "hio_read8");
-
-	x = hio_read8s(h);
-	fail_unless(x == 0x01, "hio_read8s");
-
-	x = hio_read16l(h);
-	fail_unless(x == 0x0302, "hio_read16l");
-
-	x = hio_read16b(h);
-	fail_unless(x == 0x0405, "hio_read16b");
-
-	x = hio_read24l(h);
-	fail_unless(x == 0x080706, "hio_read24l");
-
-	x = hio_read24b(h);
-	fail_unless(x == 0x090a0b, "hio_read24b");
-
-	x = hio_read32l(h);
-	fail_unless(x == 0x0f0e0d0c, "hio_read32l");
-
-	x = hio_read32b(h);
-	fail_unless(x == 0x10111213, "hio_read32b");
-
-	x = hio_tell(h);
-	fail_unless(x == 0x14, "hio_fseek");
-
-	x = hio_seek(h, 2, SEEK_SET);
-	fail_unless(x == 0, "hio_fseek SEEK_SET");
-
-	x = hio_read32b(h);
-	fail_unless(x == 0x02030405, "hio_read32b");
-
-	x = hio_seek(h, 3, SEEK_CUR);
-	fail_unless(x == 0, "hio_fseek SEEK_CUR");
-
-	x = hio_read(mem2, 1, 50, h);
-	for (i = 0; i < 50; i++)
-		fail_unless(mem2[i] == i + 9, "hio_read");
-
-	x = hio_seek(h, 0, SEEK_END);
-	fail_unless(x == -1, "hio_fseek SEEK_END");
-
-	x = hio_read8(h);
-	fail_unless(x == 59, "hio_read8");
-
-	x = hio_eof(h);
-	fail_unless(x == 0, "hio_eof");
-
-	x = hio_close(h);
-	fail_unless(x == 0, "hio_close");
+	h = hio_open_mem(&mem, 0);
+	fail_unless(h == NULL, "hio_open");
 }
 END_TEST


### PR DESCRIPTION
- return -XMP_ERROR_INVALID from xmp_load_module_from_memory() and
  xmp_test_module_from_memory() if size <= 0, remove all mention of
  size <= 0 from their documentation.
- remove non-positive sizes support from memio.c. whitespace tidy-ups.
- remove hio_size() <= 0 check from load.c::set_md5sum()
- remove file_len >= 0 checks from sample.c::libxmp_load_sample()
- document that the size parameter to xmp_load_module_from_file() is
  actually ignored. (don't know whether it had ever mattered..)
- change test_read_mem_hio_nosize so its tests always fail

Fixes: https://github.com/libxmp/libxmp/issues/325

Notes: hio.c::hio_open_file() doesn't fail if get_size() returns
negative: needs further check / handling.