### PR TITLE
fix several -Wshadow warnings.

### DIFF
--- a/src/depackers/mmcmp.c
+++ b/src/depackers/mmcmp.c
@@ -354,8 +354,6 @@ static int decrunch_mmcmp(FILE *in, FILE *out)
 			goto err2;
 
 		for (j = 0; j < block.sub_blk; j++) {
-			uint8 buf[8];
-
 			if (fread(buf, 1, 8, in) != 8) {
 				free(sub_block);
 				goto err2;
@@ -364,7 +362,7 @@ static int decrunch_mmcmp(FILE *in, FILE *out)
 			sub_block[j].unpk_pos  = readmem32l(buf);
 			sub_block[j].unpk_size = readmem32l(buf + 4);
 
-	                /* Sanity check */
+			/* Sanity check */
 			if (sub_block[j].unpk_pos < 0 ||
 			    sub_block[j].unpk_size < 0) {
 				free(sub_block);

--- a/src/depackers/uncompress.c
+++ b/src/depackers/uncompress.c
@@ -117,15 +117,15 @@ static int decrunch_compress(FILE * in, FILE * out)
 	do {
 	      resetbuf:;
 		{
-			int i;
+			int idx;
 			int e;
 			int o;
 
 			o = posbits >> 3;
 			e = o <= insize ? insize - o : 0;
 
-			for (i = 0; i < e; ++i)
-				inbuf[i] = inbuf[i + o];
+			for (idx = 0; idx < e; ++idx)
+				inbuf[idx] = inbuf[idx + o];
 
 			insize = e;
 			posbits = 0;

--- a/src/load.c
+++ b/src/load.c
@@ -68,11 +68,11 @@ static void set_md5sum(HIO_HANDLE *f, unsigned char *digest)
 static char *get_dirname(const char *name)
 {
 	char *dirname;
-	const char *div;
+	const char *p;
 	ptrdiff_t len;
 
-	if ((div = strrchr(name, '/')) != NULL) {
-		len = div - name + 1;
+	if ((p = strrchr(name, '/')) != NULL) {
+		len = p - name + 1;
 		dirname = malloc(len + 1);
 		if (dirname != NULL) {
 			memcpy(dirname, name, len);
@@ -87,11 +87,11 @@ static char *get_dirname(const char *name)
 
 static char *get_basename(const char *name)
 {
-	const char *div;
+	const char *p;
 	char *basename;
 
-	if ((div = strrchr(name, '/')) != NULL) {
-		basename = strdup(div + 1);
+	if ((p = strrchr(name, '/')) != NULL) {
+		basename = strdup(p + 1);
 	} else {
 		basename = strdup(name);
 	}

--- a/src/loaders/amf_load.c
+++ b/src/loaders/amf_load.c
@@ -176,7 +176,7 @@ static int amf_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	 */
 	if (ver == 0x0a) {
 		uint8 b;
-		uint32 len, start, end;
+		uint32 len, val;
 		long pos = hio_tell(f);
 		if (pos < 0) {
 			return -1;
@@ -205,13 +205,13 @@ static int amf_load(struct module_data *m, HIO_HANDLE *f, const int start)
 				no_loopend = 1;
 				break;
 			}
-			start = hio_read32l(f);
-			if (start > len) {		/* check loop start */
+			val = hio_read32l(f);		/* check loop start */
+			if (val > len) {
 				no_loopend = 1;
 				break;
 			}
-			end = hio_read32l(f);
-			if (end > len) {		/* check loop end */
+			val = hio_read32l(f);		/* check loop end */
+			if (val > len) {
 				no_loopend = 1;
 				break;
 			}

--- a/src/loaders/common.c
+++ b/src/loaders/common.c
@@ -309,7 +309,6 @@ int libxmp_copy_name_for_fopen(char *dest, const char *name, int n)
 	    name[0] == '\\' || name[0] == '/' || name[0] == ':')
 		return -1;
 
-
 	for (i = 0; i < n - 1; i++) {
 		uint8 t = name[i];
 		if (!t)
@@ -472,14 +471,14 @@ int libxmp_check_filename_case(const char *dir, const char *name, char *new_name
 int libxmp_check_filename_case(const char *dir, const char *name, char *new_name, int size)
 {
 	int found = 0;
-	DIR *dirfd;
+	DIR *dirp;
 	struct dirent *d;
 
-	dirfd = opendir(dir);
-	if (dirfd == NULL)
+	dirp = opendir(dir);
+	if (dirp == NULL)
 		return 0;
 
-	while ((d = readdir(dirfd)) != NULL) {
+	while ((d = readdir(dirp)) != NULL) {
 		if (!strcasecmp(d->d_name, name)) {
 			found = 1;
 			break;
@@ -489,7 +488,7 @@ int libxmp_check_filename_case(const char *dir, const char *name, char *new_name
 	if (found)
 		strncpy(new_name, d->d_name, size);
 
-	closedir(dirfd);
+	closedir(dirp);
 
 	return found;
 }

--- a/src/loaders/mdl_load.c
+++ b/src/loaders/mdl_load.c
@@ -99,16 +99,16 @@ struct local_data {
 
 
 static void fix_env(int i, struct xmp_envelope *ei, struct mdl_envelope *env,
-		    int *index, int envnum)
+		    int *idx, int envnum)
 {
     int j, k, lastx;
 
-    if (index[i] >= 0) {
+    if (idx[i] >= 0) {
 	ei->flg = XMP_ENVELOPE_ON;
 	ei->npt = 15;
 
 	for (j = 0; j < envnum; j++) {
-    	    if (index[i] == env[j].num) {
+    	    if (idx[i] == env[j].num) {
     	        ei->flg |= env[j].sus & 0x10 ? XMP_ENVELOPE_SUS : 0;
     	        ei->flg |= env[j].sus & 0x20 ? XMP_ENVELOPE_LOOP : 0;
     	        ei->sus = env[j].sus & 0x0f;

--- a/src/loaders/med4_load.c
+++ b/src/loaders/med4_load.c
@@ -148,13 +148,14 @@ static inline uint16 stream_read_aligned16(struct stream* s, int bits)
 {
 	if (bits <= 4) {
 		return stream_read4(s) << 12;
-	} else if (bits <= 8) {
-		return stream_read8(s) << 8;
-	} else if (bits <= 12) {
-		return stream_read12(s) << 4;
-	} else {
-		return stream_read16(s);
 	}
+	if (bits <= 8) {
+		return stream_read8(s) << 8;
+	}
+	if (bits <= 12) {
+		return stream_read12(s) << 4;
+	}
+	return stream_read16(s);
 }
 
 struct temp_inst {
@@ -172,7 +173,8 @@ static int med4_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	uint8 m0;
 	uint64 mask;
 	int transp, masksz;
-	int pos, vermaj, vermin;
+	int32 pos;
+	int vermaj, vermin;
 	uint8 trkvol[16], buf[1024];
 	struct xmp_event *event;
 	int flags, hexvol = 0;
@@ -586,8 +588,7 @@ static int med4_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		 */
 
 		if (type == -2) {			/* Hybrid */
-			int length, type;
-			int pos = hio_tell(f);
+			pos = hio_tell(f);
 			if (pos < 0) {
 				return -1;
 			}
@@ -659,7 +660,7 @@ static int med4_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		}
 
 		if (type == -1) {		/* Synthetic */
-			int pos = hio_tell(f);
+			pos = hio_tell(f);
 			if (pos < 0) {
 				return -1;
 			}
@@ -804,7 +805,7 @@ static int med4_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	/* IFF-like section */
 parse_iff:
 	while (!hio_eof(f)) {
-		int32 id, size, s2, pos, ver;
+		int32 id, size, s2, ver;
 
 		if ((id = hio_read32b(f)) <= 0)
 			break;

--- a/src/loaders/mfp_load.c
+++ b/src/loaders/mfp_load.c
@@ -142,11 +142,11 @@ static int mfp_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		if (mod->xxs[i].len > 0)
 			mod->xxi[i].nsm = 1;
 
-               	D_(D_INFO "[%2X] %04x %04x %04x %c V%02x %+d",
-                       	i, mod->xxs[i].len, mod->xxs[i].lps,
-                       	mod->xxs[i].lpe,
+		D_(D_INFO "[%2X] %04x %04x %04x %c V%02x %+d",
+			i, mod->xxs[i].len, mod->xxs[i].lps,
+			mod->xxs[i].lpe,
 			loop_size > 1 ? 'L' : ' ',
-                       	mod->xxi[i].sub[0].vol, mod->xxi[i].sub[0].fin >> 4);
+			mod->xxi[i].sub[0].vol, mod->xxi[i].sub[0].fin >> 4);
 	}
 
 	mod->len = mod->pat = hio_read8(f);
@@ -225,11 +225,10 @@ static int mfp_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	snprintf(smp_filename, PATH_MAX, "%s%s", m->dirname, m->basename);
 	if (stat(smp_filename, &st) < 0) {
 		/* handle .set filenames like in Kid Chaos*/
-		char *x;
 		if (strchr(m->basename, '-')) {
-			x = strrchr(smp_filename, '-');
-			if (x != NULL)
-				strcpy(x, ".set");
+			char *p = strrchr(smp_filename, '-');
+			if (p != NULL)
+				strcpy(p, ".set");
 		}
 		if (stat(smp_filename, &st) < 0) {
 			fprintf(stderr, "libxmp: missing file %s\n",

--- a/src/loaders/prowizard/heatseek.c
+++ b/src/loaders/prowizard/heatseek.c
@@ -79,7 +79,7 @@ static int depack_crb(HIO_HANDLE *in, FILE *out)
 
 					hio_seek(in, taddr[m >> 2], SEEK_SET);
 					for (m = 0; m < 64; m++) {
-						int x = m * 16 + j * 4;
+						x = m * 16 + j * 4;
 
 						c1 = hio_read8(in);
 						if (c1 == 0x80) {

--- a/src/loaders/prowizard/mp.c
+++ b/src/loaders/prowizard/mp.c
@@ -124,15 +124,15 @@ static int test_mp_noid(const uint8 *data, char *t, int s)
 	/* test #5  ptk notes .. gosh ! (testing all patterns !) */
 	for (i = 0; i < psize; i++) {
 		const uint8 *d = data + 378 + i * 4;
-		uint16 data;
+		uint16 val;
 
 		/* MadeInCroatia has l == 74 */
 		if (*d > 19 && *d != 74)
 			return -1;
 
-		data = readmem16b(d) & 0x0fff;
+		val = readmem16b(d) & 0x0fff;
 
-		if (data > 0 && data < 0x71)
+		if (val > 0 && val < 0x71)
 			return -1;
 	}
 

--- a/src/loaders/prowizard/np3.c
+++ b/src/loaders/prowizard/np3.c
@@ -99,7 +99,7 @@ static int depack_np3(HIO_HANDLE *in, FILE *out)
 
 			hio_seek(in, trk_start + trk_addr[i][3 - j], SEEK_SET);
 			for (k = 0; k < 64; k++) {
-				int x = k * 16 + j * 4;
+				x = k * 16 + j * 4;
 
 				if ((c1 = hio_read8(in)) >= 0x80) {
 					k += (0x100 - c1) - 1;

--- a/src/loaders/prowizard/p61a.c
+++ b/src/loaders/prowizard/p61a.c
@@ -38,7 +38,7 @@ static int depack_p61a(HIO_HANDLE *in, FILE *out)
     int smp_size[31];
     int saddr[31];
     int Unpacked_Sample_Data_Size;
-    int x;
+    int val;
 
     memset(taddr, 0, sizeof(taddr));
     memset(tdata, 0, sizeof(tdata));
@@ -107,14 +107,14 @@ static int depack_p61a(HIO_HANDLE *in, FILE *out)
 	write8(out, hio_read8(in));		/* volume */
 
 	/* loop start */
-	x = hio_read16b(in);
-	if (x == 0xffff) {
+	val = hio_read16b(in);
+	if (val == 0xffff) {
 	    write16b(out, 0x0000);
 	    write16b(out, 0x0001);
 	    continue;
 	}
-	write16b(out, x);
-	write16b(out, j - x);
+	write16b(out, val);
+	write16b(out, j - val);
     }
 
     /* go up to 31 samples */

--- a/src/loaders/prowizard/tp1.c
+++ b/src/loaders/prowizard/tp1.c
@@ -176,14 +176,14 @@ static int test_tp1(const uint8 *data, char *t, int s)
 	/* test sample sizes */
 	for (i = 0; i < 31; i++) {
 		const uint8 *d = data + i * 8 + 32;
-		int len = readmem16b(d + 2) << 1;	/* size */
+		int sz  = readmem16b(d + 2) << 1;	/* size */
 		int start = readmem16b(d + 4) << 1;	/* loop start */
 		int lsize = readmem16b(d + 6) << 1;	/* loop size */
 
-		if (len > 0xffff || start > 0xffff || lsize > 0xffff)
+		if (sz > 0xffff || start > 0xffff || lsize > 0xffff)
 			return -1;
 
-		if (start + lsize > len + 2)
+		if (start + lsize > sz + 2)
 			return -1;
 
 		if (start != 0 && lsize == 0)

--- a/src/loaders/sample.c
+++ b/src/loaders/sample.c
@@ -102,17 +102,17 @@ static void adpcm4_decoder(uint8 *inp, uint8 *outp, char *tab, int len)
 static void convert_delta(uint8 *p, int l, int r)
 {
 	uint16 *w = (uint16 *)p;
-	uint16 abs = 0;
+	uint16 absval = 0;
 
 	if (r) {
 		for (; l--;) {
-			abs = *w + abs;
-			*w++ = abs;
+			absval = *w + absval;
+			*w++ = absval;
 		}
 	} else {
 		for (; l--;) {
-			abs = *p + abs;
-			*p++ = (uint8) abs;
+			absval = *p + absval;
+			*p++ = (uint8) absval;
 		}
 	}
 }

--- a/src/loaders/sym_load.c
+++ b/src/loaders/sym_load.c
@@ -428,15 +428,14 @@ static int sym_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		return -1;
 
 	/* Load and convert instruments */
-
 	D_(D_INFO "Instruments: %d", mod->ins);
 
 	for (i = 0; i < mod->ins; i++) {
-		uint8 buf[128];
+		uint8 namebuf[128];
 
-		memset(buf, 0, sizeof(buf));
-		hio_read(buf, 1, sn[i] & 0x7f, f);
-		libxmp_instrument_name(mod, i, buf, 32);
+		memset(namebuf, 0, sizeof(namebuf));
+		hio_read(namebuf, 1, sn[i] & 0x7f, f);
+		libxmp_instrument_name(mod, i, namebuf, 32);
 
 		if (~sn[i] & 0x80) {
 			int looplen;
@@ -471,14 +470,14 @@ static int sym_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		}
 
 		if (a == 1) {
-			uint8 *b = malloc(mod->xxs[i].len);
-			libxmp_read_lzw_dynamic(f->handle.file, b, 13, 0,
-					mod->xxs[i].len, mod->xxs[i].len,
+			void *dec = malloc(mod->xxs[i].len);
+			libxmp_read_lzw_dynamic(f->handle.file, (uint8 *)dec,
+					13, 0, mod->xxs[i].len, mod->xxs[i].len,
 					XMP_LZW_QUIRK_DSYM);
 			ret = libxmp_load_sample(m, NULL,
 					SAMPLE_FLAG_NOLOAD | SAMPLE_FLAG_DIFF,
-					&mod->xxs[i], (char*)b);
-			free(b);
+					&mod->xxs[i], dec);
+			free(dec);
 		/*} else if (a == 4) {
 			ret = libxmp_load_sample(m, f, SAMPLE_FLAG_VIDC,
 					&mod->xxs[i], NULL);*/

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -463,13 +463,13 @@ void libxmp_mixer_softmixer(struct context_data *ctx)
 				samples = 0;
 				usmp = 1;
 			} else {
-				int s = ceil(((double)vi->end - vi->pos) / step);
+				int c = ceil(((double)vi->end - vi->pos) / step);
 				/* ...inside the tick boundaries */
-				if (s > size) {
-					s = size;
+				if (c > size) {
+					c = size;
 				}
 
-				samples = s;
+				samples = c;
 				if (samples > 0) {
 					usmp = 0;
 				}

--- a/src/player.c
+++ b/src/player.c
@@ -69,15 +69,15 @@ static const struct retrig_control rval[] = {
 static int check_envelope_end(struct xmp_envelope *env, int x)
 {
 	int16 *data = env->data;
-	int index;
+	int idx;
 
 	if (~env->flg & XMP_ENVELOPE_ON || env->npt <= 0)
 		return 0;
 
-	index = (env->npt - 1) * 2;
+	idx = (env->npt - 1) * 2;
 
 	/* last node */
-	if (x >= data[index] || index == 0) {
+	if (x >= data[idx] || idx == 0) {
 		if (~env->flg & XMP_ENVELOPE_LOOP) {
 			return 1;
 		}
@@ -90,27 +90,27 @@ static int get_envelope(struct xmp_envelope *env, int x, int def)
 {
 	int x1, x2, y1, y2;
 	int16 *data = env->data;
-	int index;
+	int idx;
 
 	if (x < 0 || ~env->flg & XMP_ENVELOPE_ON || env->npt <= 0)
 		return def;
 
-	index = (env->npt - 1) * 2;
+	idx = (env->npt - 1) * 2;
 
-	x1 = data[index];		/* last node */
-	if (x >= x1 || index == 0) {
-		return data[index + 1];
+	x1 = data[idx]; /* last node */
+	if (x >= x1 || idx == 0) {
+		return data[idx + 1];
 	}
 
 	do {
-		index -= 2;
-		x1 = data[index];
-	} while (index > 0 && x1 > x);
+		idx -= 2;
+		x1 = data[idx];
+	} while (idx > 0 && x1 > x);
 
 	/* interpolate */
-	y1 = data[index + 1];
-	x2 = data[index + 2];
-	y2 = data[index + 3];
+	y1 = data[idx + 1];
+	x2 = data[idx + 2];
+	y2 = data[idx + 3];
 
 	return x2 == x1 ? y2 : ((y2 - y1) * (x - x1) / (x2 - x1)) + y1;
 }
@@ -232,14 +232,14 @@ static int update_envelope(struct xmp_envelope *env, int x, int release, int key
 static int check_envelope_fade(struct xmp_envelope *env, int x)
 {
 	int16 *data = env->data;
-	int index;
+	int idx;
 
 	if (~env->flg & XMP_ENVELOPE_ON)
 		return 0;
 
-	index = (env->npt - 1) * 2;		/* last node */
-	if (x > data[index]) {
-		if (data[index + 1] == 0)
+	idx = (env->npt - 1) * 2;		/* last node */
+	if (x > data[idx]) {
+		if (data[idx + 1] == 0)
 			return -1;
 		else
 			return 1;

--- a/src/read_event.c
+++ b/src/read_event.c
@@ -67,7 +67,7 @@ static void reset_envelopes(struct context_data *ctx, struct channel_data *xc)
 	if (!IS_VALID_INSTRUMENT(xc->ins))
 		return;
 
- 	RESET_NOTE(NOTE_ENV_END);
+	RESET_NOTE(NOTE_ENV_END);
 
 	xc->v_idx = -1;
 	xc->p_idx = -1;
@@ -457,19 +457,17 @@ static int read_event_ft2(struct context_data *ctx, struct xmp_event *e, int chn
 	/* FT2: Retrieve old instrument volume */
 	if (ins) {
 		if (key == 0 || key >= XMP_KEY_OFF) {
-			struct xmp_subinstrument *sub;
-
 			/* Previous instrument */
 			sub = get_subinstrument(ctx, xc->ins, xc->key);
 
 			/* No note */
 			if (sub != NULL) {
-				int p = mod->xxc[chn].pan - 128;
+				int pan = mod->xxc[chn].pan - 128;
 				xc->volume = sub->vol;
 
 				if (!HAS_QUIRK(QUIRK_FTMOD)) {
-					xc->pan.val = p + ((sub->pan - 128) *
-						(128 - abs(p))) / 128 + 128;
+					xc->pan.val = pan + ((sub->pan - 128) *
+						(128 - abs(pan))) / 128 + 128;
 				}
 
 				xc->ins_fade = mod->xxi[xc->ins].rls;
@@ -516,11 +514,8 @@ static int read_event_ft2(struct context_data *ctx, struct xmp_event *e, int chn
 	}
 
 	/* Check note */
-
 	if (ins) {
 		if (key > 0 && key < XMP_KEY_OFF) {
-			struct xmp_subinstrument *sub;
-
 			/* Retrieve volume when we have note */
 
 			/* and only if we have instrument, otherwise we're in
@@ -530,12 +525,12 @@ static int read_event_ft2(struct context_data *ctx, struct xmp_event *e, int chn
 			/* Current instrument */
 			sub = get_subinstrument(ctx, xc->ins, key - 1);
 			if (sub != NULL) {
-				int p = mod->xxc[chn].pan - 128;
+				int pan = mod->xxc[chn].pan - 128;
 				xc->volume = sub->vol;
 
 				if (!HAS_QUIRK(QUIRK_FTMOD)) {
-					xc->pan.val = p + ((sub->pan - 128) *
-						(128 - abs(p))) / 128 + 128;
+					xc->pan.val = pan + ((sub->pan - 128) *
+						(128 - abs(pan))) / 128 + 128;
 				}
 
 				xc->ins_fade = mod->xxi[xc->ins].rls;

--- a/src/scan.c
+++ b/src/scan.c
@@ -73,7 +73,7 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
 	return 0;
 
     for (i = 0; i < mod->len; i++) {
-	int pat = mod->xxo[i];
+	pat = mod->xxo[i];
 	memset(m->scan_cnt[i], 0, pat >= mod->pat ? 1 :
 			mod->xxp[pat]->rows ? mod->xxp[pat]->rows : 1);
     }


### PR DESCRIPTION
This fixes many `-Wshadow` warnings from gcc:
```
src/read_event.c: In function 'read_event_ft2':
src/read_event.c:460:30: warning: declaration of 'sub' shadows a previous local
src/read_event.c:389:28: warning: shadowed declaration is here
src/read_event.c:467:9: warning: declaration of 'p' shadows a previous local
src/read_event.c:384:22: warning: shadowed declaration is here
src/read_event.c:522:30: warning: declaration of 'sub' shadows a previous local
src/read_event.c:389:28: warning: shadowed declaration is here
src/read_event.c:533:9: warning: declaration of 'p' shadows a previous local
src/read_event.c:384:22: warning: shadowed declaration is here

src/scan.c: In function 'scan_module':
src/scan.c:76:6: warning: declaration of 'pat' shadows a previous local
src/scan.c:65:12: warning: shadowed declaration is here

src/mixer.c: In function 'libxmp_mixer_softmixer':
src/mixer.c:466:9: warning: declaration of 's' shadows a previous local
src/mixer.c:331:21: warning: shadowed declaration is here

src/load.c: In function 'get_dirname':
src/load.c:71:14: warning: declaration of 'div' shadows a global declaration
src/load.c: In function 'get_basename':
src/load.c:90:14: warning: declaration of 'div' shadows a global declaration

src/loaders/sample.c: In function 'convert_delta':
src/loaders/sample.c:105:9: warning: declaration of 'abs' shadows a global declaration

src/loaders/it_load.c: In function 'load_it_sample':
src/loaders/it_load.c:831:11: warning: declaration of 'buf' shadows a previous local
src/loaders/it_load.c:687:8: warning: shadowed declaration is here

src/loaders/amf_load.c: In function 'amf_load':
src/loaders/amf_load.c:179:15: warning: declaration of 'start' shadows a parameter
src/loaders/amf_load.c:66:69: warning: shadowed declaration is here

src/loaders/sym_load.c: In function 'sym_load':
src/loaders/sym_load.c:435:9: warning: declaration of 'buf' shadows a previous local
src/loaders/sym_load.c:259:9: warning: shadowed declaration is here
src/loaders/sym_load.c:474:11: warning: declaration of 'b' shadows a previous local
src/loaders/sym_load.c:258:12: warning: shadowed declaration is here

src/loaders/med4_load.c: In function 'med4_load':
src/loaders/med4_load.c:589:8: warning: declaration of 'length' shadows a previous local
src/loaders/med4_load.c:564:7: warning: shadowed declaration is here
src/loaders/med4_load.c:589:16: warning: declaration of 'type' shadows a previous local
src/loaders/med4_load.c:564:15: warning: shadowed declaration is here
src/loaders/med4_load.c:590:8: warning: declaration of 'pos' shadows a previous local
src/loaders/med4_load.c:175:6: warning: shadowed declaration is here
src/loaders/med4_load.c:662:8: warning: declaration of 'pos' shadows a previous local
src/loaders/med4_load.c:175:6: warning: shadowed declaration is here
src/loaders/med4_load.c:807:23: warning: declaration of 'pos' shadows a previous local
src/loaders/med4_load.c:175:6: warning: shadowed declaration is here

src/loaders/mfp_load.c: In function 'mfp_load':
src/loaders/mfp_load.c:228:9: warning: declaration of 'x' shadows a previous local
src/loaders/mfp_load.c:103:15: warning: shadowed declaration is here

src/loaders/prowizard/heatseek.c: In function 'depack_crb':
src/loaders/prowizard/heatseek.c:82:11: warning: declaration of 'x' shadows a previous local
src/loaders/prowizard/heatseek.c:59:8: warning: shadowed declaration is here

src/loaders/prowizard/mp.c: In function 'test_mp_noid':
src/loaders/prowizard/mp.c:127:10: warning: declaration of 'data' shadows a parameter
src/loaders/prowizard/mp.c:60:38: warning: shadowed declaration is here

src/loaders/prowizard/np3.c: In function 'depack_np3':
src/loaders/prowizard/np3.c:102:9: warning: declaration of 'x' shadows a previous local
src/loaders/prowizard/np3.c:98:8: warning: shadowed declaration is here

src/loaders/prowizard/p61a.c: In function 'depack_p61a':
src/loaders/prowizard/p61a.c:155:10: warning: declaration of 'x' shadows a previous local
src/loaders/prowizard/p61a.c:41:9: warning: shadowed declaration is here

src/loaders/prowizard/tp1.c: In function 'test_tp1':
src/loaders/prowizard/tp1.c:179:7: warning: declaration of 'len' shadows a previous local
src/loaders/prowizard/tp1.c:144:6: warning: shadowed declaration is here

src/depackers/mmcmp.c: In function 'decrunch_mmcmp':
src/depackers/mmcmp.c:357:10: warning: declaration of 'buf' shadows a previous local
src/depackers/mmcmp.c:315:9: warning: shadowed declaration is here

src/depackers/uncompress.c: In function 'decrunch_compress':
src/depackers/uncompress.c:120:8: warning: declaration of 'i' shadows a previous local
src/depackers/uncompress.c:72:6: warning: shadowed declaration is here
```

Some of them are annoyance of older gcc, like `abs`, `index`, `y0`, `y1` and `div`.

I did my best, but this needs _careful_ review: please do.

There are more warnings, namely from `mix_all.c`, `unlzx.c` and `vorbis.c`.
The `mix_all.c` case is tricky, and I don't know whether I want to touch the
latter two. But here they are:
```
src/mix_all.c: In function 'libxmp_mix_mono_8bit_linear_filter':
src/mix_all.c:294:32: warning: declaration of 'vl' shadows a parameter
src/mix_all.c:289:1: warning: shadowed declaration is here
src/mix_all.c: In function 'libxmp_mix_mono_16bit_linear_filter':
src/mix_all.c:307:38: warning: declaration of 'vl' shadows a parameter
src/mix_all.c:302:1: warning: shadowed declaration is here
src/mix_all.c: In function 'libxmp_mix_stereo_8bit_linear_filter':
src/mix_all.c:320:32: warning: declaration of 'vr' shadows a parameter
src/mix_all.c:315:1: warning: shadowed declaration is here
src/mix_all.c:320:32: warning: declaration of 'vl' shadows a parameter
src/mix_all.c:315:1: warning: shadowed declaration is here
src/mix_all.c: In function 'libxmp_mix_stereo_16bit_linear_filter':
src/mix_all.c:333:38: warning: declaration of 'vr' shadows a parameter
src/mix_all.c:328:1: warning: shadowed declaration is here
src/mix_all.c:333:38: warning: declaration of 'vl' shadows a parameter
src/mix_all.c:328:1: warning: shadowed declaration is here
src/mix_all.c: In function 'libxmp_mix_mono_8bit_spline_filter':
src/mix_all.c:394:32: warning: declaration of 'vl' shadows a parameter
src/mix_all.c:389:1: warning: shadowed declaration is here
src/mix_all.c: In function 'libxmp_mix_mono_16bit_spline_filter':
src/mix_all.c:407:38: warning: declaration of 'vl' shadows a parameter
src/mix_all.c:402:1: warning: shadowed declaration is here
src/mix_all.c: In function 'libxmp_mix_stereo_8bit_spline_filter':
src/mix_all.c:420:32: warning: declaration of 'vr' shadows a parameter
src/mix_all.c:415:1: warning: shadowed declaration is here
src/mix_all.c:420:32: warning: declaration of 'vl' shadows a parameter
src/mix_all.c:415:1: warning: shadowed declaration is here
src/mix_all.c: In function 'libxmp_mix_stereo_16bit_spline_filter':
src/mix_all.c:433:38: warning: declaration of 'vr' shadows a parameter
src/mix_all.c:428:1: warning: shadowed declaration is here
src/mix_all.c:433:38: warning: declaration of 'vl' shadows a parameter
src/mix_all.c:428:1: warning: shadowed declaration is here

src/depackers/unlzx.c: In function 'read_literal_table':
src/depackers/unlzx.c:477:9: warning: declaration of 'abort' shadows a global declaration
src/depackers/unlzx.c: In function 'extract_normal':
src/depackers/unlzx.c:816:9: warning: declaration of 'abort' shadows a global declaration
src/depackers/unlzx.c: In function 'extract_archive':
src/depackers/unlzx.c:951:9: warning: declaration of 'abort' shadows a global declaration

src/depackers/vorbis.c: In function 'float32_unpack':
src/depackers/vorbis.c:681:11: warning: declaration of 'exp' shadows a global declaration
src/depackers/vorbis.c: In function 'start_page_no_capturepattern':
src/depackers/vorbis.c:1114:11: warning: declaration of 'i' shadows a previous local
src/depackers/vorbis.c:1079:8: warning: shadowed declaration is here
src/depackers/vorbis.c: In function 'get_bits':
src/depackers/vorbis.c:1237:14: warning: declaration of 'z' shadows a previous local
src/depackers/vorbis.c:1225:11: warning: shadowed declaration is here
src/depackers/vorbis.c: In function 'predict_point':
src/depackers/vorbis.c:1668:53: warning: declaration of 'y0' shadows a global declaration
src/depackers/vorbis.c:1668:61: warning: declaration of 'y1' shadows a global declaration
src/depackers/vorbis.c: In function 'draw_line':
src/depackers/vorbis.c:1767:63: warning: declaration of 'y0' shadows a global declaration
src/depackers/vorbis.c:1767:79: warning: declaration of 'y1' shadows a global declaration
src/depackers/vorbis.c: In function 'decode_residue':
src/depackers/vorbis.c:2035:29: warning: declaration of 'c' shadows a previous local
src/depackers/vorbis.c:1858:8: warning: shadowed declaration is here
src/depackers/vorbis.c:2037:19: warning: declaration of 'n' shadows a parameter
src/depackers/vorbis.c:1853:74: warning: shadowed declaration is here
src/depackers/vorbis.c:2054:23: warning: declaration of 'c' shadows a previous local
src/depackers/vorbis.c:1858:8: warning: shadowed declaration is here
src/depackers/vorbis.c:2064:26: warning: declaration of 'n' shadows a parameter
src/depackers/vorbis.c:1853:74: warning: shadowed declaration is here
src/depackers/vorbis.c: In function 'iter_54':
src/depackers/vorbis.c:2372:10: warning: declaration of 'y0' shadows a global declaration
src/depackers/vorbis.c:2372:13: warning: declaration of 'y1' shadows a global declaration
src/depackers/vorbis.c: In function 'do_floor':
src/depackers/vorbis.c:2892:30: warning: declaration of 'floor' shadows a global declaration
src/depackers/vorbis.c: In function 'vorbis_decode_packet_rest':
src/depackers/vorbis.c:3000:33: warning: declaration of 'floor' shadows a global declaration
src/depackers/vorbis.c:3024:19: warning: declaration of 'n' shadows a previous local
src/depackers/vorbis.c:2983:14: warning: shadowed declaration is here
src/depackers/vorbis.c:3032:22: warning: declaration of 'n' shadows a previous local
src/depackers/vorbis.c:2983:14: warning: shadowed declaration is here
src/depackers/vorbis.c:3145:11: warning: declaration of 'n2' shadows a previous local
src/depackers/vorbis.c:2983:16: warning: shadowed declaration is here
src/depackers/vorbis.c:3146:14: warning: declaration of 'm' shadows a parameter
src/depackers/vorbis.c:2980:63: warning: shadowed declaration is here
src/depackers/vorbis.c: In function 'vorbis_finish_frame':
src/depackers/vorbis.c:3277:11: warning: declaration of 'i' shadows a previous local
src/depackers/vorbis.c:3266:13: warning: shadowed declaration is here
src/depackers/vorbis.c:3277:13: warning: declaration of 'j' shadows a previous local
src/depackers/vorbis.c:3266:15: warning: shadowed declaration is here
src/depackers/vorbis.c: In function 'start_decoder':
src/depackers/vorbis.c:3638:17: warning: declaration of 'len' shadows a previous local
src/depackers/vorbis.c:3401:8: warning: shadowed declaration is here
src/depackers/vorbis.c:3651:58: warning: declaration of 'div' shadows a global declaration
src/depackers/vorbis.c:3951:11: warning: declaration of 'i' shadows a previous local
src/depackers/vorbis.c:3401:12: warning: shadowed declaration is here
src/depackers/vorbis.c: In function 'stb_vorbis_open_memory':
src/depackers/vorbis.c:4924:72: warning: declaration of 'error' shadows a global declaration
src/depackers/vorbis.c:510:12: warning: shadowed declaration is here
src/depackers/vorbis.c: In function 'stb_vorbis_decode_memory':
src/depackers/vorbis.c:5235:40: warning: declaration of 'error' shadows a global declaration
src/depackers/vorbis.c:510:12: warning: shadowed declaration is here
```
