### PR TITLE
misc cleanups / tidy-ups:

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -321,6 +321,33 @@ struct module_data {
 };
 
 
+struct pattern_loop {
+	int start;
+	int count;
+};
+
+struct flow_control {
+	int pbreak;
+	int jump;
+	int delay;
+	int jumpline;
+	int loop_chn;
+
+	struct pattern_loop *loop;
+
+	int num_rows;
+	int end_point;
+#define ROWDELAY_ON		(1 << 0)
+#define ROWDELAY_FIRST_FRAME	(1 << 1)
+	int rowdelay;		/* For IT pattern row delay */
+	int rowdelay_set;
+};
+
+struct virt_channel {
+	int count;
+	int map;
+};
+
 struct player_data {
 	int ord;
 	int pos;
@@ -343,25 +370,7 @@ struct player_data {
 	int master_vol;			/* Music volume */
 	int gvol;
 
-	struct flow_control {
-		int pbreak;
-		int jump;
-		int delay;
-		int jumpline;
-		int loop_chn;
-
-		struct pattern_loop {
-			int start;
-			int count;
-		} *loop;
-
-		int num_rows;
-		int end_point;
-#define ROWDELAY_ON		(1 << 0)
-#define ROWDELAY_FIRST_FRAME	(1 << 1)
-		int rowdelay;		/* For IT pattern row delay */
-		int rowdelay_set;
-	} flow;
+	struct flow_control flow;
 
 	struct {
 		int time;		/* replay time in ms */
@@ -381,10 +390,7 @@ struct player_data {
 		int virt_used;		/* Number of voices currently in use */
 		int maxvoc;		/* Number of sound card voices */
 
-		struct virt_channel {
-			int count;
-			int map;
-		} *virt_channel;
+		struct virt_channel *virt_channel;
 
 		struct mixer_voice *voice_array;
 	} virt;

--- a/src/depackers/xz.h
+++ b/src/depackers/xz.h
@@ -11,21 +11,10 @@
 #ifndef XZ_H
 #define XZ_H
 
-#ifdef __KERNEL__
-#	include <linux/stddef.h>
-#	include <linux/types.h>
-#else
-/*
-#	include <stddef.h>
-#	include <stdint.h>
-*/
-#	include "common.h"
-#	define false 0
-#	define true 1
-#ifndef B_BEOS_VERSION
-	typedef int bool;
-#endif
-#endif
+#include "common.h"
+#define xz_false 0
+#define xz_true 1
+typedef int xz_bool;
 
 #ifdef __cplusplus
 extern "C" {
@@ -252,11 +241,7 @@ XZ_EXTERN void xz_dec_end(struct xz_dec *s);
  * care about the functions below.
  */
 #ifndef XZ_INTERNAL_CRC32
-#	ifdef __KERNEL__
-#		define XZ_INTERNAL_CRC32 0
-#	else
 #		define XZ_INTERNAL_CRC32 1
-#	endif
 #endif
 
 #if XZ_INTERNAL_CRC32

--- a/src/depackers/xz_config.h
+++ b/src/depackers/xz_config.h
@@ -20,13 +20,9 @@
 
 #define XZ_DEC_ANY_CHECK 1
 
-/*
-#include <stdlib.h>
-#include <string.h>
-*/
-
 #include "xz.h"
 
+#define GFP_KERNEL (0)
 #define kmalloc(size, flags) malloc(size)
 #define kfree(ptr) free(ptr)
 #define vmalloc(size) malloc(size)

--- a/src/depackers/xz_dec_lzma2.c
+++ b/src/depackers/xz_dec_lzma2.c
@@ -241,13 +241,13 @@ struct lzma2_dec {
 	 * True if dictionary reset is needed. This is false before
 	 * the first chunk (LZMA or uncompressed).
 	 */
-	bool need_dict_reset;
+	xz_bool need_dict_reset;
 
 	/*
 	 * True if new LZMA properties are needed. This is false
 	 * before the first LZMA chunk.
 	 */
-	bool need_props;
+	xz_bool need_props;
 };
 
 struct xz_dec_lzma2 {
@@ -306,7 +306,7 @@ static void dict_limit(struct dictionary *dict, size_t out_max)
 }
 
 /* Return true if at least one byte can be written into the dictionary. */
-static inline bool dict_has_space(const struct dictionary *dict)
+static inline xz_bool dict_has_space(const struct dictionary *dict)
 {
 	return dict->pos < dict->limit;
 }
@@ -343,13 +343,13 @@ static inline void dict_put(struct dictionary *dict, uint8 byte)
  * invalid, false is returned. On success, true is returned and *len is
  * updated to indicate how many bytes were left to be repeated.
  */
-static bool dict_repeat(struct dictionary *dict, uint32 *len, uint32 dist)
+static xz_bool dict_repeat(struct dictionary *dict, uint32 *len, uint32 dist)
 {
 	size_t back;
 	uint32 left;
 
 	if (dist >= dict->full || dist >= dict->size)
-		return false;
+		return xz_false;
 
 	left = min_t(size_t, dict->limit - dict->pos, *len);
 	*len -= left;
@@ -367,7 +367,7 @@ static bool dict_repeat(struct dictionary *dict, uint32 *len, uint32 dist)
 	if (dict->full < dict->pos)
 		dict->full = dict->pos;
 
-	return true;
+	return xz_true;
 }
 
 /* Copy uncompressed data as is from input to dictionary and output buffers. */
@@ -446,21 +446,21 @@ static void rc_reset(struct rc_dec *rc)
  * Read the first five initial bytes into rc->code if they haven't been
  * read already. (Yes, the first byte gets completely ignored.)
  */
-static bool rc_read_init(struct rc_dec *rc, struct xz_buf *b)
+static xz_bool rc_read_init(struct rc_dec *rc, struct xz_buf *b)
 {
 	while (rc->init_bytes_left > 0) {
 		if (b->in_pos == b->in_size)
-			return false;
+			return xz_false;
 
 		rc->code = (rc->code << 8) + b->in[b->in_pos++];
 		--rc->init_bytes_left;
 	}
 
-	return true;
+	return xz_true;
 }
 
 /* Return true if there may not be enough input for the next decoding loop. */
-static inline bool rc_limit_exceeded(const struct rc_dec *rc)
+static inline xz_bool rc_limit_exceeded(const struct rc_dec *rc)
 {
 	return rc->in_pos > rc->in_limit;
 }
@@ -469,7 +469,7 @@ static inline bool rc_limit_exceeded(const struct rc_dec *rc)
  * Return true if it is possible (from point of view of range decoder) that
  * we have reached the end of the LZMA chunk.
  */
-static inline bool rc_is_finished(const struct rc_dec *rc)
+static inline xz_bool rc_is_finished(const struct rc_dec *rc)
 {
 	return rc->code == 0;
 }
@@ -719,7 +719,7 @@ static void lzma_rep_match(struct xz_dec_lzma2 *s, uint32 pos_state)
 }
 
 /* LZMA decoder core */
-static bool lzma_main(struct xz_dec_lzma2 *s)
+static xz_bool lzma_main(struct xz_dec_lzma2 *s)
 {
 	uint32 pos_state;
 
@@ -747,7 +747,7 @@ static bool lzma_main(struct xz_dec_lzma2 *s)
 				lzma_match(s, pos_state);
 
 			if (!dict_repeat(&s->dict, &s->lzma.len, s->lzma.rep0))
-				return false;
+				return xz_false;
 		}
 	}
 
@@ -757,7 +757,7 @@ static bool lzma_main(struct xz_dec_lzma2 *s)
 	 */
 	rc_normalize(&s->rc);
 
-	return true;
+	return xz_true;
 }
 
 /*
@@ -796,10 +796,10 @@ static void lzma_reset(struct xz_dec_lzma2 *s)
  * from the decoded lp and pb values. On success, the LZMA decoder state is
  * reset and true is returned.
  */
-static bool lzma_props(struct xz_dec_lzma2 *s, uint8 props)
+static xz_bool lzma_props(struct xz_dec_lzma2 *s, uint8 props)
 {
 	if (props > (4 * 5 + 4) * 9 + 8)
-		return false;
+		return xz_false;
 
 	s->lzma.pos_mask = 0;
 	while (props >= 9 * 5) {
@@ -818,13 +818,13 @@ static bool lzma_props(struct xz_dec_lzma2 *s, uint8 props)
 	s->lzma.lc = props;
 
 	if (s->lzma.lc + s->lzma.literal_pos_mask > 4)
-		return false;
+		return xz_false;
 
 	s->lzma.literal_pos_mask = (1 << s->lzma.literal_pos_mask) - 1;
 
 	lzma_reset(s);
 
-	return true;
+	return xz_true;
 }
 
 /*********
@@ -843,7 +843,7 @@ static bool lzma_props(struct xz_dec_lzma2 *s, uint8 props)
  * function. We decode a few bytes from the temporary buffer so that we can
  * continue decoding from the caller-supplied input buffer again.
  */
-static bool lzma2_lzma(struct xz_dec_lzma2 *s, struct xz_buf *b)
+static xz_bool lzma2_lzma(struct xz_dec_lzma2 *s, struct xz_buf *b)
 {
 	size_t in_avail;
 	uint32 tmp;
@@ -866,7 +866,7 @@ static bool lzma2_lzma(struct xz_dec_lzma2 *s, struct xz_buf *b)
 		} else if (s->temp.size + tmp < LZMA_IN_REQUIRED) {
 			s->temp.size += tmp;
 			b->in_pos += tmp;
-			return true;
+			return xz_true;
 		} else {
 			s->rc.in_limit = s->temp.size + tmp - LZMA_IN_REQUIRED;
 		}
@@ -875,7 +875,7 @@ static bool lzma2_lzma(struct xz_dec_lzma2 *s, struct xz_buf *b)
 		s->rc.in_pos = 0;
 
 		if (!lzma_main(s) || s->rc.in_pos > s->temp.size + tmp)
-			return false;
+			return xz_false;
 
 		s->lzma2.compressed -= s->rc.in_pos;
 
@@ -883,7 +883,7 @@ static bool lzma2_lzma(struct xz_dec_lzma2 *s, struct xz_buf *b)
 			s->temp.size -= s->rc.in_pos;
 			memmove(s->temp.buf, s->temp.buf + s->rc.in_pos,
 					s->temp.size);
-			return true;
+			return xz_true;
 		}
 
 		b->in_pos += s->rc.in_pos - s->temp.size;
@@ -901,11 +901,11 @@ static bool lzma2_lzma(struct xz_dec_lzma2 *s, struct xz_buf *b)
 			s->rc.in_limit = b->in_size - LZMA_IN_REQUIRED;
 
 		if (!lzma_main(s))
-			return false;
+			return xz_false;
 
 		in_avail = s->rc.in_pos - b->in_pos;
 		if (in_avail > s->lzma2.compressed)
-			return false;
+			return xz_false;
 
 		s->lzma2.compressed -= in_avail;
 		b->in_pos = s->rc.in_pos;
@@ -921,7 +921,7 @@ static bool lzma2_lzma(struct xz_dec_lzma2 *s, struct xz_buf *b)
 		b->in_pos += in_avail;
 	}
 
