### PR TITLE
Fix missing free in test_depack_rar.c when unrar is missing.

### DIFF
--- a/test-dev/test_depack_rar.c
+++ b/test-dev/test_depack_rar.c
@@ -25,9 +25,8 @@ TEST(test_depack_rar)
 
 		ret = compare_module(info.mod, f);
 		fail_unless(ret == 0, "RARed module not correctly loaded");
-
-		xmp_release_module(c);
-		xmp_free_context(c);
 	}
+	xmp_release_module(c);
+	xmp_free_context(c);
 }
 END_TEST


### PR DESCRIPTION
These functions should always be called in this test, not just when opening the module succeeds. Not sure why I thought this was correct, but ASan errors for this test in my Fedora VM (where `unrar` is not available).