### PR TITLE
Move IT sample decompression declarations to it.h.

### DIFF
--- a/src/loaders/it.h
+++ b/src/loaders/it.h
@@ -20,6 +20,11 @@
  * THE SOFTWARE.
  */
 
+#ifndef LIBXMP_LOADERS_IT_H
+#define LIBXMP_LOADERS_IT_H
+
+#include "loader.h"
+
 /* IT flags */
 #define IT_STEREO	0x01
 #define IT_VOL_OPT	0x02	/* Not recognized */
@@ -179,3 +184,7 @@ struct it_sample_header {
 	uint8 vit;		/* Vibrato waveform */
 };
 
+int itsex_decompress8(HIO_HANDLE *src, uint8 *dst, int len, int it215);
+int itsex_decompress16(HIO_HANDLE *src, int16 *dst, int len, int it215);
+
+#endif /* LIBXMP_LOADERS_IT_H */

--- a/src/loaders/it_load.c
+++ b/src/loaders/it_load.c
@@ -91,11 +91,6 @@ static const uint8 fx[32] = {
 	/* ? */ FX_NONE
 };
 
-
-int itsex_decompress8 (HIO_HANDLE *, void *, int, int);
-int itsex_decompress16 (HIO_HANDLE *, void *, int, int);
-
-
 static void xlat_fx(int c, struct xmp_event *e, uint8 *last_fxp, int new_fx)
 {
 	uint8 h = MSN(e->fxp), l = LSN(e->fxp);
@@ -863,7 +858,7 @@ static int load_it_sample(struct module_data *m, int i, int start,
 				return -1;
 
 			if (ish.flags & IT_SMP_16BIT) {
-				itsex_decompress16(f, buf, xxs->len,
+				itsex_decompress16(f, (int16 *)buf, xxs->len,
 						   ish.convert & IT_CVT_DIFF);
 
 #ifdef WORDS_BIGENDIAN

--- a/src/loaders/itsex.c
+++ b/src/loaders/itsex.c
@@ -3,6 +3,7 @@
 /* Public domain IT sample decompressor by Olivier Lapicque */
 
 #include "loader.h"
+#include "it.h"
 
 static inline uint32 read_bits(HIO_HANDLE *ibuf, uint32 *bitbuf, int *bitnum, int n)
 {

--- a/test-dev/test_depack_it_sample_16bit.c
+++ b/test-dev/test_depack_it_sample_16bit.c
@@ -1,7 +1,6 @@
 #include "test.h"
 #include "../src/loaders/loader.h"
-
-int itsex_decompress16(HIO_HANDLE *module, void *dst, int len, char it215);
+#include "../src/loaders/it.h"
 
 
 TEST(test_depack_it_sample_16bit)
@@ -17,7 +16,7 @@ TEST(test_depack_it_sample_16bit)
 	fo = fopen(TMP_FILE, "wb");
 	fail_unless(fo != NULL, "can't open output file");
 
-	ret = itsex_decompress16(f, dest, 4646, 0);
+	ret = itsex_decompress16(f, (int16 *)dest, 4646, 0);
 	fail_unless(ret == 0, "decompression fail");
 
 	if (is_big_endian()) {

--- a/test-dev/test_depack_it_sample_8bit.c
+++ b/test-dev/test_depack_it_sample_8bit.c
@@ -1,7 +1,6 @@
 #include "test.h"
 #include "../src/loaders/loader.h"
-
-int itsex_decompress8(HIO_HANDLE *module, void *dst, int len, char it215);
+#include "../src/loaders/it.h"
 
 
 TEST(test_depack_it_sample_8bit)
@@ -9,7 +8,7 @@ TEST(test_depack_it_sample_8bit)
 	HIO_HANDLE *f;
 	FILE *fo;
 	int ret;
-	char dest[10000];
+	uint8 dest[10000];
 
 	f = hio_open("data/it-sample-8bit.raw", "rb");
 	fail_unless(f != NULL, "can't open data file");


### PR DESCRIPTION
This should fix a warning that occurs when building the regression tests with -flto (and is a better practice than leaving declarations everywhere).