### PR TITLE
Fix GCC warning in iff.c due to (correct) strncpy usage.

### DIFF
--- a/src/loaders/iff.c
+++ b/src/loaders/iff.c
@@ -162,12 +162,18 @@ int libxmp_iff_register(iff_handle opaque, const char *id,
 {
 	struct iff_data *data = (struct iff_data *)opaque;
 	struct iff_info *f;
+	int i = 0;
 
 	f = malloc(sizeof(struct iff_info));
 	if (f == NULL)
 		return -1;
 
-	strncpy(f->id, id, 4);
+	/* Note: previously was an strncpy */
+	for (; i < 4 && id && id[i]; i++)
+		f->id[i] = id[i];
+	for (; i < 4; i++)
+		f->id[i] = '\0';
+
 	f->loader = loader;
 
 	list_add_tail(&f->list, &data->iff_list);


### PR DESCRIPTION
Another minor tidying patch. Most of the -Wstringop-truncation warnings in libxmp were fixed by #179, but the `strncpy` in iff.c had to be reverted in #184 because, for a change, it's actually being used the way it was intended. GCC has been complaining about it since, though, and the simplest non-breaking fix seems to be to just expand the buffer size so it can be terminated. Not that it matters much, but this is a slight size increase for `iff_info` for 32-bit machines and was existing padding for 64-bit.

With this patch, neither GCC 10 nor GCC 11 emits any warnings on my end during the libxmp build process. :)