### PR TITLE
Allow loading MED2 samples from the module directory.

### DIFF
--- a/test-dev/test_loader_med2.c
+++ b/test-dev/test_loader_med2.c
@@ -22,6 +22,20 @@ TEST(test_loader_med2)
 	ret = compare_module(info.mod, f);
 	fail_unless(ret == 0, "format not correctly loaded");
 
+	rewind(f);
+
+	/* libxmp can load samples from the module directory too. */
+	ret = xmp_set_instrument_path(opaque, "jgklfjdgk");
+	fail_unless(ret == 0, "set instrument path (junk)");
+
+	ret = xmp_load_module(opaque, "data/m/med2test.med");
+	fail_unless(ret == 0, "module load (junk instrument path)");
+
+	xmp_get_module_info(opaque, &info);
+
+	ret = compare_module(info.mod, f);
+	fail_unless(ret == 0, "format not correctly loaded (junk instrument path)");
+
 	xmp_release_module(opaque);
 	xmp_free_context(opaque);
 }


### PR DESCRIPTION
This is a bandaid fix for the MED2 test failing for some setups: when the instrument path doesn't work (usually due to being relative), the MED2 loader now allows loading samples from the current module directory. I don't think this is how MED2 is supposed to work but IMO it's a reasonable way to distribute MED2 modules and it's how other song files are handled by libxmp.

Should fix #414, but we'll see.