### PR TITLE
Remove unused includes

### DIFF
--- a/lite/src/format.c
+++ b/lite/src/format.c
@@ -20,11 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdlib.h>
-#include <string.h>
-#ifndef LIBXMP_CORE_PLAYER
-#include "loaders/prowizard/prowiz.h"
-#endif
 #include "format.h"
 
 extern const struct format_loader libxmp_loader_xm;

--- a/src/common.h
+++ b/src/common.h
@@ -2,6 +2,7 @@
 #define LIBXMP_COMMON_H
 
 #include <stdarg.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include "xmp.h"

--- a/src/control.c
+++ b/src/control.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdlib.h>
 #include <ctype.h>
 
 #include "format.h"

--- a/src/control.c
+++ b/src/control.c
@@ -20,11 +20,8 @@
  * THE SOFTWARE.
  */
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <ctype.h>
-#include <stdarg.h>
 
 #include "format.h"
 #include "virtual.h"

--- a/src/control.c
+++ b/src/control.c
@@ -20,8 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <ctype.h>
-
 #include "format.h"
 #include "virtual.h"
 #include "mixer.h"

--- a/src/depacker.h
+++ b/src/depacker.h
@@ -1,7 +1,7 @@
 #ifndef XMP_DEPACKER_H
 #define XMP_DEPACKER_H
 
-#include <stdio.h>
+#include "common.h"
 
 extern struct depacker libxmp_depacker_zip;
 extern struct depacker libxmp_depacker_lha;

--- a/src/depackers/arcfs.c
+++ b/src/depackers/arcfs.c
@@ -9,8 +9,6 @@
  * for more information.
  */
 
-#include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <time.h>

--- a/src/depackers/arcfs.c
+++ b/src/depackers/arcfs.c
@@ -9,10 +9,6 @@
  * for more information.
  */
 
-#include <errno.h>
-#include <time.h>
-#include <sys/types.h>
-#include <unistd.h>
 #include "common.h"
 #include "depacker.h"
 #include "readlzw.h"

--- a/src/depackers/arcfs.c
+++ b/src/depackers/arcfs.c
@@ -9,7 +9,6 @@
  * for more information.
  */
 
-#include <stdlib.h>
 #include <errno.h>
 #include <time.h>
 #include <sys/types.h>

--- a/src/depackers/bunzip2.c
+++ b/src/depackers/bunzip2.c
@@ -34,9 +34,7 @@
  */
 
 #include <setjmp.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <unistd.h>
 #include <limits.h>
 #include "common.h"

--- a/src/depackers/bunzip2.c
+++ b/src/depackers/bunzip2.c
@@ -34,7 +34,6 @@
  */
 
 #include <setjmp.h>
-#include <unistd.h>
 #include <limits.h>
 #include "common.h"
 #include "depacker.h"

--- a/src/depackers/bunzip2.c
+++ b/src/depackers/bunzip2.c
@@ -34,7 +34,6 @@
  */
 
 #include <setjmp.h>
-#include <stdlib.h>
 #include <unistd.h>
 #include <limits.h>
 #include "common.h"

--- a/src/depackers/gunzip.c
+++ b/src/depackers/gunzip.c
@@ -6,7 +6,6 @@
  * for more information.
  */
 
-#include <stdio.h>
 #include "common.h"
 #include "inflate.h"
 #include "depacker.h"

--- a/src/depackers/inflate.c
+++ b/src/depackers/inflate.c
@@ -1,6 +1,4 @@
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include "common.h"
 #include "inflate.h"

--- a/src/depackers/inflate.c
+++ b/src/depackers/inflate.c
@@ -1,5 +1,3 @@
-#include <stdlib.h>
-
 #include "common.h"
 #include "inflate.h"
 #include "crc32.h"

--- a/src/depackers/mmcmp.c
+++ b/src/depackers/mmcmp.c
@@ -23,7 +23,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdlib.h>
 #include <unistd.h>
 #include "common.h"
 #include "depacker.h"

--- a/src/depackers/mmcmp.c
+++ b/src/depackers/mmcmp.c
@@ -23,7 +23,6 @@
  * THE SOFTWARE.
  */
 
-#include <unistd.h>
 #include "common.h"
 #include "depacker.h"
 

--- a/src/depackers/mmcmp.c
+++ b/src/depackers/mmcmp.c
@@ -25,7 +25,6 @@
 
 #include <stdlib.h>
 #include <unistd.h>
-#include <string.h>
 #include "common.h"
 #include "depacker.h"
 

--- a/src/depackers/muse.c
+++ b/src/depackers/muse.c
@@ -6,7 +6,6 @@
  * for more information.
  */
 
-#include <stdio.h>
 #include <stdlib.h>
 #include "common.h"
 #include "depacker.h"

--- a/src/depackers/muse.c
+++ b/src/depackers/muse.c
@@ -6,7 +6,6 @@
  * for more information.
  */
 
-#include <stdlib.h>
 #include "common.h"
 #include "depacker.h"
 #include "inflate.h"

--- a/src/depackers/oxm.c
+++ b/src/depackers/oxm.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdlib.h>
 #include "vorbis.h"
 #include "common.h"
 #include "depacker.h"

--- a/src/depackers/oxm.c
+++ b/src/depackers/oxm.c
@@ -20,9 +20,7 @@
  * THE SOFTWARE.
  */
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include "vorbis.h"
 #include "common.h"
 #include "depacker.h"

--- a/src/depackers/ppdepack.c
+++ b/src/depackers/ppdepack.c
@@ -18,8 +18,6 @@
  */
  
 #include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/depackers/ppdepack.c
+++ b/src/depackers/ppdepack.c
@@ -16,8 +16,7 @@
  * Modified for xmp by Claudio Matsuoka, 05/2013
  * - decryption code removed
  */
- 
-#include <stdlib.h>
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/depackers/ppdepack.c
+++ b/src/depackers/ppdepack.c
@@ -17,9 +17,7 @@
  * - decryption code removed
  */
 
-#include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include "common.h"
 #include "depacker.h"
 