-	return true;
+	return xz_true;
 }
 
 /*
@@ -973,8 +973,8 @@ XZ_EXTERN enum xz_ret xz_dec_lzma2_run(struct xz_dec_lzma2 *s,
 				return XZ_STREAM_END;
 
 			if (tmp >= 0xE0 || tmp == 0x01) {
-				s->lzma2.need_props = true;
-				s->lzma2.need_dict_reset = false;
+				s->lzma2.need_props = xz_true;
+				s->lzma2.need_dict_reset = xz_false;
 				dict_reset(&s->dict, b);
 			} else if (s->lzma2.need_dict_reset) {
 				return XZ_DATA_ERROR;
@@ -990,7 +990,7 @@ XZ_EXTERN enum xz_ret xz_dec_lzma2_run(struct xz_dec_lzma2 *s,
 					 * state reset is done at
 					 * SEQ_PROPERTIES.
 					 */
-					s->lzma2.need_props = false;
+					s->lzma2.need_props = xz_false;
 					s->lzma2.next_sequence
 							= SEQ_PROPERTIES;
 
@@ -1155,7 +1155,7 @@ XZ_EXTERN enum xz_ret xz_dec_lzma2_reset(struct xz_dec_lzma2 *s, uint8 props)
 	s->lzma.len = 0;
 
 	s->lzma2.sequence = SEQ_CONTROL;
