### PR TITLE
Fix crash when xmp_set_row is used on an IT end marker.

### DIFF
--- a/src/control.c
+++ b/src/control.c
@@ -185,16 +185,17 @@ int xmp_set_row(xmp_context opaque, int row)
 	struct xmp_module *mod = &m->mod;
 	struct flow_control *f = &p->flow;
 	int pos = p->pos;
-	int pattern = mod->xxo[pos];
+	int pattern;
 
 	if (pos < 0 || pos >= mod->len) {
 		pos = 0;
 	}
+	pattern = mod->xxo[pos];
 
 	if (ctx->state < XMP_STATE_PLAYING)
 		return -XMP_ERROR_STATE;
 
-	if (row >= mod->xxp[pattern]->rows)
+	if (pattern >= mod->pat || row >= mod->xxp[pattern]->rows)
 		return -XMP_ERROR_INVALID;
 
 	/* See set_position. */

--- a/test-dev/test_api_set_position.c
+++ b/test-dev/test_api_set_position.c
@@ -22,6 +22,8 @@ TEST(test_api_set_position)
 	set_order(ctx, 0, 0);
 	set_order(ctx, 1, 1);
 	set_order(ctx, 2, 0);
+	set_order(ctx, 3, 0xff); /* End marker. */
+	set_quirk(ctx, QUIRK_MARKER, READ_EVENT_IT);
 
 	libxmp_prepare_scan(ctx);
 	libxmp_scan_sequences(ctx);
@@ -35,6 +37,11 @@ TEST(test_api_set_position)
 	fail_unless(p->ord == 2, "didn't set position 2");
 
 	ret = xmp_set_position(opaque, 3);
+	fail_unless(ret == 3, "return value error (marker position)");
+	xmp_play_frame(opaque);
+	fail_unless(p->ord == 0, "didn't wrap to position 0");
+
+	ret = xmp_set_position(opaque, 4);
 	fail_unless(ret == -XMP_ERROR_INVALID, "return value error");
 
 	xmp_release_module(opaque);

--- a/test-dev/test_api_set_row.c
+++ b/test-dev/test_api_set_row.c
@@ -20,6 +20,8 @@ TEST(test_api_set_row)
 	create_simple_module(ctx, 1, 1);
 	libxmp_free_scan(ctx);
 	set_order(ctx, 0, 0);
+	set_order(ctx, 1, 0xff); /* End marker. */
+	set_quirk(ctx, QUIRK_MARKER, READ_EVENT_IT);
 
 	libxmp_prepare_scan(ctx);
 	libxmp_scan_sequences(ctx);
@@ -34,6 +36,14 @@ TEST(test_api_set_row)
 
 	ret = xmp_set_row(opaque, 64);
 	fail_unless(ret == -XMP_ERROR_INVALID, "return value error");
+
+	/* Go to end marker. */
+	ret = xmp_set_position(opaque, 1);
+	fail_unless(ret == 1, "set_position error");
+
+	/* Set row on a marker should just fail (meaningless). */
+	ret = xmp_set_row(opaque, 0);
+	fail_unless(ret == -XMP_ERROR_INVALID, "set row at marker");
 
 	xmp_free_context(opaque);
 }


### PR DESCRIPTION
`xmp_set_position` allows setting the current order to an IT end marker, but `xmp_set_row` was missing safety checks for this situation.