### PR TITLE
Fix linking for gen_module_data utility.

### DIFF
--- a/test-dev/Makefile.in
+++ b/test-dev/Makefile.in
@@ -626,7 +626,7 @@ gen_mixer_data: gen_mixer_data.o
 	if [ "$(V)" -gt 0 ]; then echo $$CMD; else echo LD $@ ; fi; \
 	eval $$CMD
 
-gen_module_data: gen_module_data.o util.o ${SRC_PATH}/md5.o
+gen_module_data: gen_module_data.o util.o ${SRC_PATH}/hio.o ${SRC_PATH}/dataio.o ${SRC_PATH}/memio.o ${SRC_PATH}/md5.o
 	@CMD='$(LD) $(LDFLAGS) -o $@ $^ -L../lib -lxmp $(LIBS)'; \
 	if [ "$(V)" -gt 0 ]; then echo $$CMD; else echo LD $@ ; fi; \
 	eval $$CMD


### PR DESCRIPTION
Split from #398. The utility `gen_module_data` fails to link due to `util.o` depending on `hio.o`. This regression was introduced by #388.