-	s->lzma2.need_dict_reset = true;
+	s->lzma2.need_dict_reset = xz_true;
 
 	s->temp.size = 0;
 

--- a/src/depackers/xz_dec_lzma2.c
+++ b/src/depackers/xz_dec_lzma2.c
@@ -211,19 +211,21 @@ struct lzma_dec {
 	uint16 literal[LITERAL_CODERS_MAX][LITERAL_CODER_SIZE];
 };
 
+enum lzma2_seq {
+	SEQ_CONTROL,
+	SEQ_UNCOMPRESSED_1,
+	SEQ_UNCOMPRESSED_2,
+	SEQ_COMPRESSED_0,
+	SEQ_COMPRESSED_1,
+	SEQ_PROPERTIES,
+	SEQ_LZMA_PREPARE,
+	SEQ_LZMA_RUN,
+	SEQ_COPY
+};
+
 struct lzma2_dec {
 	/* Position in xz_dec_lzma2_run(). */
-	enum lzma2_seq {
-		SEQ_CONTROL,
-		SEQ_UNCOMPRESSED_1,
-		SEQ_UNCOMPRESSED_2,
-		SEQ_COMPRESSED_0,
-		SEQ_COMPRESSED_1,
-		SEQ_PROPERTIES,
-		SEQ_LZMA_PREPARE,
-		SEQ_LZMA_RUN,
-		SEQ_COPY
-	} sequence;
+	enum lzma2_seq sequence;
 
 	/* Next position after decoding the compressed size of the chunk. */
 	enum lzma2_seq next_sequence;

--- a/src/depackers/xz_dec_stream.c
+++ b/src/depackers/xz_dec_stream.c
@@ -18,20 +18,28 @@ struct xz_dec_hash {
 	uint32 crc32;
 };
 
+enum dec_sequence_main  {
+	SEQ_STREAM_HEADER,
+	SEQ_BLOCK_START,
+	SEQ_BLOCK_HEADER,
+	SEQ_BLOCK_UNCOMPRESS,
+	SEQ_BLOCK_PADDING,
+	SEQ_BLOCK_CHECK,
+	SEQ_INDEX,
+	SEQ_INDEX_PADDING,
+	SEQ_INDEX_CRC32,
+	SEQ_STREAM_FOOTER
+};
+
+enum dec_sequence_index {
+	SEQ_INDEX_COUNT,
+	SEQ_INDEX_UNPADDED,
+	SEQ_INDEX_UNCOMPRESSED
+};
+
 struct xz_dec {
 	/* Position in dec_main() */
-	enum {
-		SEQ_STREAM_HEADER,
-		SEQ_BLOCK_START,
-		SEQ_BLOCK_HEADER,
-		SEQ_BLOCK_UNCOMPRESS,
-		SEQ_BLOCK_PADDING,
-		SEQ_BLOCK_CHECK,
-		SEQ_INDEX,
-		SEQ_INDEX_PADDING,
-		SEQ_INDEX_CRC32,
-		SEQ_STREAM_FOOTER
-	} sequence;
+	enum dec_sequence_main sequence;
 
 	/* Position in variable-length integers and Check fields */
 	uint32 pos;
@@ -97,11 +105,7 @@ struct xz_dec {
 	/* Variables needed when verifying the Index field */
 	struct {
 		/* Position in dec_index() */
-		enum {
-			SEQ_INDEX_COUNT,
-			SEQ_INDEX_UNPADDED,
-			SEQ_INDEX_UNCOMPRESSED
-		} sequence;
+		enum dec_sequence_index sequence;
 
 		/* Size of the Index in bytes */
 		vli_type size;

--- a/src/depackers/xz_dec_stream.c
+++ b/src/depackers/xz_dec_stream.c
@@ -56,7 +56,7 @@ struct xz_dec {
 	 * True if the next call to xz_dec_run() is allowed to return
 	 * XZ_BUF_ERROR.
 	 */
-	bool allow_buf_error;
+	xz_bool allow_buf_error;
 
 	/* Information stored in Block Header */
 	struct {
@@ -133,7 +133,7 @@ struct xz_dec {
 
 #ifdef XZ_DEC_BCJ
 	struct xz_dec_bcj *bcj;
-	bool bcj_active;
+	xz_bool bcj_active;
 #endif
 };
 
@@ -155,7 +155,7 @@ static const uint8 check_sizes[16] = {
  * to copy into s->temp.buf. Return true once s->temp.pos has reached
  * s->temp.size.
  */
-static bool fill_temp(struct xz_dec *s, struct xz_buf *b)
+static xz_bool fill_temp(struct xz_dec *s, struct xz_buf *b)
 {
 	size_t copy_size = min_t(size_t,
 			b->in_size - b->in_pos, s->temp.size - s->temp.pos);
@@ -166,10 +166,10 @@ static bool fill_temp(struct xz_dec *s, struct xz_buf *b)
 
 	if (s->temp.pos == s->temp.size) {
 		s->temp.pos = 0;
-		return true;
+		return xz_true;
 	}
 
-	return false;
+	return xz_false;
 }
 
 /* Decode a variable-length integer (little-endian base-128 encoding) */
@@ -368,11 +368,11 @@ static enum xz_ret libxmp_crc32_validate(struct xz_dec *s, struct xz_buf *b)
  * Skip over the Check field when the Check ID is not supported.
  * Returns true once the whole Check field has been skipped over.
  */
-static bool check_skip(struct xz_dec *s, struct xz_buf *b)
+static xz_bool check_skip(struct xz_dec *s, struct xz_buf *b)
 {
 	while (s->pos < check_sizes[s->check_type]) {
 		if (b->in_pos == b->in_size)
-			return false;
+			return xz_false;
 
 		++b->in_pos;
 		++s->pos;
@@ -380,7 +380,7 @@ static bool check_skip(struct xz_dec *s, struct xz_buf *b)
 
 	s->pos = 0;
 
-	return true;
+	return xz_true;
 }
 #endif
 
@@ -557,7 +557,7 @@ static enum xz_ret dec_main(struct xz_dec *s, struct xz_buf *b)
 	 */
 	s->in_start = b->in_pos;
 
-	while (true) {
+	for ( ;; ) {
 		switch (s->sequence) {
 		case SEQ_STREAM_HEADER:
 			/*
@@ -760,9 +760,9 @@ XZ_EXTERN enum xz_ret xz_dec_run(struct xz_dec *s, struct xz_buf *b)
 		if (s->allow_buf_error)
 			ret = XZ_BUF_ERROR;
 
-		s->allow_buf_error = true;
+		s->allow_buf_error = xz_true;
 	} else {
-		s->allow_buf_error = false;
+		s->allow_buf_error = xz_false;
 	}
 
 	return ret;
@@ -801,7 +801,7 @@ error_bcj:
 XZ_EXTERN void xz_dec_reset(struct xz_dec *s)
 {
 	s->sequence = SEQ_STREAM_HEADER;
-	s->allow_buf_error = false;
+	s->allow_buf_error = xz_false;
 	s->pos = 0;
 	s->crc32 = 0;
 	memzero(&s->block, sizeof(s->block));

--- a/src/depackers/xz_lzma2.h
+++ b/src/depackers/xz_lzma2.h
@@ -90,7 +90,7 @@ static inline void lzma_state_short_rep(enum lzma_state *state)
 }
 
 /* Test if the previous symbol was a literal. */
-static inline bool lzma_state_is_literal(enum lzma_state state)
+static inline xz_bool lzma_state_is_literal(enum lzma_state state)
 {
 	return state < LIT_STATES;
 }

--- a/src/depackers/xz_private.h
+++ b/src/depackers/xz_private.h
@@ -10,45 +10,7 @@
 #ifndef XZ_PRIVATE_H
 #define XZ_PRIVATE_H
 
-#ifdef __KERNEL__
-#	include <linux/xz.h>
-#	include <linux/kernel.h>
-#	include <asm/unaligned.h>
-	/* XZ_PREBOOT may be defined only via decompress_unxz.c. */
-#	ifndef XZ_PREBOOT
-#		include <linux/slab.h>
-#		include <linux/vmalloc.h>
-#		include <linux/string.h>
-#		ifdef CONFIG_XZ_DEC_X86
-#			define XZ_DEC_X86
-#		endif
-#		ifdef CONFIG_XZ_DEC_POWERPC
-#			define XZ_DEC_POWERPC
-#		endif
-#		ifdef CONFIG_XZ_DEC_IA64
-#			define XZ_DEC_IA64
-#		endif
-#		ifdef CONFIG_XZ_DEC_ARM
-#			define XZ_DEC_ARM
-#		endif
-#		ifdef CONFIG_XZ_DEC_ARMTHUMB
-#			define XZ_DEC_ARMTHUMB
-#		endif
-#		ifdef CONFIG_XZ_DEC_SPARC
-#			define XZ_DEC_SPARC
-#		endif
-#		define memeq(a, b, size) (memcmp(a, b, size) == 0)
-#		define memzero(buf, size) memset(buf, 0, size)
-#	endif
-#	define get_le32(p) le32_to_cpup((const uint32 *)(p))
-#else
-	/*
-	 * For userspace builds, use a separate header to define the required
-	 * macros and functions. This makes it easier to adapt the code into
-	 * different environments and avoids clutter in the Linux kernel tree.
-	 */
 #	include "xz_config.h"
-#endif
 
 /* If no specific decoding mode is requested, enable support for all modes. */
 #if !defined(XZ_DEC_SINGLE) && !defined(XZ_DEC_PREALLOC) \
@@ -66,27 +28,27 @@
 #ifdef XZ_DEC_SINGLE
 #	define DEC_IS_SINGLE(mode) ((mode) == XZ_SINGLE)
 #else
-#	define DEC_IS_SINGLE(mode) (false)
+#	define DEC_IS_SINGLE(mode) (xz_false)
 #endif
 
 #ifdef XZ_DEC_PREALLOC
 #	define DEC_IS_PREALLOC(mode) ((mode) == XZ_PREALLOC)
 #else
-#	define DEC_IS_PREALLOC(mode) (false)
+#	define DEC_IS_PREALLOC(mode) (xz_false)
 #endif
 
 #ifdef XZ_DEC_DYNALLOC
 #	define DEC_IS_DYNALLOC(mode) ((mode) == XZ_DYNALLOC)
 #else
-#	define DEC_IS_DYNALLOC(mode) (false)
+#	define DEC_IS_DYNALLOC(mode) (xz_false)
 #endif
 
 #if !defined(XZ_DEC_SINGLE)
-#	define DEC_IS_MULTI(mode) (true)
+#	define DEC_IS_MULTI(mode) (xz_true)
 #elif defined(XZ_DEC_PREALLOC) || defined(XZ_DEC_DYNALLOC)
 #	define DEC_IS_MULTI(mode) ((mode) != XZ_SINGLE)
 #else
-#	define DEC_IS_MULTI(mode) (false)
+#	define DEC_IS_MULTI(mode) (xz_false)
 #endif
 
 /*
@@ -130,7 +92,7 @@ XZ_EXTERN void xz_dec_lzma2_end(struct xz_dec_lzma2 *s);
  * Allocate memory for BCJ decoders. xz_dec_bcj_reset() must be used before
  * calling xz_dec_bcj_run().
  */
-XZ_EXTERN struct xz_dec_bcj *xz_dec_bcj_create(bool single_call);
+XZ_EXTERN struct xz_dec_bcj *xz_dec_bcj_create(xz_bool single_call);
 
 /*
  * Decode the Filter ID of a BCJ filter. This implementation doesn't

--- a/src/depackers/xz_stream.h
+++ b/src/depackers/xz_stream.h
@@ -10,13 +10,6 @@
 #ifndef XZ_STREAM_H
 #define XZ_STREAM_H
 
-#if defined(__KERNEL__) && !XZ_INTERNAL_CRC32
-#	include <linux/crc32.h>
-#	undef crc32
-#	define xz_crc32(buf, size, crc) \
-		(~crc32_le(~(uint32)(crc), buf, size))
-#endif
-
 /*
  * See the .xz file format specification at
  * http://tukaani.org/xz/xz-file-format.txt

--- a/src/hio.h
+++ b/src/hio.h
@@ -6,12 +6,14 @@
 
 #define HIO_HANDLE_TYPE(x) ((x)->type)
 
+enum hio_type {
+	HIO_HANDLE_TYPE_FILE,
+	HIO_HANDLE_TYPE_MEMORY,
+	HIO_HANDLE_TYPE_CBFILE
+};
+
 typedef struct {
-	enum {
-		HIO_HANDLE_TYPE_FILE,
-		HIO_HANDLE_TYPE_MEMORY,
-		HIO_HANDLE_TYPE_CBFILE
-	} type;
+	enum hio_type type;
 	long size;
 	union {
 		FILE *file;

--- a/src/med_extras.c
+++ b/src/med_extras.c
@@ -207,7 +207,6 @@ void libxmp_med_play_extras(struct context_data *ctx, struct channel_data *xc, i
 			ce->vp = temp;
 			loop = 1;
 			goto next_vt;
-			break;
 		case 0xfa:	/* JWS */
 			jws = VT;
 			break;
@@ -236,7 +235,6 @@ void libxmp_med_play_extras(struct context_data *ctx, struct channel_data *xc, i
 		}
 
 	    skip_vol:
-
 		/* volume envelope */
 		if (ce->env_wav >= 0) {
 			int sid = mod->xxi[xc->ins].sub[ce->env_wav].sid;
@@ -327,7 +325,6 @@ void libxmp_med_play_extras(struct context_data *ctx, struct channel_data *xc, i
 		}
 
 	    skip_wav:
-
 		xc->period += ce->wv;
 	}
 
@@ -385,10 +382,10 @@ int libxmp_med_new_module_extras(struct module_data *m)
 
 	me = (struct med_module_extras *)m->extra;
 
-        me->vol_table = calloc(sizeof(uint8 *), mod->ins);
+	me->vol_table = calloc(sizeof(uint8 *), mod->ins);
 	if (me->vol_table == NULL)
 		return -1;
-        me->wav_table = calloc(sizeof(uint8 *), mod->ins);
+	me->wav_table = calloc(sizeof(uint8 *), mod->ins);
 	if (me->wav_table == NULL)
 		return -1;
 
@@ -403,7 +400,7 @@ void libxmp_med_release_module_extras(struct module_data *m)
 
 	me = (struct med_module_extras *)m->extra;
 
-        if (me->vol_table) {
+	if (me->vol_table) {
 		for (i = 0; i < mod->ins; i++)
 			free(me->vol_table[i]);
 		free(me->vol_table);
@@ -413,7 +410,7 @@ void libxmp_med_release_module_extras(struct module_data *m)
 		for (i = 0; i < mod->ins; i++)
 			free(me->wav_table[i]);
 		free(me->wav_table);
-        }
+	}
 
 	free(m->extra);
 	m->extra = NULL;
@@ -423,7 +420,7 @@ void libxmp_med_extras_process_fx(struct context_data *ctx, struct channel_data 
 			int chn, uint8 note, uint8 fxt, uint8 fxp, int fnum)
 {
 	switch (fxt) {
-        case FX_MED_HOLD:
+	case FX_MED_HOLD:
 		MED_CHANNEL_EXTRAS((*xc))->hold_count++;
 		MED_CHANNEL_EXTRAS((*xc))->hold = 1;
 		break;


### PR DESCRIPTION
This patchset greatly reduces the number of errors from c++ compilers.
The normal C builds are not affected - e.g. the watcom-built os/2 dlls
before and after this patchset are identical.
