### PR TITLE
use the symver attribute, if available, for versioned symbols,

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -145,6 +145,12 @@ __attribute__((visibility("default"),externally_visible)) int foo(void);
 int foo(void) { return 0; }],
     [CFLAGS="${old_CFLAGS} -DHAVE_EXTERNAL_VISIBILITY"],
     [CFLAGS="${old_CFLAGS}"])
+
+   XMP_TRY_COMPILE(whether compiler understands attribute __symver__,
+    ac_cv_c_attribute_symver,[-Werror=attributes],[
+void foo(void) __attribute__((__symver__("foo@bar")));],
+    [CFLAGS="${CFLAGS} -DHAVE_ATTRIBUTE_SYMVER"],
+    [CFLAGS="${CFLAGS}"])
 fi
 
 dnl for clang

--- a/lite/configure.ac
+++ b/lite/configure.ac
@@ -144,6 +144,12 @@ __attribute__((visibility("default"),externally_visible)) int foo(void);
 int foo(void) { return 0; }],
     [CFLAGS="${old_CFLAGS} -DHAVE_EXTERNAL_VISIBILITY"],
     [CFLAGS="${old_CFLAGS}"])
+
+   XMP_TRY_COMPILE(whether compiler understands attribute __symver__,
+    ac_cv_c_attribute_symver,[-Werror=attributes],[
+void foo(void) __attribute__((__symver__("foo@bar")));],
+    [CFLAGS="${CFLAGS} -DHAVE_ATTRIBUTE_SYMVER"],
+    [CFLAGS="${CFLAGS}"])
 fi
 
 dnl for clang

--- a/src/common.h
+++ b/src/common.h
@@ -29,6 +29,11 @@
 #else
 #define LIBXMP_EXPORT_VERSIONED __attribute__((visibility("default")))
 #endif
+#ifdef HAVE_ATTRIBUTE_SYMVER
+#define LIBXMP_ATTRIB_SYMVER(_sym) __attribute__((__symver__(_sym)))
+#else
+#define LIBXMP_ATTRIB_SYMVER(_sym)
+#endif
 #endif
 #endif
 

--- a/src/control.c
+++ b/src/control.c
@@ -310,18 +310,20 @@ int xmp_channel_vol(xmp_context opaque, int chn, int vol)
 }
 
 #ifdef USE_VERSIONED_SYMBOLS
-LIBXMP_EXPORT_VERSIONED extern int xmp_set_player_v40__(xmp_context, int, int);
+LIBXMP_EXPORT_VERSIONED extern int xmp_set_player_v40__(xmp_context, int, int) LIBXMP_ATTRIB_SYMVER("xmp_set_player@XMP_4.0");
 LIBXMP_EXPORT_VERSIONED extern int xmp_set_player_v41__(xmp_context, int, int)
-			__attribute__((alias("xmp_set_player_v40__")));
+			__attribute__((alias("xmp_set_player_v40__"))) LIBXMP_ATTRIB_SYMVER("xmp_set_player@XMP_4.1");
 LIBXMP_EXPORT_VERSIONED extern int xmp_set_player_v43__(xmp_context, int, int)
-			__attribute__((alias("xmp_set_player_v40__")));
+			__attribute__((alias("xmp_set_player_v40__"))) LIBXMP_ATTRIB_SYMVER("xmp_set_player@XMP_4.3");
 LIBXMP_EXPORT_VERSIONED extern int xmp_set_player_v44__(xmp_context, int, int)
-			__attribute__((alias("xmp_set_player_v40__")));
+			__attribute__((alias("xmp_set_player_v40__"))) LIBXMP_ATTRIB_SYMVER("xmp_set_player@@XMP_4.4");
 
+#ifndef HAVE_ATTRIBUTE_SYMVER
 asm(".symver xmp_set_player_v40__, xmp_set_player@XMP_4.0");
 asm(".symver xmp_set_player_v41__, xmp_set_player@XMP_4.1");
 asm(".symver xmp_set_player_v43__, xmp_set_player@XMP_4.3");
 asm(".symver xmp_set_player_v44__, xmp_set_player@@XMP_4.4");
+#endif
 
 #define xmp_set_player__ xmp_set_player_v40__
 #else
@@ -428,21 +430,23 @@ int xmp_set_player__(xmp_context opaque, int parm, int val)
 }
 
 #ifdef USE_VERSIONED_SYMBOLS
-LIBXMP_EXPORT_VERSIONED extern int xmp_get_player_v40__(xmp_context, int);
+LIBXMP_EXPORT_VERSIONED extern int xmp_get_player_v40__(xmp_context, int) LIBXMP_ATTRIB_SYMVER("xmp_get_player@XMP_4.0");
 LIBXMP_EXPORT_VERSIONED extern int xmp_get_player_v41__(xmp_context, int)
-		__attribute__((alias("xmp_get_player_v40__")));
+		__attribute__((alias("xmp_get_player_v40__"))) LIBXMP_ATTRIB_SYMVER("xmp_get_player@XMP_4.1");
 LIBXMP_EXPORT_VERSIONED extern int xmp_get_player_v42__(xmp_context, int)
-		__attribute__((alias("xmp_get_player_v40__")));
+		__attribute__((alias("xmp_get_player_v40__"))) LIBXMP_ATTRIB_SYMVER("xmp_get_player@XMP_4.2");
 LIBXMP_EXPORT_VERSIONED extern int xmp_get_player_v43__(xmp_context, int)
-		__attribute__((alias("xmp_get_player_v40__")));
+		__attribute__((alias("xmp_get_player_v40__"))) LIBXMP_ATTRIB_SYMVER("xmp_get_player@XMP_4.3");
 LIBXMP_EXPORT_VERSIONED extern int xmp_get_player_v44__(xmp_context, int)
-		__attribute__((alias("xmp_get_player_v40__")));
+		__attribute__((alias("xmp_get_player_v40__"))) LIBXMP_ATTRIB_SYMVER("xmp_get_player@@XMP_4.4");
 
+#ifndef HAVE_ATTRIBUTE_SYMVER
 asm(".symver xmp_get_player_v40__, xmp_get_player@XMP_4.0");
 asm(".symver xmp_get_player_v41__, xmp_get_player@XMP_4.1");
 asm(".symver xmp_get_player_v42__, xmp_get_player@XMP_4.2");
 asm(".symver xmp_get_player_v43__, xmp_get_player@XMP_4.3");
 asm(".symver xmp_get_player_v44__, xmp_get_player@@XMP_4.4");
+#endif
 
 #define xmp_get_player__ xmp_get_player_v40__
 #else


### PR DESCRIPTION
e.g. with gcc >= 10.
Co-authored-by: Claudio Matsuoka
Closes: https://github.com/libxmp/libxmp/issues/385