--- a/src/depackers/readhuff.c
+++ b/src/depackers/readhuff.c
@@ -10,7 +10,6 @@
  * a bit unusual. So this is from scratch (though it wasn't too hard).
  */
 
-#include <stdlib.h>
 #include "common.h"
 #include "readhuff.h"
 #include "readrle.h"	/* for struct data_in_out */

--- a/src/depackers/readhuff.c
+++ b/src/depackers/readhuff.c
@@ -10,8 +10,8 @@
  * a bit unusual. So this is from scratch (though it wasn't too hard).
  */
 
-#include <stdio.h>
 #include <stdlib.h>
+#include "common.h"
 #include "readhuff.h"
 #include "readrle.h"	/* for struct data_in_out */
 

--- a/src/depackers/readlzw.c
+++ b/src/depackers/readlzw.c
@@ -16,7 +16,6 @@
  */
 
 #include <unistd.h>
-#include <stdlib.h>
 #include "readrle.h"
 
 #include "common.h"

--- a/src/depackers/readlzw.c
+++ b/src/depackers/readlzw.c
@@ -15,8 +15,6 @@
  * wall therapy. %-(
  */
 
-#include <stdio.h>
-#include <string.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include "readrle.h"

--- a/src/depackers/readlzw.c
+++ b/src/depackers/readlzw.c
@@ -15,7 +15,6 @@
  * wall therapy. %-(
  */
 
-#include <unistd.h>
 #include "readrle.h"
 
 #include "common.h"

--- a/src/depackers/readrle.c
+++ b/src/depackers/readrle.c
@@ -7,8 +7,6 @@
  * to use.
  */
 
-#include <unistd.h>
-
 #include "common.h"
 #include "readrle.h"
 

--- a/src/depackers/readrle.c
+++ b/src/depackers/readrle.c
@@ -8,7 +8,6 @@
  */
 
 #include <unistd.h>
-#include <stdlib.h>
 
 #include "common.h"
 #include "readrle.h"

--- a/src/depackers/readrle.c
+++ b/src/depackers/readrle.c
@@ -7,11 +7,10 @@
  * to use.
  */
 
-#include <stdio.h>
-#include <string.h>
 #include <unistd.h>
 #include <stdlib.h>
 
+#include "common.h"
 #include "readrle.h"
 
 

--- a/src/depackers/s404_dec.c
+++ b/src/depackers/s404_dec.c
@@ -12,7 +12,6 @@
    (couldn't keep stdint types, some platforms we build on didn't like them)
 */
 
-#include <stdlib.h>
 #include <assert.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/depackers/s404_dec.c
+++ b/src/depackers/s404_dec.c
@@ -12,9 +12,7 @@
    (couldn't keep stdint types, some platforms we build on didn't like them)
 */
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <assert.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/depackers/s404_dec.c
+++ b/src/depackers/s404_dec.c
@@ -12,8 +12,7 @@
    (couldn't keep stdint types, some platforms we build on didn't like them)
 */
 
-#include <assert.h>
-#include <sys/types.h>
+/* #include <assert.h> */
 #include <sys/stat.h>
 #include "common.h"
 #include "depacker.h"

--- a/src/depackers/unarc.c
+++ b/src/depackers/unarc.c
@@ -23,7 +23,6 @@
 
 #define NOMARCH_VER	"1.4"
 
-#include <stdlib.h>
 #include <ctype.h>
 #include "common.h"
 #include "depacker.h"

--- a/src/depackers/unarc.c
+++ b/src/depackers/unarc.c
@@ -23,8 +23,6 @@
 
 #define NOMARCH_VER	"1.4"
 
-#include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include "common.h"

--- a/src/depackers/uncompress.c
+++ b/src/depackers/uncompress.c
@@ -1,7 +1,5 @@
 /* public domain decompress code */
 
-#include <stdio.h>
-#include <string.h>
 #include "depacker.h"
 
 #define	MAGIC_1		31	/* First byte of compressed file */

--- a/src/depackers/unlha.c
+++ b/src/depackers/unlha.c
@@ -23,7 +23,6 @@
     Modified for xmp by Claudio Matsuoka, 20120812
  */
 
-#include <stdlib.h>
 #include "common.h"
 #include "depacker.h"
 

--- a/src/depackers/unlha.c
+++ b/src/depackers/unlha.c
@@ -24,7 +24,6 @@
  */
 
 #include <stdlib.h>
-#include <string.h>
 #include "common.h"
 #include "depacker.h"
 

--- a/src/depackers/unlzx.c
+++ b/src/depackers/unlzx.c
@@ -23,7 +23,6 @@
     Modified for xmp by Claudio Matsuoka, 2014-01-04
 */
 
-#include <stdlib.h>
 #include "common.h"
 #include "depacker.h"
 #include "crc32.h"

--- a/src/depackers/unlzx.c
+++ b/src/depackers/unlzx.c
@@ -23,9 +23,7 @@
     Modified for xmp by Claudio Matsuoka, 2014-01-04
 */
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include "common.h"
 #include "depacker.h"
 #include "crc32.h"

--- a/src/depackers/unsqsh.c
+++ b/src/depackers/unsqsh.c
@@ -25,7 +25,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdlib.h>
 #include "common.h"
 #include "depacker.h"
 

--- a/src/depackers/unsqsh.c
+++ b/src/depackers/unsqsh.c
@@ -25,9 +25,7 @@
  * THE SOFTWARE.
  */
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include "common.h"
 #include "depacker.h"
 

--- a/src/depackers/unxz.c
+++ b/src/depackers/unxz.c
@@ -6,9 +6,7 @@
  * for more information.
  */
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include "depacker.h"
 #include "xz.h"
 #include "crc32.h"

--- a/src/depackers/unxz.c
+++ b/src/depackers/unxz.c
@@ -6,7 +6,6 @@
  * for more information.
  */
 
-#include <stdlib.h>
 #include "depacker.h"
 #include "xz.h"
 #include "crc32.h"

--- a/src/depackers/unzip.c
+++ b/src/depackers/unzip.c
@@ -11,10 +11,6 @@ me and we can work something out.
 Michael Kohn <mike@mikekohn.net>
 
 */
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <time.h>
-#include <unistd.h>
 #include "common.h"
 #include "depacker.h"
 #include "inflate.h"

--- a/src/depackers/unzip.c
+++ b/src/depackers/unzip.c
@@ -11,9 +11,7 @@ me and we can work something out.
 Michael Kohn <mike@mikekohn.net>
 
 */
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <time.h>

--- a/src/depackers/unzip.c
+++ b/src/depackers/unzip.c
@@ -11,7 +11,6 @@ me and we can work something out.
 Michael Kohn <mike@mikekohn.net>
 
 */
-#include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <time.h>

--- a/src/depackers/unzoo.c
+++ b/src/depackers/unzoo.c
@@ -30,7 +30,6 @@ code.  The contents of this file are hereby released to the public domain.
                                  -- Rahul Dhesi 1986/11/14
 */
 
-#include <stdlib.h>
 #include "common.h"
 
 #define  STACKSIZE	4000
@@ -337,7 +336,6 @@ static int lzd(BLOCKFILE input_f, BLOCKFILE output_f, uint32 *crc_table)
 **
 *****************************************************************************/
 
-#include <stdlib.h>
 #include "common.h"
 
 struct description {

--- a/src/depackers/unzoo.c
+++ b/src/depackers/unzoo.c
@@ -30,7 +30,6 @@ code.  The contents of this file are hereby released to the public domain.
                                  -- Rahul Dhesi 1986/11/14
 */
 
-#include <stdio.h>
 #include <stdlib.h>
 #include "common.h"
 
@@ -338,9 +337,7 @@ static int lzd(BLOCKFILE input_f, BLOCKFILE output_f, uint32 *crc_table)
 **
 *****************************************************************************/
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include "common.h"
 
 struct description {

--- a/src/depackers/xfd.c
+++ b/src/depackers/xfd.c
@@ -15,7 +15,6 @@
 #include <proto/exec.h>
 #include <proto/xfdmaster.h>
 #include <exec/types.h>
-#include <stdio.h>
 #include <sys/stat.h>
 #include "common.h"
 #include "depacker.h"

--- a/src/depackers/xz_config.h
+++ b/src/depackers/xz_config.h
@@ -21,7 +21,9 @@
 #define XZ_DEC_ANY_CHECK 1
 
 #include <stdlib.h>
+/*
 #include <string.h>
+*/
 
 #include "xz.h"
 

--- a/src/depackers/xz_config.h
+++ b/src/depackers/xz_config.h
@@ -20,8 +20,8 @@
 
 #define XZ_DEC_ANY_CHECK 1
 
-#include <stdlib.h>
 /*
+#include <stdlib.h>
 #include <string.h>
 */
 

--- a/src/extras.c
+++ b/src/extras.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdlib.h>
 #include "common.h"
 #include "player.h"
 #include "extras.h"

--- a/src/format.c
+++ b/src/format.c
@@ -21,7 +21,6 @@
  */
 
 #include <stdlib.h>
-#include <string.h>
 #include "format.h"
 
 #ifndef LIBXMP_NO_PROWIZARD

--- a/src/format.c
+++ b/src/format.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdlib.h>
 #include "format.h"
 
 #ifndef LIBXMP_NO_PROWIZARD

--- a/src/format.h
+++ b/src/format.h
@@ -1,7 +1,6 @@
 #ifndef LIBXMP_FORMAT_H
 #define LIBXMP_FORMAT_H
 
-#include <stdio.h>
 #include "common.h"
 #include "hio.h"
 

--- a/src/hio.c
+++ b/src/hio.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <limits.h>
 #include <errno.h>
 #include "common.h"
 #include "hio.h"

--- a/src/hio.c
+++ b/src/hio.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <limits.h>
 #include <errno.h>

--- a/src/hio.c
+++ b/src/hio.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdlib.h>
 #include <limits.h>
 #include <errno.h>
 #include "common.h"

--- a/src/hio.h
+++ b/src/hio.h
@@ -1,9 +1,6 @@
 #ifndef XMP_HIO_H
 #define XMP_HIO_H
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <stddef.h>
 #include "memio.h"
 
 #define HIO_HANDLE_TYPE(x) ((x)->type)

--- a/src/hmn_extras.c
+++ b/src/hmn_extras.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdlib.h>
 #include "common.h"
 #include "player.h"
 #include "virtual.h"

--- a/src/lfo.c
+++ b/src/lfo.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdlib.h>
 #include "lfo.h"
 
 #define WAVEFORM_SIZE 64

--- a/src/load.c
+++ b/src/load.c
@@ -21,7 +21,6 @@
  */
 
 #include <stddef.h>
-#include <stdlib.h>
 #include <ctype.h>
 #include <errno.h>
 #ifdef __native_client__

--- a/src/load.c
+++ b/src/load.c
@@ -20,14 +20,8 @@
  * THE SOFTWARE.
  */
 
-#include <stddef.h>
-#include <ctype.h>
+#include <sys/stat.h>
 #include <errno.h>
-#ifdef __native_client__
-#include <sys/syslimits.h>
-#else
-#include <limits.h>
-#endif
 
 #include "format.h"
 #include "list.h"

--- a/src/load.c
+++ b/src/load.c
@@ -21,9 +21,7 @@
  */
 
 #include <stddef.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <ctype.h>
 #include <errno.h>
 #ifdef __native_client__

--- a/src/load_helpers.c
+++ b/src/load_helpers.c
@@ -21,7 +21,6 @@
  */
 
 #include <ctype.h>
-#include <stdlib.h>
 #include "common.h"
 #include "loaders/loader.h"
 

--- a/src/load_helpers.c
+++ b/src/load_helpers.c
@@ -20,9 +20,7 @@
  * THE SOFTWARE.
  */
 
-#include <stdio.h>
 #include <ctype.h>
-#include <string.h>
 #include <stdlib.h>
 #include "common.h"
 #include "loaders/loader.h"

--- a/src/load_helpers.c
+++ b/src/load_helpers.c
@@ -27,12 +27,6 @@
 
 #ifndef LIBXMP_CORE_PLAYER
 
-#ifdef __ANDROID__
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#endif
-
 #include "xfnmatch.h"
 
 /*

--- a/src/loaders/abk_load.c
+++ b/src/loaders/abk_load.c
@@ -21,12 +21,6 @@
  * THE SOFTWARE.
  */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#include <ctype.h>
-
 #include "loader.h"
 #include "effects.h"
 #include "period.h"

--- a/src/loaders/asif.c
+++ b/src/loaders/asif.c
@@ -20,8 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdio.h>
-
 #include "loader.h"
 #include "asif.h"
 

--- a/src/loaders/asif.h
+++ b/src/loaders/asif.h
@@ -1,7 +1,6 @@
 #ifndef XMP_ASIF_H
 #define XMP_ASIF_H
 
-#include <stdio.h>
 #include "common.h"
 #include "hio.h"
 

--- a/src/loaders/common.c
+++ b/src/loaders/common.c
@@ -22,7 +22,6 @@
 
 #include <ctype.h>
 #include <sys/types.h>
-#include <stdarg.h>
 
 #ifndef LIBXMP_CORE_PLAYER
 #include <limits.h>

--- a/src/loaders/common.c
+++ b/src/loaders/common.c
@@ -21,15 +21,14 @@
  */
 
 #include <ctype.h>
-#include <sys/types.h>
 
 #ifndef LIBXMP_CORE_PLAYER
-#include <limits.h>
 #if defined(_WIN32)
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
+#include <limits.h>
 #elif defined(__OS2__) || defined(__EMX__)
 #define INCL_DOS
 #define INCL_DOSERRORS

--- a/src/loaders/dmf_load.c
+++ b/src/loaders/dmf_load.c
@@ -24,8 +24,6 @@
  * Public domain DMF sample decompressor by Olivier Lapicque
  */
 
-#include <assert.h>
-
 #include "loader.h"
 #include "iff.h"
 #include "period.h"

--- a/src/loaders/dt_load.c
+++ b/src/loaders/dt_load.c
@@ -20,8 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <assert.h>
-
 #include "loader.h"
 #include "iff.h"
 #include "period.h"

--- a/src/loaders/emod_load.c
+++ b/src/loaders/emod_load.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdio.h>
 #include "loader.h"
 #include "iff.h"
 

--- a/src/loaders/gal4_load.c
+++ b/src/loaders/gal4_load.c
@@ -20,8 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <unistd.h>
-#include <limits.h>
 #include "loader.h"
 #include "iff.h"
 #include "period.h"

--- a/src/loaders/gal5_load.c
+++ b/src/loaders/gal5_load.c
@@ -20,8 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <unistd.h>
-#include <limits.h>
 #include "loader.h"
 #include "iff.h"
 #include "period.h"

--- a/src/loaders/iff.c
+++ b/src/loaders/iff.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdlib.h>
 #include "common.h"
 #include "list.h"
 #include "iff.h"

--- a/src/loaders/iff.c
+++ b/src/loaders/iff.c
@@ -20,9 +20,7 @@
  * THE SOFTWARE.
  */
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include "common.h"
 #include "list.h"
 #include "iff.h"

--- a/src/loaders/ims_load.c
+++ b/src/loaders/ims_load.c
@@ -39,9 +39,6 @@
  * tunes as a UNIC file.
  */
 
-#include <ctype.h>
-#include <sys/types.h>
-
 #include "loader.h"
 #include "period.h"
 

--- a/src/loaders/loader.h
+++ b/src/loaders/loader.h
@@ -1,9 +1,7 @@
 #ifndef XMP_LOADER_H
 #define XMP_LOADER_H
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include "common.h"
 #include "effects.h"
 #include "format.h"

--- a/src/loaders/loader.h
+++ b/src/loaders/loader.h
@@ -1,7 +1,6 @@
 #ifndef XMP_LOADER_H
 #define XMP_LOADER_H
 
-#include <stdlib.h>
 #include "common.h"
 #include "effects.h"
 #include "format.h"

--- a/src/loaders/med3_load.c
+++ b/src/loaders/med3_load.c
@@ -25,7 +25,6 @@
  * from ftp://ftp.funet.fi/pub/amiga/fish/301-400/ff349
  */
 
-#include <assert.h>
 #include "loader.h"
 
 #define MAGIC_MED3	MAGIC4('M','E','D',3)

--- a/src/loaders/med4_load.c
+++ b/src/loaders/med4_load.c
@@ -26,7 +26,6 @@
  * HappySong MED4 is in ff401. MED 3.00 is in ff476.
  */
 
-#include <assert.h>
 #include "med.h"
 #include "loader.h"
 #include "med_extras.h"

--- a/src/loaders/mfp_load.c
+++ b/src/loaders/mfp_load.c
@@ -27,14 +27,12 @@
  */
 
 #include "loader.h"
-#include <sys/types.h>
 #include <sys/stat.h>
 #ifdef __native_client__
 #include <sys/syslimits.h>
 #else
 #include <limits.h>
 #endif
-#include <unistd.h>
 
 static int mfp_test(HIO_HANDLE *, char *, const int);
 static int mfp_load(struct module_data *, HIO_HANDLE *, const int);

--- a/src/loaders/prowizard/ac1d.c
+++ b/src/loaders/prowizard/ac1d.c
@@ -8,7 +8,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 #define NO_NOTE 0xff

--- a/src/loaders/prowizard/ac1d.c
+++ b/src/loaders/prowizard/ac1d.c
@@ -9,7 +9,6 @@
  */
 
 #include <stdlib.h>
-#include <string.h>
 #include "prowiz.h"
 
 #define NO_NOTE 0xff

--- a/src/loaders/prowizard/di.c
+++ b/src/loaders/prowizard/di.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/di.c
+++ b/src/loaders/prowizard/di.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/eureka.c
+++ b/src/loaders/prowizard/eureka.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/eureka.c
+++ b/src/loaders/prowizard/eureka.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/fc-m.c
+++ b/src/loaders/prowizard/fc-m.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/fc-m.c
+++ b/src/loaders/prowizard/fc-m.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/fuchs.c
+++ b/src/loaders/prowizard/fuchs.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/fuchs.c
+++ b/src/loaders/prowizard/fuchs.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/fuzzac.c
+++ b/src/loaders/prowizard/fuzzac.c
@@ -14,7 +14,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/fuzzac.c
+++ b/src/loaders/prowizard/fuzzac.c
@@ -14,7 +14,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/gmc.c
+++ b/src/loaders/prowizard/gmc.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/gmc.c
+++ b/src/loaders/prowizard/gmc.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/heatseek.c
+++ b/src/loaders/prowizard/heatseek.c
@@ -8,7 +8,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/heatseek.c
+++ b/src/loaders/prowizard/heatseek.c
@@ -8,7 +8,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/hrt.c
+++ b/src/loaders/prowizard/hrt.c
@@ -4,7 +4,6 @@
  * Modified in 2009,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/hrt.c
+++ b/src/loaders/prowizard/hrt.c
@@ -4,7 +4,6 @@
  * Modified in 2009,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/kris.c
+++ b/src/loaders/prowizard/kris.c
@@ -5,7 +5,6 @@
  * Kris Tracker to Protracker.
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/kris.c
+++ b/src/loaders/prowizard/kris.c
@@ -5,7 +5,6 @@
  * Kris Tracker to Protracker.
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/ksm.c
+++ b/src/loaders/prowizard/ksm.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/ksm.c
+++ b/src/loaders/prowizard/ksm.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/mp.c
+++ b/src/loaders/prowizard/mp.c
@@ -7,7 +7,6 @@
  */
 
 #include <stdlib.h>
-#include <string.h>
 #include "prowiz.h"
 
 #define MAGIC_TRK1	MAGIC4('T','R','K','1')

--- a/src/loaders/prowizard/mp.c
+++ b/src/loaders/prowizard/mp.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 #define MAGIC_TRK1	MAGIC4('T','R','K','1')

--- a/src/loaders/prowizard/noiserun.c
+++ b/src/loaders/prowizard/noiserun.c
@@ -6,7 +6,6 @@
  *  Modified in 2010,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/noiserun.c
+++ b/src/loaders/prowizard/noiserun.c
@@ -6,7 +6,6 @@
  *  Modified in 2010,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/novotrade.c
+++ b/src/loaders/prowizard/novotrade.c
@@ -4,7 +4,6 @@
  * Modified in 2009,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/novotrade.c
+++ b/src/loaders/prowizard/novotrade.c
@@ -4,7 +4,6 @@
  * Modified in 2009,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/np1.c
+++ b/src/loaders/prowizard/np1.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014,2015 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/np1.c
+++ b/src/loaders/prowizard/np1.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014,2015 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/np2.c
+++ b/src/loaders/prowizard/np2.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014,2015 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/np2.c
+++ b/src/loaders/prowizard/np2.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014,2015 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/np3.c
+++ b/src/loaders/prowizard/np3.c
@@ -9,7 +9,6 @@
  * Modified in 2006,2007,2014,2015 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/np3.c
+++ b/src/loaders/prowizard/np3.c
@@ -9,7 +9,6 @@
  * Modified in 2006,2007,2014,2015 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/p40.c
+++ b/src/loaders/prowizard/p40.c
@@ -6,7 +6,6 @@
  * The Player 4.0a and 4.0b to Protracker.
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/p40.c
+++ b/src/loaders/prowizard/p40.c
@@ -6,7 +6,6 @@
  * The Player 4.0a and 4.0b to Protracker.
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 #define MAGIC_P40A	MAGIC4('P','4','0','A')

--- a/src/loaders/prowizard/p61a.c
+++ b/src/loaders/prowizard/p61a.c
@@ -12,7 +12,6 @@
  *      be a good idea too :).
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/p61a.c
+++ b/src/loaders/prowizard/p61a.c
@@ -12,7 +12,6 @@
  *      be a good idea too :).
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/pha.c
+++ b/src/loaders/prowizard/pha.c
@@ -7,7 +7,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/pha.c
+++ b/src/loaders/prowizard/pha.c
@@ -7,7 +7,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/pm.c
+++ b/src/loaders/prowizard/pm.c
@@ -5,8 +5,8 @@
  *
 */
 
-#include <string.h>
 #include <stdlib.h>
+#include "prowiz.h"
 
 void Depack_PM (FILE * in, FILE * out)
 {

--- a/src/loaders/prowizard/pm.c
+++ b/src/loaders/prowizard/pm.c
@@ -5,7 +5,6 @@
  *
 */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 void Depack_PM (FILE * in, FILE * out)

--- a/src/loaders/prowizard/pm01.c
+++ b/src/loaders/prowizard/pm01.c
@@ -6,7 +6,6 @@
  * Modified in 2016 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include <math.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/pm01.c
+++ b/src/loaders/prowizard/pm01.c
@@ -6,7 +6,6 @@
  * Modified in 2016 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include <math.h>
 #include "prowiz.h"

--- a/src/loaders/prowizard/pm10c.c
+++ b/src/loaders/prowizard/pm10c.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/pm10c.c
+++ b/src/loaders/prowizard/pm10c.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/pm18a.c
+++ b/src/loaders/prowizard/pm18a.c
@@ -8,7 +8,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/pm18a.c
+++ b/src/loaders/prowizard/pm18a.c
@@ -8,7 +8,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/pm20.c
+++ b/src/loaders/prowizard/pm20.c
@@ -5,8 +5,8 @@
  *
 */
 
-#include <string.h>
 #include <stdlib.h>
+#include "prowiz.h"
 
 #define ON  0
 #define OFF 1

--- a/src/loaders/prowizard/pm20.c
+++ b/src/loaders/prowizard/pm20.c
@@ -5,7 +5,6 @@
  *
 */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 #define ON  0

--- a/src/loaders/prowizard/pm40.c
+++ b/src/loaders/prowizard/pm40.c
@@ -5,8 +5,8 @@
  *
 */
 
-#include <string.h>
 #include <stdlib.h>
+#include "prowiz.h"
 
 #define ON  0
 #define OFF 1

--- a/src/loaders/prowizard/pm40.c
+++ b/src/loaders/prowizard/pm40.c
@@ -5,7 +5,6 @@
  *
 */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 #define ON  0

--- a/src/loaders/prowizard/pp10.c
+++ b/src/loaders/prowizard/pp10.c
@@ -6,7 +6,6 @@
  * Modified in 2016 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 static int depack_pp10(HIO_HANDLE *in, FILE *out)

--- a/src/loaders/prowizard/pp10.c
+++ b/src/loaders/prowizard/pp10.c
@@ -6,7 +6,6 @@
  * Modified in 2016 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/pp21.c
+++ b/src/loaders/prowizard/pp21.c
@@ -12,7 +12,6 @@
  * - Add PP30 support
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/pp21.c
+++ b/src/loaders/prowizard/pp21.c
@@ -12,7 +12,6 @@
  * - Add PP30 support
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/pp30.c
+++ b/src/loaders/prowizard/pp30.c
@@ -7,7 +7,6 @@
  *
 */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 void Depack_PP30 (FILE * in, FILE * out)

--- a/src/loaders/prowizard/pp30.c
+++ b/src/loaders/prowizard/pp30.c
@@ -7,8 +7,8 @@
  *
 */
 
-#include <string.h>
 #include <stdlib.h>
+#include "prowiz.h"
 
 void Depack_PP30 (FILE * in, FILE * out)
 {

--- a/src/loaders/prowizard/prowiz.c
+++ b/src/loaders/prowizard/prowiz.c
@@ -5,7 +5,6 @@
  * Copyright (C) 2006-2007 Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/loaders/prowizard/prowiz.c
+++ b/src/loaders/prowizard/prowiz.c
@@ -5,7 +5,6 @@
  * Copyright (C) 2006-2007 Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/loaders/prowizard/prowiz.c
+++ b/src/loaders/prowizard/prowiz.c
@@ -5,9 +5,6 @@
  * Copyright (C) 2006-2007 Claudio Matsuoka
  */
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
 #include "xmp.h"
 
 #include "prowiz.h"

--- a/src/loaders/prowizard/prowiz.h
+++ b/src/loaders/prowizard/prowiz.h
@@ -1,7 +1,6 @@
 #ifndef PROWIZ_H
 #define PROWIZ_H
 
-#include <stdio.h>
 #include "list.h"
 #include "common.h"
 #include "format.h"

--- a/src/loaders/prowizard/prun1.c
+++ b/src/loaders/prowizard/prun1.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/prun1.c
+++ b/src/loaders/prowizard/prun1.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/prun2.c
+++ b/src/loaders/prowizard/prun2.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/prun2.c
+++ b/src/loaders/prowizard/prun2.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/ptk.c
+++ b/src/loaders/prowizard/ptk.c
@@ -1,6 +1,6 @@
 
-#include <string.h>
 #include <stdlib.h>
+#include "prowiz.h"
 
 void testPTK (void)
 {

--- a/src/loaders/prowizard/ptk.c
+++ b/src/loaders/prowizard/ptk.c
@@ -1,5 +1,4 @@
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 void testPTK (void)

--- a/src/loaders/prowizard/qc.c
+++ b/src/loaders/prowizard/qc.c
@@ -5,7 +5,6 @@
  * Converts QC MODs back to PTK MODs
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 static int test_emod (const uint8 *, int);

--- a/src/loaders/prowizard/qc.c
+++ b/src/loaders/prowizard/qc.c
@@ -5,7 +5,6 @@
  * Converts QC MODs back to PTK MODs
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/skyt.c
+++ b/src/loaders/prowizard/skyt.c
@@ -4,7 +4,6 @@
  *   Modified in 2009,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/skyt.c
+++ b/src/loaders/prowizard/skyt.c
@@ -4,7 +4,6 @@
  *   Modified in 2009,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/soundfx.c
+++ b/src/loaders/prowizard/soundfx.c
@@ -5,8 +5,8 @@
  *
 */
 
-#include <string.h>
 #include <stdlib.h>
+#include "prowiz.h"
 
 void Depack_SoundFX13 (FILE * in, FILE * out)
 {
@@ -202,7 +202,6 @@ void Depack_SoundFX13 (FILE * in, FILE * out)
 
 }
 
-#include <string.h>
 #include <stdlib.h>
 
 void testSoundFX13 (void)

--- a/src/loaders/prowizard/soundfx.c
+++ b/src/loaders/prowizard/soundfx.c
@@ -5,7 +5,6 @@
  *
 */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 void Depack_SoundFX13 (FILE * in, FILE * out)
@@ -201,8 +200,6 @@ void Depack_SoundFX13 (FILE * in, FILE * out)
 	return;			/* useless ... but */
 
 }
-
-#include <stdlib.h>
 
 void testSoundFX13 (void)
 {

--- a/src/loaders/prowizard/soundtk.c
+++ b/src/loaders/prowizard/soundtk.c
@@ -1,7 +1,6 @@
 
 /* Empty file */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 void testSoundTracker (void)

--- a/src/loaders/prowizard/soundtk.c
+++ b/src/loaders/prowizard/soundtk.c
@@ -1,8 +1,8 @@
 
 /* Empty file */
 
-#include <string.h>
 #include <stdlib.h>
+#include "prowiz.h"
 
 void testSoundTracker (void)
 {

--- a/src/loaders/prowizard/starpack.c
+++ b/src/loaders/prowizard/starpack.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2009,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/starpack.c
+++ b/src/loaders/prowizard/starpack.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2009,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/stim.c
+++ b/src/loaders/prowizard/stim.c
@@ -9,7 +9,6 @@
  *     It speeds-up the process quite a bit :).
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 static int test_stim (uint8 *, int);

--- a/src/loaders/prowizard/stim.c
+++ b/src/loaders/prowizard/stim.c
@@ -9,7 +9,6 @@
  *     It speeds-up the process quite a bit :).
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/tdd.c
+++ b/src/loaders/prowizard/tdd.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/tdd.c
+++ b/src/loaders/prowizard/tdd.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/theplayer.c
+++ b/src/loaders/prowizard/theplayer.c
@@ -7,7 +7,6 @@
  * Original code by Sylvain Chipaux, modified for xmp by Claudio Matsuoka.
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/theplayer.c
+++ b/src/loaders/prowizard/theplayer.c
@@ -7,7 +7,6 @@
  * Original code by Sylvain Chipaux, modified for xmp by Claudio Matsuoka.
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/titanics.c
+++ b/src/loaders/prowizard/titanics.c
@@ -8,7 +8,6 @@
  * Titan Trax vol. 1: http://www.youtube.com/watch?v=blgm0EcPUd8
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/titanics.c
+++ b/src/loaders/prowizard/titanics.c
@@ -8,7 +8,6 @@
  * Titan Trax vol. 1: http://www.youtube.com/watch?v=blgm0EcPUd8
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/tp1.c
+++ b/src/loaders/prowizard/tp1.c
@@ -6,7 +6,6 @@
  * Modified in 2016 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 static int depack_tp1(HIO_HANDLE *in, FILE *out)

--- a/src/loaders/prowizard/tp1.c
+++ b/src/loaders/prowizard/tp1.c
@@ -6,7 +6,6 @@
  * Modified in 2016 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/tp2.c
+++ b/src/loaders/prowizard/tp2.c
@@ -9,7 +9,6 @@
  *
 */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 void Depack_TP2 (FILE * in, FILE * out)

--- a/src/loaders/prowizard/tp2.c
+++ b/src/loaders/prowizard/tp2.c
@@ -9,8 +9,8 @@
  *
 */
 
-#include <string.h>
 #include <stdlib.h>
+#include "prowiz.h"
 
 void Depack_TP2 (FILE * in, FILE * out)
 {

--- a/src/loaders/prowizard/tp3.c
+++ b/src/loaders/prowizard/tp3.c
@@ -6,7 +6,6 @@
  * Modified in 2007,2014,2016 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/tp3.c
+++ b/src/loaders/prowizard/tp3.c
@@ -6,7 +6,6 @@
  * Modified in 2007,2014,2016 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/unic.c
+++ b/src/loaders/prowizard/unic.c
@@ -7,7 +7,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/unic.c
+++ b/src/loaders/prowizard/unic.c
@@ -7,7 +7,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 #define MAGIC_UNIC	MAGIC4('U','N','I','C')

--- a/src/loaders/prowizard/unic2.c
+++ b/src/loaders/prowizard/unic2.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/unic2.c
+++ b/src/loaders/prowizard/unic2.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/wn.c
+++ b/src/loaders/prowizard/wn.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/wn.c
+++ b/src/loaders/prowizard/wn.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/prowizard/xann.c
+++ b/src/loaders/prowizard/xann.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include "prowiz.h"
 
 #define SMP_DESC_ADDRESS 0x206

--- a/src/loaders/prowizard/zen.c
+++ b/src/loaders/prowizard/zen.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <stdlib.h>
 #include "prowiz.h"
 
 

--- a/src/loaders/prowizard/zen.c
+++ b/src/loaders/prowizard/zen.c
@@ -6,7 +6,6 @@
  * Modified in 2006,2007,2014 by Claudio Matsuoka
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "prowiz.h"
 

--- a/src/loaders/pt3_load.c
+++ b/src/loaders/pt3_load.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdio.h>
 #include "loader.h"
 #include "mod.h"
 #include "iff.h"

--- a/src/loaders/pw_load.c
+++ b/src/loaders/pw_load.c
@@ -20,12 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <unistd.h>
-#ifdef __native_client__
-#include <sys/syslimits.h>
-#else
-#include <limits.h>
-#endif
 #include "loader.h"
 #include "mod.h"
 #include "period.h"

--- a/src/loaders/ssmt_load.c
+++ b/src/loaders/ssmt_load.c
@@ -20,7 +20,6 @@
  * actually worth listening to.  
  */
 
-#include <string.h>
 #include "loader.h"
 #include "asif.h"
 

--- a/src/loaders/st_load.c
+++ b/src/loaders/st_load.c
@@ -24,7 +24,6 @@
  * written by Michael Schwendt <sidplay@geocities.com>
  */
 
-#include <ctype.h>
 #include "loader.h"
 #include "mod.h"
 #include "period.h"

--- a/src/md5.c
+++ b/src/md5.c
@@ -16,7 +16,6 @@
  */
 
 #include <sys/types.h>
-#include <string.h>
 #include "common.h"
 #include "md5.h"
 

--- a/src/md5.c
+++ b/src/md5.c
@@ -15,7 +15,6 @@
  * will fill a supplied 16-byte array with the digest.
  */
 
-#include <sys/types.h>
 #include "common.h"
 #include "md5.h"
 

--- a/src/mdataio.h
+++ b/src/mdataio.h
@@ -2,6 +2,7 @@
 #define LIBXMP_MDATAIO_H
 
 #include <stddef.h>
+#include <limits.h>
 #include "common.h"
 
 static inline ptrdiff_t CAN_READ(MFILE *m)

--- a/src/med_extras.c
+++ b/src/med_extras.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdlib.h>
 #include "common.h"
 #include "player.h"
 #include "virtual.h"

--- a/src/memio.c
+++ b/src/memio.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdlib.h>
 #include <stddef.h>
 #include <limits.h>
 #ifndef LIBXMP_CORE_PLAYER

--- a/src/memio.c
+++ b/src/memio.c
@@ -20,12 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stddef.h>
-#include <limits.h>
-#ifndef LIBXMP_CORE_PLAYER
-#include <sys/types.h>
-#include <sys/stat.h>
-#endif
 #include "common.h"
 #include "memio.h"
 

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -21,7 +21,6 @@
  */
 
 #include <stdlib.h>
-#include <string.h>
 #include <math.h>
 #include "common.h"
 #include "virtual.h"

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdlib.h>
 #include <math.h>
 #include "common.h"
 #include "virtual.h"

--- a/src/period.c
+++ b/src/period.c
@@ -23,8 +23,6 @@
 #define _GNU_SOURCE
 #endif
 
-#include <stdio.h>
-#include <string.h>
 #include "common.h"
 #include "period.h"
 

--- a/src/player.c
+++ b/src/player.c
@@ -38,7 +38,6 @@
  */
 
 #include <stdlib.h>
-#include <string.h>
 #include "virtual.h"
 #include "period.h"
 #include "effects.h"

--- a/src/player.c
+++ b/src/player.c
@@ -37,7 +37,6 @@
  * Claudio's fix: implementing effect K
  */
 
-#include <stdlib.h>
 #include "virtual.h"
 #include "period.h"
 #include "effects.h"

--- a/src/read_event.c
+++ b/src/read_event.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdlib.h>
 #include "common.h"
 #include "player.h"
 #include "effects.h"

--- a/src/read_event.c
+++ b/src/read_event.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <string.h>
 #include <stdlib.h>
 #include "common.h"
 #include "player.h"

--- a/src/scan.c
+++ b/src/scan.c
@@ -39,7 +39,6 @@
 
 
 #include <stdlib.h>
-#include <string.h>
 #include "common.h"
 #include "effects.h"
 #include "mixer.h"

--- a/src/scan.c
+++ b/src/scan.c
@@ -38,7 +38,6 @@
  */
 
 
-#include <stdlib.h>
 #include "common.h"
 #include "effects.h"
 #include "mixer.h"

--- a/src/smix.c
+++ b/src/smix.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdlib.h>
 #include "common.h"
 #include "period.h"
 #include "player.h"

--- a/src/tempfile.c
+++ b/src/tempfile.c
@@ -26,9 +26,7 @@
 
 #ifndef LIBXMP_CORE_PLAYER
 
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <limits.h>
 #include <unistd.h>
 

--- a/src/tempfile.c
+++ b/src/tempfile.c
@@ -26,7 +26,6 @@
 
 #ifndef LIBXMP_CORE_PLAYER
 
-#include <stdlib.h>
 #include <limits.h>
 #include <unistd.h>
 

--- a/src/virtual.c
+++ b/src/virtual.c
@@ -21,7 +21,6 @@
  */
 
 #include <stdlib.h>
-#include <string.h>
 #include <limits.h>
 #include "common.h"
 #include "virtual.h"

--- a/src/virtual.c
+++ b/src/virtual.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <stdlib.h>
 #include <limits.h>
 #include "common.h"
 #include "virtual.h"

--- a/src/win32.c
+++ b/src/win32.c
@@ -1,8 +1,6 @@
 /* _[v]snprintf() from msvcrt.dll might not nul terminate */
 /* OpenWatcom-provided versions seem to behave the same... */
 
-#include <stdarg.h>
-#include <stdio.h>
 #include "common.h"
 
 #if defined(USE_LIBXMP_SNPRINTF)

--- a/src/win32/debug.c
+++ b/src/win32/debug.c
@@ -4,8 +4,8 @@
 
 #if defined(_WIN32) && defined(_DEBUG)
 
-#include <stdio.h>
-#include <stdarg.h>
+#include "common.h"
+
 void D_(const char *format, ...)
 {
 	va_list argptr;

--- a/test-dev/compare_mixer_data.c
+++ b/test-dev/compare_mixer_data.c
@@ -1,7 +1,4 @@
 #include "test.h"
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 #undef TEST
 #include "../src/player.h"
 #include "../src/mixer.h"

--- a/test-dev/gen_mixer_data.c
+++ b/test-dev/gen_mixer_data.c
@@ -1,5 +1,3 @@
-#include <stdio.h>
-#include <stdlib.h>
 #include "../include/xmp.h"
 #include "../src/common.h"
 #include "../src/mixer.h"

--- a/test-dev/gen_mixer_data_loops.c
+++ b/test-dev/gen_mixer_data_loops.c
@@ -1,5 +1,3 @@
-#include <stdio.h>
-#include <stdlib.h>
 #include "../include/xmp.h"
 #include "../src/common.h"
 #include "../src/mixer.h"

--- a/test-dev/gen_module_data.c
+++ b/test-dev/gen_module_data.c
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include "../include/xmp.h"
 #include "test.h"
 

--- a/test-dev/main.c
+++ b/test-dev/main.c
@@ -10,7 +10,6 @@
 #include <sys/wait.h>
 #endif
 #include <unistd.h>
-#include <stdio.h>
 #include "test.h"
 #include "../src/list.h"
 

--- a/test-dev/md5.c
+++ b/test-dev/md5.c
@@ -15,8 +15,6 @@
  * will fill a supplied 16-byte array with the digest.
  */
 
-#include <sys/types.h>
-#include <string.h>
 #include "../src/common.h"
 #include "md5.h"
 

--- a/test-dev/test.h
+++ b/test-dev/test.h
@@ -1,10 +1,3 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdint.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
 #include <xmp.h>
 #include "md5.h"
 

--- a/test-dev/test_api_load_module.c
+++ b/test-dev/test_api_load_module.c
@@ -1,7 +1,5 @@
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 #include <errno.h>
+#include <unistd.h>
 #include "test.h"
 
 TEST(test_api_load_module)

--- a/test-dev/test_api_load_module_from_file.c
+++ b/test-dev/test_api_load_module_from_file.c
@@ -1,4 +1,3 @@
-#include <stdlib.h>
 #include "test.h"
 
 

--- a/test-dev/test_api_load_module_from_memory.c
+++ b/test-dev/test_api_load_module_from_memory.c
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include "test.h"
 
 #define BUFFER_SIZE 256000

--- a/test-dev/test_api_test_module.c
+++ b/test-dev/test_api_test_module.c
@@ -1,7 +1,4 @@
 #include "test.h"
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 #include <errno.h>
 
 TEST(test_api_test_module)

--- a/test-dev/test_api_test_module_from_file.c
+++ b/test-dev/test_api_test_module_from_file.c
@@ -1,7 +1,4 @@
 #include "test.h"
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 
 static int test_module_from_file_helper(const char* filename, struct xmp_test_info *tinfo)
 {

--- a/test-dev/test_api_test_module_from_memory.c
+++ b/test-dev/test_api_test_module_from_memory.c
@@ -1,7 +1,4 @@
 #include "test.h"
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 
 static int test_module_from_memory_helper(const char* filename, struct xmp_test_info *tinfo, char* buf)
 {

--- a/test-dev/test_depack_vorbis.c
+++ b/test-dev/test_depack_vorbis.c
@@ -1,4 +1,5 @@
 #include "test.h"
+#include <sys/stat.h>
 
 
 TEST(test_depack_vorbis)

--- a/test-dev/test_depack_vorbis_8bit.c
+++ b/test-dev/test_depack_vorbis_8bit.c
@@ -1,4 +1,5 @@
 #include "test.h"
+#include <sys/stat.h>
 
 
 TEST(test_depack_vorbis_8bit)

--- a/test-dev/test_openmpt_xm_envloops.c
+++ b/test-dev/test_openmpt_xm_envloops.c
@@ -1,7 +1,4 @@
 #include "test.h"
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 #include "../src/mixer.h"
 #include "../src/virtual.h"
 

--- a/test-dev/test_read_file_hio_pipe.c
+++ b/test-dev/test_read_file_hio_pipe.c
@@ -1,7 +1,8 @@
-#include <sys/types.h>
-#include <sys/stat.h>
 #include "test.h"
 #include "../src/hio.h"
+#ifdef HAVE_PIPE
+#include <unistd.h>
+#endif
 
 /* libxmp requires a seekable input file.
  * Attempting to open a non-seekable file should fail. */

--- a/test-dev/test_read_mem_hio.c
+++ b/test-dev/test_read_mem_hio.c
@@ -1,5 +1,3 @@
-#include <sys/types.h>
-#include <sys/stat.h>
 #include "test.h"
 #include "../src/hio.h"
 
@@ -9,7 +7,6 @@ TEST(test_read_mem_hio)
 	int i;
 	int x;
 	HIO_HANDLE *h;
-	struct stat st;
 
 	for (i = 0; i < 100; i++)
 		mem[i] = i;

--- a/test-dev/test_read_mem_hio_nosize.c
+++ b/test-dev/test_read_mem_hio_nosize.c
@@ -1,5 +1,3 @@
-#include <sys/types.h>
-#include <sys/stat.h>
 #include "test.h"
 #include "../src/hio.h"
 

--- a/test-dev/test_storlek_09_sample_change_no_note.c
+++ b/test-dev/test_storlek_09_sample_change_no_note.c
@@ -1,7 +1,4 @@
 #include "test.h"
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 
 /*
 09 - Sample change with no note

--- a/test-dev/test_storlek_14_pingpong_loop_and_sample_number.c
+++ b/test-dev/test_storlek_14_pingpong_loop_and_sample_number.c
@@ -1,7 +1,4 @@
 #include "test.h"
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 
 /*
 14 - Ping-pong loop and sample number

--- a/test-dev/test_storlek_15_retrigger.c
+++ b/test-dev/test_storlek_15_retrigger.c
@@ -1,7 +1,4 @@
 #include "test.h"
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 
 /*
 15 - Retrigger

--- a/test-dev/test_storlek_21_pitch_slide_limits.c
+++ b/test-dev/test_storlek_21_pitch_slide_limits.c
@@ -1,7 +1,4 @@
 #include "test.h"
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 #include "../src/mixer.h"
 #include "../src/virtual.h"
 

--- a/test-dev/test_write_file_move_data.c
+++ b/test-dev/test_write_file_move_data.c
@@ -1,7 +1,5 @@
 #include "test.h"
-#include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
 TEST(test_write_file_move_data)
 {

--- a/test-dev/util.c
+++ b/test-dev/util.c
@@ -1,5 +1,3 @@
-#include <stdio.h>
-#include <stdlib.h>
 #include <math.h>
 #include "test.h"
 


### PR DESCRIPTION
Common system headers are included from `src/common.h`, and duplicate or unused includes have been removed.