### PR TITLE
Make libxmp-lite valid C++ (also minor fixes)

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -128,19 +128,6 @@ void __inline CLIB_DECL D_(const char *text, ...) { do {} while (0); }
 #define D_(...) do {} while (0)
 #endif
 
-#elif defined(__WATCOMC__)
-#ifdef DEBUG
-#define D_INFO "\x1b[33m"
-#define D_CRIT "\x1b[31m"
-#define D_WARN "\x1b[36m"
-#define D_(...) do { \
-	printf("\x1b[33m%s \x1b[37m[%s:%d] " D_INFO, __FUNCTION__, \
-		__FILE__, __LINE__); printf (__VA_ARGS__); printf ("\x1b[0m\n"); \
-	} while (0)
-#else
-#define D_(...) do {} while (0)
-#endif
-
 #else
 
 #ifdef DEBUG

--- a/src/common.h
+++ b/src/common.h
@@ -110,7 +110,7 @@ void CLIB_DECL D_(const char *text, ...) ATTR_PRINTF(1,2);
 #if _MSC_VER < 1400
 void __inline CLIB_DECL D_(const char *text, ...) { do {} while (0); }
 #else
-#define D_(args, ...) do {} while (0)
+#define D_(...) do {} while (0)
 #endif
 #endif
 
@@ -121,11 +121,11 @@ void __inline CLIB_DECL D_(const char *text, ...) { do {} while (0); }
 #define D_CRIT "  Error: "
 #define D_WARN "Warning: "
 #define D_INFO "   Info: "
-#define D_(args...) do { \
-	__android_log_print(ANDROID_LOG_DEBUG, "libxmp", args); \
+#define D_(...) do { \
+	__android_log_print(ANDROID_LOG_DEBUG, "libxmp", __VA_ARGS__); \
 	} while (0)
 #else
-#define D_(args...) do {} while (0)
+#define D_(...) do {} while (0)
 #endif
 
 #elif defined(__WATCOMC__)
@@ -147,12 +147,12 @@ void __inline CLIB_DECL D_(const char *text, ...) { do {} while (0); }
 #define D_INFO "\x1b[33m"
 #define D_CRIT "\x1b[31m"
 #define D_WARN "\x1b[36m"
-#define D_(args...) do { \
+#define D_(...) do { \
 	printf("\x1b[33m%s \x1b[37m[%s:%d] " D_INFO, __FUNCTION__, \
-		__FILE__, __LINE__); printf (args); printf ("\x1b[0m\n"); \
+		__FILE__, __LINE__); printf (__VA_ARGS__); printf ("\x1b[0m\n"); \
 	} while (0)
 #else
-#define D_(args...) do {} while (0)
+#define D_(...) do {} while (0)
 #endif
 
 #endif	/* !_MSC_VER */

--- a/src/control.c
+++ b/src/control.c
@@ -310,6 +310,9 @@ int xmp_channel_vol(xmp_context opaque, int chn, int vol)
 }
 
 #ifdef USE_VERSIONED_SYMBOLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 LIBXMP_EXPORT_VERSIONED extern int xmp_set_player_v40__(xmp_context, int, int) LIBXMP_ATTRIB_SYMVER("xmp_set_player@XMP_4.0");
 LIBXMP_EXPORT_VERSIONED extern int xmp_set_player_v41__(xmp_context, int, int)
 			__attribute__((alias("xmp_set_player_v40__"))) LIBXMP_ATTRIB_SYMVER("xmp_set_player@XMP_4.1");
@@ -323,6 +326,10 @@ asm(".symver xmp_set_player_v40__, xmp_set_player@XMP_4.0");
 asm(".symver xmp_set_player_v41__, xmp_set_player@XMP_4.1");
 asm(".symver xmp_set_player_v43__, xmp_set_player@XMP_4.3");
 asm(".symver xmp_set_player_v44__, xmp_set_player@@XMP_4.4");
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #define xmp_set_player__ xmp_set_player_v40__
@@ -430,6 +437,9 @@ int xmp_set_player__(xmp_context opaque, int parm, int val)
 }
 
 #ifdef USE_VERSIONED_SYMBOLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 LIBXMP_EXPORT_VERSIONED extern int xmp_get_player_v40__(xmp_context, int) LIBXMP_ATTRIB_SYMVER("xmp_get_player@XMP_4.0");
 LIBXMP_EXPORT_VERSIONED extern int xmp_get_player_v41__(xmp_context, int)
 		__attribute__((alias("xmp_get_player_v40__"))) LIBXMP_ATTRIB_SYMVER("xmp_get_player@XMP_4.1");
@@ -446,6 +456,10 @@ asm(".symver xmp_get_player_v41__, xmp_get_player@XMP_4.1");
 asm(".symver xmp_get_player_v42__, xmp_get_player@XMP_4.2");
 asm(".symver xmp_get_player_v43__, xmp_get_player@XMP_4.3");
 asm(".symver xmp_get_player_v44__, xmp_get_player@@XMP_4.4");
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #define xmp_get_player__ xmp_get_player_v40__

--- a/src/control.c
+++ b/src/control.c
@@ -31,7 +31,7 @@ xmp_context xmp_create_context(void)
 {
 	struct context_data *ctx;
 
-	ctx = calloc(1, sizeof(struct context_data));
+	ctx = (struct context_data*)calloc(1, sizeof(struct context_data));
 	if (ctx == NULL) {
 		return NULL;
 	}

--- a/src/control.c
+++ b/src/control.c
@@ -31,7 +31,7 @@ xmp_context xmp_create_context(void)
 {
 	struct context_data *ctx;
 
-	ctx = (struct context_data*)calloc(1, sizeof(struct context_data));
+	ctx = (struct context_data *)calloc(1, sizeof(struct context_data));
 	if (ctx == NULL) {
 		return NULL;
 	}

--- a/src/format.h
+++ b/src/format.h
@@ -6,8 +6,8 @@
 
 struct format_loader {
 	const char *name;
-	int (*const test)(HIO_HANDLE *, char *, const int);
-	int (*const loader)(struct module_data *, HIO_HANDLE *, const int);
+	int (*test)(HIO_HANDLE *, char *, const int);
+	int (*loader)(struct module_data *, HIO_HANDLE *, const int);
 };
 
 const char *const *format_list(void);

--- a/src/format.h
+++ b/src/format.h
@@ -10,6 +10,8 @@ struct format_loader {
 	int (*loader)(struct module_data *, HIO_HANDLE *, const int);
 };
 
+extern const struct format_loader *const format_loaders[];
+
 const char *const *format_list(void);
 
 #ifndef LIBXMP_CORE_PLAYER

--- a/src/load.c
+++ b/src/load.c
@@ -39,8 +39,6 @@
 #endif
 
 
-extern struct format_loader *format_loaders[];
-
 void libxmp_load_prologue(struct context_data *);
 void libxmp_load_epilogue(struct context_data *);
 int  libxmp_prepare_scan(struct context_data *);

--- a/src/load_helpers.c
+++ b/src/load_helpers.c
@@ -283,7 +283,7 @@ int libxmp_prepare_scan(struct context_data *ctx)
 		return 0;
 	}
 
-	m->scan_cnt = calloc(sizeof (uint8 *), mod->len);
+	m->scan_cnt = (uint8**)calloc(sizeof (uint8 *), mod->len);
 	if (m->scan_cnt == NULL)
 		return -XMP_ERROR_SYSTEM;
 
@@ -299,7 +299,7 @@ int libxmp_prepare_scan(struct context_data *ctx)
 		}
 
 		pat = pat_idx >= mod->pat ? NULL : mod->xxp[pat_idx];
-		m->scan_cnt[i] = calloc(1, pat && pat->rows ? pat->rows : 1);
+		m->scan_cnt[i] = (uint8*)calloc(1, pat && pat->rows ? pat->rows : 1);
 		if (m->scan_cnt[i] == NULL)
 			return -XMP_ERROR_SYSTEM;
 	}

--- a/src/load_helpers.c
+++ b/src/load_helpers.c
@@ -283,7 +283,7 @@ int libxmp_prepare_scan(struct context_data *ctx)
 		return 0;
 	}
 
-	m->scan_cnt = (uint8**)calloc(sizeof (uint8 *), mod->len);
+	m->scan_cnt = (uint8 **)calloc(sizeof (uint8 *), mod->len);
 	if (m->scan_cnt == NULL)
 		return -XMP_ERROR_SYSTEM;
 
@@ -299,7 +299,7 @@ int libxmp_prepare_scan(struct context_data *ctx)
 		}
 
 		pat = pat_idx >= mod->pat ? NULL : mod->xxp[pat_idx];
-		m->scan_cnt[i] = (uint8*)calloc(1, pat && pat->rows ? pat->rows : 1);
+		m->scan_cnt[i] = (uint8 *)calloc(1, pat && pat->rows ? pat->rows : 1);
 		if (m->scan_cnt[i] == NULL)
 			return -XMP_ERROR_SYSTEM;
 	}

--- a/src/loaders/common.c
+++ b/src/loaders/common.c
@@ -57,7 +57,7 @@ int libxmp_init_instrument(struct module_data *m)
 	struct xmp_module *mod = &m->mod;
 
 	if (mod->ins > 0) {
-		mod->xxi = (struct xmp_instrument*)calloc(sizeof (struct xmp_instrument), mod->ins);
+		mod->xxi = (struct xmp_instrument *)calloc(sizeof (struct xmp_instrument), mod->ins);
 		if (mod->xxi == NULL)
 			return -1;
 	}
@@ -71,10 +71,10 @@ int libxmp_init_instrument(struct module_data *m)
 			return -1;
 		}
 
-		mod->xxs = (struct xmp_sample*)calloc(sizeof (struct xmp_sample), mod->smp);
+		mod->xxs = (struct xmp_sample *)calloc(sizeof (struct xmp_sample), mod->smp);
 		if (mod->xxs == NULL)
 			return -1;
-		m->xtra = (struct extra_sample_data*)calloc(sizeof (struct extra_sample_data), mod->smp);
+		m->xtra = (struct extra_sample_data *)calloc(sizeof (struct extra_sample_data), mod->smp);
 		if (m->xtra == NULL)
 			return -1;
 
@@ -109,12 +109,12 @@ int libxmp_realloc_samples(struct module_data *m, int new_size)
 		return 0;
 	}
 
-	xxs = (struct xmp_sample*)realloc(mod->xxs, sizeof(struct xmp_sample) * new_size);
+	xxs = (struct xmp_sample *)realloc(mod->xxs, sizeof(struct xmp_sample) * new_size);
 	if (xxs == NULL)
 		return -1;
 	mod->xxs = xxs;
 
-	xtra = (struct extra_sample_data*)realloc(m->xtra, sizeof(struct extra_sample_data) * new_size);
+	xtra = (struct extra_sample_data *)realloc(m->xtra, sizeof(struct extra_sample_data) * new_size);
 	if (xtra == NULL)
 		return -1;
 	m->xtra = xtra;
@@ -139,7 +139,7 @@ int libxmp_alloc_subinstrument(struct xmp_module *mod, int i, int num)
 	if (num == 0)
 		return 0;
 
-	mod->xxi[i].sub = (struct xmp_subinstrument*)calloc(sizeof (struct xmp_subinstrument), num);
+	mod->xxi[i].sub = (struct xmp_subinstrument *)calloc(sizeof (struct xmp_subinstrument), num);
 	if (mod->xxi[i].sub == NULL)
 		return -1;
 
@@ -148,11 +148,11 @@ int libxmp_alloc_subinstrument(struct xmp_module *mod, int i, int num)
 
 int libxmp_init_pattern(struct xmp_module *mod)
 {
-	mod->xxt = (struct xmp_track**)calloc(sizeof (struct xmp_track *), mod->trk);
+	mod->xxt = (struct xmp_track **)calloc(sizeof (struct xmp_track *), mod->trk);
 	if (mod->xxt == NULL)
 		return -1;
 
-	mod->xxp = (struct xmp_pattern**)calloc(sizeof (struct xmp_pattern *), mod->pat);
+	mod->xxp = (struct xmp_pattern **)calloc(sizeof (struct xmp_pattern *), mod->pat);
 	if (mod->xxp == NULL)
 		return -1;
 
@@ -165,7 +165,7 @@ int libxmp_alloc_pattern(struct xmp_module *mod, int num)
 	if (num < 0 || num >= mod->pat || mod->xxp[num] != NULL)
 		return -1;
 
-	mod->xxp[num] = (struct xmp_pattern*)calloc(1, sizeof (struct xmp_pattern) +
+	mod->xxp[num] = (struct xmp_pattern *)calloc(1, sizeof (struct xmp_pattern) +
         				sizeof (int) * (mod->chn - 1));
 	if (mod->xxp[num] == NULL)
 		return -1;
@@ -179,7 +179,7 @@ int libxmp_alloc_track(struct xmp_module *mod, int num, int rows)
 	if (num < 0 || num >= mod->trk || mod->xxt[num] != NULL || rows <= 0)
 		return -1;
 
-	mod->xxt[num] = (struct xmp_track*)calloc(sizeof (struct xmp_track) +
+	mod->xxt[num] = (struct xmp_track *)calloc(sizeof (struct xmp_track) +
 			       sizeof (struct xmp_event) * (rows - 1), 1);
 	if (mod->xxt[num] == NULL)
 		return -1;

--- a/src/loaders/common.c
+++ b/src/loaders/common.c
@@ -57,7 +57,7 @@ int libxmp_init_instrument(struct module_data *m)
 	struct xmp_module *mod = &m->mod;
 
 	if (mod->ins > 0) {
-		mod->xxi = calloc(sizeof (struct xmp_instrument), mod->ins);
+		mod->xxi = (struct xmp_instrument*)calloc(sizeof (struct xmp_instrument), mod->ins);
 		if (mod->xxi == NULL)
 			return -1;
 	}
@@ -71,10 +71,10 @@ int libxmp_init_instrument(struct module_data *m)
 			return -1;
 		}
 
-		mod->xxs = calloc(sizeof (struct xmp_sample), mod->smp);
+		mod->xxs = (struct xmp_sample*)calloc(sizeof (struct xmp_sample), mod->smp);
 		if (mod->xxs == NULL)
 			return -1;
-		m->xtra = calloc(sizeof (struct extra_sample_data), mod->smp);
+		m->xtra = (struct extra_sample_data*)calloc(sizeof (struct extra_sample_data), mod->smp);
 		if (m->xtra == NULL)
 			return -1;
 
@@ -109,12 +109,12 @@ int libxmp_realloc_samples(struct module_data *m, int new_size)
 		return 0;
 	}
 
-	xxs = realloc(mod->xxs, sizeof(struct xmp_sample) * new_size);
+	xxs = (struct xmp_sample*)realloc(mod->xxs, sizeof(struct xmp_sample) * new_size);
 	if (xxs == NULL)
 		return -1;
 	mod->xxs = xxs;
 
-	xtra = realloc(m->xtra, sizeof(struct extra_sample_data) * new_size);
+	xtra = (struct extra_sample_data*)realloc(m->xtra, sizeof(struct extra_sample_data) * new_size);
 	if (xtra == NULL)
 		return -1;
 	m->xtra = xtra;
@@ -139,7 +139,7 @@ int libxmp_alloc_subinstrument(struct xmp_module *mod, int i, int num)
 	if (num == 0)
 		return 0;
 
-	mod->xxi[i].sub = calloc(sizeof (struct xmp_subinstrument), num);
+	mod->xxi[i].sub = (struct xmp_subinstrument*)calloc(sizeof (struct xmp_subinstrument), num);
 	if (mod->xxi[i].sub == NULL)
 		return -1;
 
@@ -148,11 +148,11 @@ int libxmp_alloc_subinstrument(struct xmp_module *mod, int i, int num)
 
 int libxmp_init_pattern(struct xmp_module *mod)
 {
-	mod->xxt = calloc(sizeof (struct xmp_track *), mod->trk);
+	mod->xxt = (struct xmp_track**)calloc(sizeof (struct xmp_track *), mod->trk);
 	if (mod->xxt == NULL)
 		return -1;
 
-	mod->xxp = calloc(sizeof (struct xmp_pattern *), mod->pat);
+	mod->xxp = (struct xmp_pattern**)calloc(sizeof (struct xmp_pattern *), mod->pat);
 	if (mod->xxp == NULL)
 		return -1;
 
@@ -165,7 +165,7 @@ int libxmp_alloc_pattern(struct xmp_module *mod, int num)
 	if (num < 0 || num >= mod->pat || mod->xxp[num] != NULL)
 		return -1;
 
-	mod->xxp[num] = calloc(1, sizeof (struct xmp_pattern) +
+	mod->xxp[num] = (struct xmp_pattern*)calloc(1, sizeof (struct xmp_pattern) +
         				sizeof (int) * (mod->chn - 1));
 	if (mod->xxp[num] == NULL)
 		return -1;
@@ -179,7 +179,7 @@ int libxmp_alloc_track(struct xmp_module *mod, int num, int rows)
 	if (num < 0 || num >= mod->trk || mod->xxt[num] != NULL || rows <= 0)
 		return -1;
 
-	mod->xxt[num] = calloc(sizeof (struct xmp_track) +
+	mod->xxt[num] = (struct xmp_track*)calloc(sizeof (struct xmp_track) +
 			       sizeof (struct xmp_event) * (rows - 1), 1);
 	if (mod->xxt[num] == NULL)
 		return -1;

--- a/src/loaders/common.c
+++ b/src/loaders/common.c
@@ -22,7 +22,7 @@
 
 #include <ctype.h>
 
-#include "common.h"
+#include "../common.h"
 
 #ifndef LIBXMP_CORE_PLAYER
 #if defined(_WIN32)
@@ -49,7 +49,7 @@
 #endif /* LIBXMP_CORE_PLAYER */
 
 #include "xmp.h"
-#include "period.h"
+#include "../period.h"
 #include "loader.h"
 
 int libxmp_init_instrument(struct module_data *m)

--- a/src/loaders/it.h
+++ b/src/loaders/it.h
@@ -184,6 +184,8 @@ struct it_sample_header {
 	uint8 vit;		/* Vibrato waveform */
 };
 
+extern const struct format_loader libxmp_loader_it;
+
 int itsex_decompress8(HIO_HANDLE *src, uint8 *dst, int len, int it215);
 int itsex_decompress16(HIO_HANDLE *src, int16 *dst, int len, int it215);
 

--- a/src/loaders/it_load.c
+++ b/src/loaders/it_load.c
@@ -24,7 +24,7 @@
 
 #include "loader.h"
 #include "it.h"
-#include "period.h"
+#include "../period.h"
 
 #define MAGIC_IMPM	MAGIC4('I','M','P','M')
 #define MAGIC_IMPI	MAGIC4('I','M','P','I')

--- a/src/loaders/it_load.c
+++ b/src/loaders/it_load.c
@@ -479,7 +479,7 @@ static int load_old_it_instrument(struct xmp_instrument *xxi, HIO_HANDLE *f)
 	xxi->vol = 0x40;
 
 	if (k) {
-		xxi->sub = (struct xmp_subinstrument*)calloc(sizeof(struct xmp_subinstrument), k);
+		xxi->sub = (struct xmp_subinstrument *)calloc(sizeof(struct xmp_subinstrument), k);
 		if (xxi->sub == NULL) {
 			return -1;
 		}
@@ -630,7 +630,7 @@ static int load_new_it_instrument(struct xmp_instrument *xxi, HIO_HANDLE *f)
 	xxi->vol = i2h.gbv >> 1;
 
 	if (k) {
-		xxi->sub = (struct xmp_subinstrument*)calloc(sizeof(struct xmp_subinstrument), k);
+		xxi->sub = (struct xmp_subinstrument *)calloc(sizeof(struct xmp_subinstrument), k);
 		if (xxi->sub == NULL)
 			return -1;
 
@@ -685,7 +685,7 @@ static int load_it_sample(struct module_data *m, int i, int start,
 	uint8 buf[80];
 
 	if (sample_mode) {
-		mod->xxi[i].sub = (struct xmp_subinstrument*)calloc(sizeof(struct xmp_subinstrument), 1);
+		mod->xxi[i].sub = (struct xmp_subinstrument *)calloc(sizeof(struct xmp_subinstrument), 1);
 		if (mod->xxi[i].sub == NULL) {
 			return -1;
 		}
@@ -851,7 +851,7 @@ static int load_it_sample(struct module_data *m, int i, int start,
 					force_sample_length(xsmp, left << 3);
 			}
 
-			decbuf = (uint8*)calloc(1, xxs->len * 2);
+			decbuf = (uint8 *)calloc(1, xxs->len * 2);
 			if (decbuf == NULL)
 				return -1;
 
@@ -1113,18 +1113,18 @@ static int it_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	}
 
 	if (mod->ins) {
-		pp_ins = (uint32*)calloc(4, mod->ins);
+		pp_ins = (uint32 *)calloc(4, mod->ins);
 		if (pp_ins == NULL)
 			goto err;
 	} else {
 		pp_ins = NULL;
 	}
 
-	pp_smp = (uint32*)calloc(4, mod->smp);
+	pp_smp = (uint32 *)calloc(4, mod->smp);
 	if (pp_smp == NULL)
 		goto err2;
 
-	pp_pat = (uint32*)calloc(4, mod->pat);
+	pp_pat = (uint32 *)calloc(4, mod->pat);
 	if (pp_pat == NULL)
 		goto err3;
 
@@ -1194,7 +1194,7 @@ static int it_load(struct module_data *m, HIO_HANDLE *f, const int start)
 
 	/* Alloc extra samples for sustain loop */
 	if (mod->smp > 0) {
-		m->xsmp = (struct xmp_sample*)calloc(sizeof (struct xmp_sample), mod->smp);
+		m->xsmp = (struct xmp_sample *)calloc(sizeof (struct xmp_sample), mod->smp);
 		if (m->xsmp == NULL) {
 			goto err4;
 		}
@@ -1368,7 +1368,7 @@ static int it_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	/* Song message */
 
 	if (ifh.special & IT_HAS_MSG) {
-		if ((m->comment = (char*)malloc(ifh.msglen)) != NULL) {
+		if ((m->comment = (char *)malloc(ifh.msglen)) != NULL) {
 			hio_seek(f, start + ifh.msgofs, SEEK_SET);
 
 			D_(D_INFO "Message length : %d", ifh.msglen);

--- a/src/loaders/it_load.c
+++ b/src/loaders/it_load.c
@@ -479,7 +479,7 @@ static int load_old_it_instrument(struct xmp_instrument *xxi, HIO_HANDLE *f)
 	xxi->vol = 0x40;
 
 	if (k) {
-		xxi->sub = calloc(sizeof(struct xmp_subinstrument), k);
+		xxi->sub = (struct xmp_subinstrument*)calloc(sizeof(struct xmp_subinstrument), k);
 		if (xxi->sub == NULL) {
 			return -1;
 		}
@@ -630,7 +630,7 @@ static int load_new_it_instrument(struct xmp_instrument *xxi, HIO_HANDLE *f)
 	xxi->vol = i2h.gbv >> 1;
 
 	if (k) {
-		xxi->sub = calloc(sizeof(struct xmp_subinstrument), k);
+		xxi->sub = (struct xmp_subinstrument*)calloc(sizeof(struct xmp_subinstrument), k);
 		if (xxi->sub == NULL)
 			return -1;
 
@@ -685,7 +685,7 @@ static int load_it_sample(struct module_data *m, int i, int start,
 	uint8 buf[80];
 
 	if (sample_mode) {
-		mod->xxi[i].sub = calloc(sizeof(struct xmp_subinstrument), 1);
+		mod->xxi[i].sub = (struct xmp_subinstrument*)calloc(sizeof(struct xmp_subinstrument), 1);
 		if (mod->xxi[i].sub == NULL) {
 			return -1;
 		}
@@ -851,7 +851,7 @@ static int load_it_sample(struct module_data *m, int i, int start,
 					force_sample_length(xsmp, left << 3);
 			}
 
-			decbuf = calloc(1, xxs->len * 2);
+			decbuf = (uint8*)calloc(1, xxs->len * 2);
 			if (decbuf == NULL)
 				return -1;
 
@@ -1113,18 +1113,18 @@ static int it_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	}
 
 	if (mod->ins) {
-		pp_ins = calloc(4, mod->ins);
+		pp_ins = (uint32*)calloc(4, mod->ins);
 		if (pp_ins == NULL)
 			goto err;
 	} else {
 		pp_ins = NULL;
 	}
 
-	pp_smp = calloc(4, mod->smp);
+	pp_smp = (uint32*)calloc(4, mod->smp);
 	if (pp_smp == NULL)
 		goto err2;
 
-	pp_pat = calloc(4, mod->pat);
+	pp_pat = (uint32*)calloc(4, mod->pat);
 	if (pp_pat == NULL)
 		goto err3;
 
@@ -1194,7 +1194,7 @@ static int it_load(struct module_data *m, HIO_HANDLE *f, const int start)
 
 	/* Alloc extra samples for sustain loop */
 	if (mod->smp > 0) {
-		m->xsmp = calloc(sizeof (struct xmp_sample), mod->smp);
+		m->xsmp = (struct xmp_sample*)calloc(sizeof (struct xmp_sample), mod->smp);
 		if (m->xsmp == NULL) {
 			goto err4;
 		}
@@ -1368,7 +1368,7 @@ static int it_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	/* Song message */
 
 	if (ifh.special & IT_HAS_MSG) {
-		if ((m->comment = malloc(ifh.msglen)) != NULL) {
+		if ((m->comment = (char*)malloc(ifh.msglen)) != NULL) {
 			hio_seek(f, start + ifh.msgofs, SEEK_SET);
 
 			D_(D_INFO "Message length : %d", ifh.msglen);

--- a/src/loaders/loader.h
+++ b/src/loaders/loader.h
@@ -1,10 +1,10 @@
 #ifndef XMP_LOADER_H
 #define XMP_LOADER_H
 
-#include "common.h"
-#include "effects.h"
-#include "format.h"
-#include "hio.h"
+#include "../common.h"
+#include "../effects.h"
+#include "../format.h"
+#include "../hio.h"
 
 /* Sample flags */
 #define SAMPLE_FLAG_DIFF	0x0001	/* Differential */

--- a/src/loaders/mod.h
+++ b/src/loaders/mod.h
@@ -57,4 +57,6 @@ struct st_header {
 };
 #endif
 
+extern const struct format_loader libxmp_loader_mod;
+
 #endif

--- a/src/loaders/mod.h
+++ b/src/loaders/mod.h
@@ -20,6 +20,9 @@
  * THE SOFTWARE.
  */
 
+#ifndef LIBXMP_LOADERS_MOD_H
+#define LIBXMP_LOADERS_MOD_H
+
 struct mod_instrument {
 	uint8 name[22];		/* Instrument name */
 	uint16 size;		/* Sample length in 16-bit words */
@@ -52,4 +55,6 @@ struct st_header {
 	uint8 restart;
 	uint8 order[128];
 };
+#endif
+
 #endif

--- a/src/loaders/s3m.h
+++ b/src/loaders/s3m.h
@@ -20,6 +20,9 @@
  * THE SOFTWARE.
  */
 
+#ifndef LIBXMP_LOADERS_S3M_H
+#define LIBXMP_LOADERS_S3M_H
+
 /* S3M packed pattern macros */
 #define S3M_EOR		0	/* End of row */
 #define S3M_CH_MASK	0x1f	/* Channel */
@@ -114,3 +117,4 @@ struct s3m_adlib_header {
 };
 #endif
 
+#endif

--- a/src/loaders/s3m.h
+++ b/src/loaders/s3m.h
@@ -117,4 +117,6 @@ struct s3m_adlib_header {
 };
 #endif
 
+extern const struct format_loader libxmp_loader_s3m;
+
 #endif

--- a/src/loaders/s3m_load.c
+++ b/src/loaders/s3m_load.c
@@ -262,12 +262,12 @@ static int s3m_load(struct module_data *m, HIO_HANDLE * f, const int start)
 
 	libxmp_copy_adjust(mod->name, sfh.name, 28);
 
-	pp_ins = calloc(2, sfh.insnum);
+	pp_ins = (uint16*)calloc(2, sfh.insnum);
 	if (pp_ins == NULL) {
 		goto err;
 	}
 
-	pp_pat = calloc(2, sfh.patnum);
+	pp_pat = (uint16*)calloc(2, sfh.patnum);
 	if (pp_pat == NULL) {
 		goto err2;
 	}
@@ -488,7 +488,7 @@ static int s3m_load(struct module_data *m, HIO_HANDLE * f, const int start)
 		struct xmp_subinstrument *sub;
 		int load_sample_flags;
 
-		xxi->sub = calloc(sizeof(struct xmp_subinstrument), 1);
+		xxi->sub = (struct xmp_subinstrument*)calloc(sizeof(struct xmp_subinstrument), 1);
 		if (xxi->sub == NULL) {
 			goto err3;
 		}

--- a/src/loaders/s3m_load.c
+++ b/src/loaders/s3m_load.c
@@ -60,7 +60,7 @@
 
 #include "loader.h"
 #include "s3m.h"
-#include "period.h"
+#include "../period.h"
 
 #define MAGIC_SCRM	MAGIC4('S','C','R','M')
 #define MAGIC_SCRI	MAGIC4('S','C','R','I')

--- a/src/loaders/s3m_load.c
+++ b/src/loaders/s3m_load.c
@@ -262,12 +262,12 @@ static int s3m_load(struct module_data *m, HIO_HANDLE * f, const int start)
 
 	libxmp_copy_adjust(mod->name, sfh.name, 28);
 
-	pp_ins = (uint16*)calloc(2, sfh.insnum);
+	pp_ins = (uint16 *)calloc(2, sfh.insnum);
 	if (pp_ins == NULL) {
 		goto err;
 	}
 
-	pp_pat = (uint16*)calloc(2, sfh.patnum);
+	pp_pat = (uint16 *)calloc(2, sfh.patnum);
 	if (pp_pat == NULL) {
 		goto err2;
 	}
@@ -488,7 +488,7 @@ static int s3m_load(struct module_data *m, HIO_HANDLE * f, const int start)
 		struct xmp_subinstrument *sub;
 		int load_sample_flags;
 
-		xxi->sub = (struct xmp_subinstrument*)calloc(sizeof(struct xmp_subinstrument), 1);
+		xxi->sub = (struct xmp_subinstrument *)calloc(sizeof(struct xmp_subinstrument), 1);
 		if (xxi->sub == NULL) {
 			goto err3;
 		}

--- a/src/loaders/sample.c
+++ b/src/loaders/sample.c
@@ -20,7 +20,7 @@
  * THE SOFTWARE.
  */
 
-#include "common.h"
+#include "../common.h"
 #include "loader.h"
 
 #ifndef LIBXMP_CORE_PLAYER

--- a/src/loaders/sample.c
+++ b/src/loaders/sample.c
@@ -290,7 +290,7 @@ int libxmp_load_sample(struct module_data *m, HIO_HANDLE *f, int flags, struct x
 	}
 
 	/* add guard bytes before the buffer for higher order interpolation */
-	xxs->data = malloc(bytelen + extralen + unroll_extralen + 4);
+	xxs->data = (unsigned char*)malloc(bytelen + extralen + unroll_extralen + 4);
 	if (xxs->data == NULL) {
 		goto err;
 	}

--- a/src/loaders/sample.c
+++ b/src/loaders/sample.c
@@ -290,7 +290,7 @@ int libxmp_load_sample(struct module_data *m, HIO_HANDLE *f, int flags, struct x
 	}
 
 	/* add guard bytes before the buffer for higher order interpolation */
-	xxs->data = (unsigned char*)malloc(bytelen + extralen + unroll_extralen + 4);
+	xxs->data = (unsigned char *)malloc(bytelen + extralen + unroll_extralen + 4);
 	if (xxs->data == NULL) {
 		goto err;
 	}

--- a/src/loaders/xm.h
+++ b/src/loaders/xm.h
@@ -98,4 +98,6 @@ struct xm_event {
 	uint8 fx_parm;		/* Effect parameter */
 };
 
+extern const struct format_loader libxmp_loader_xm;
+
 #endif

--- a/src/loaders/xm_load.c
+++ b/src/loaders/xm_load.c
@@ -100,7 +100,7 @@ static int load_xm_pattern(struct module_data *m, int num, int version, HIO_HAND
 
 	size = xph.datasize;
 
-	pat = patbuf = calloc(1, size);
+	pat = patbuf = (uint8*)calloc(1, size);
 	if (patbuf == NULL) {
 		goto err;
 	}

--- a/src/loaders/xm_load.c
+++ b/src/loaders/xm_load.c
@@ -100,7 +100,7 @@ static int load_xm_pattern(struct module_data *m, int num, int version, HIO_HAND
 
 	size = xph.datasize;
 
-	pat = patbuf = (uint8*)calloc(1, size);
+	pat = patbuf = (uint8 *)calloc(1, size);
 	if (patbuf == NULL) {
 		goto err;
 	}

--- a/src/memio.c
+++ b/src/memio.c
@@ -97,7 +97,7 @@ MFILE *mopen(const void *ptr, long size)
 	if (m == NULL)
 		return NULL;
 
-	m->start = ptr;
+	m->start = (const unsigned char*)ptr;
 	m->pos = 0;
 	m->size = size;
 

--- a/src/memio.c
+++ b/src/memio.c
@@ -97,7 +97,7 @@ MFILE *mopen(const void *ptr, long size)
 	if (m == NULL)
 		return NULL;
 
-	m->start = (const unsigned char*)ptr;
+	m->start = (const unsigned char *)ptr;
 	m->pos = 0;
 	m->size = size;
 

--- a/src/mix_all.c
+++ b/src/mix_all.c
@@ -148,7 +148,7 @@
 
 #define VAR_NORM(x) \
     register int smp_in; \
-    x *sptr = vi->sptr; \
+    x *sptr = (x*)vi->sptr; \
     unsigned int pos = vi->pos; \
     int frac = (1 << SMIX_SHIFT) * (vi->pos - (int)vi->pos)
 

--- a/src/mix_all.c
+++ b/src/mix_all.c
@@ -148,7 +148,7 @@
 
 #define VAR_NORM(x) \
     register int smp_in; \
-    x *sptr = (x*)vi->sptr; \
+    x *sptr = (x *)vi->sptr; \
     unsigned int pos = vi->pos; \
     int frac = (1 << SMIX_SHIFT) * (vi->pos - (int)vi->pos)
 

--- a/src/player.c
+++ b/src/player.c
@@ -1566,13 +1566,13 @@ int xmp_start_player(xmp_context opaque, int rate, int format)
 	f->pbreak = 0;
 	f->rowdelay_set = 0;
 
-	f->loop = (struct pattern_loop*)calloc(p->virt.virt_channels, sizeof(struct pattern_loop));
+	f->loop = (struct pattern_loop *)calloc(p->virt.virt_channels, sizeof(struct pattern_loop));
 	if (f->loop == NULL) {
 		ret = -XMP_ERROR_SYSTEM;
 		goto err;
 	}
 
-	p->xc_data = (struct channel_data*)calloc(p->virt.virt_channels, sizeof(struct channel_data));
+	p->xc_data = (struct channel_data *)calloc(p->virt.virt_channels, sizeof(struct channel_data));
 	if (p->xc_data == NULL) {
 		ret = -XMP_ERROR_SYSTEM;
 		goto err1;
@@ -1779,7 +1779,7 @@ int xmp_play_buffer(xmp_context opaque, void *out_buffer, int size, int loop)
 			}
 
 			p->buffer_data.consumed = 0;
-			p->buffer_data.in_buffer = (char*)fi.buffer;
+			p->buffer_data.in_buffer = (char *)fi.buffer;
 			p->buffer_data.in_size = fi.buffer_size;
 		}
 

--- a/src/player.c
+++ b/src/player.c
@@ -1566,13 +1566,13 @@ int xmp_start_player(xmp_context opaque, int rate, int format)
 	f->pbreak = 0;
 	f->rowdelay_set = 0;
 
-	f->loop = calloc(p->virt.virt_channels, sizeof(struct pattern_loop));
+	f->loop = (struct pattern_loop*)calloc(p->virt.virt_channels, sizeof(struct pattern_loop));
 	if (f->loop == NULL) {
 		ret = -XMP_ERROR_SYSTEM;
 		goto err;
 	}
 
-	p->xc_data = calloc(p->virt.virt_channels, sizeof(struct channel_data));
+	p->xc_data = (struct channel_data*)calloc(p->virt.virt_channels, sizeof(struct channel_data));
 	if (p->xc_data == NULL) {
 		ret = -XMP_ERROR_SYSTEM;
 		goto err1;
@@ -1779,7 +1779,7 @@ int xmp_play_buffer(xmp_context opaque, void *out_buffer, int size, int loop)
 			}
 
 			p->buffer_data.consumed = 0;
-			p->buffer_data.in_buffer = fi.buffer;
+			p->buffer_data.in_buffer = (char*)fi.buffer;
 			p->buffer_data.in_size = fi.buffer_size;
 		}
 

--- a/src/scan.c
+++ b/src/scan.c
@@ -530,7 +530,7 @@ int libxmp_scan_sequences(struct context_data *ctx)
 	int seq;
 	unsigned char temp_ep[XMP_MAX_MOD_LENGTH];
 
-	s = (struct scan_data*)realloc(p->scan, MAX(1, mod->len) * sizeof(struct scan_data));
+	s = (struct scan_data *)realloc(p->scan, MAX(1, mod->len) * sizeof(struct scan_data));
 	if (!s) {
 		D_(D_CRIT "failed to allocate scan data");
 		return -1;
@@ -576,7 +576,7 @@ int libxmp_scan_sequences(struct context_data *ctx)
 	}
 
 	if (seq < mod->len) {
-		s = (struct scan_data*)realloc(p->scan, seq * sizeof(struct scan_data));
+		s = (struct scan_data *)realloc(p->scan, seq * sizeof(struct scan_data));
 		if (s != NULL) {
 			p->scan = s;
 		}

--- a/src/scan.c
+++ b/src/scan.c
@@ -530,7 +530,7 @@ int libxmp_scan_sequences(struct context_data *ctx)
 	int seq;
 	unsigned char temp_ep[XMP_MAX_MOD_LENGTH];
 
-	s = realloc(p->scan, MAX(1, mod->len) * sizeof(struct scan_data));
+	s = (struct scan_data*)realloc(p->scan, MAX(1, mod->len) * sizeof(struct scan_data));
 	if (!s) {
 		D_(D_CRIT "failed to allocate scan data");
 		return -1;
@@ -576,7 +576,7 @@ int libxmp_scan_sequences(struct context_data *ctx)
 	}
 
 	if (seq < mod->len) {
-		s = realloc(p->scan, seq * sizeof(struct scan_data));
+		s = (struct scan_data*)realloc(p->scan, seq * sizeof(struct scan_data));
 		if (s != NULL) {
 			p->scan = s;
 		}

--- a/src/smix.c
+++ b/src/smix.c
@@ -72,11 +72,11 @@ int xmp_start_smix(xmp_context opaque, int chn, int smp)
 		return -XMP_ERROR_STATE;
 	}
 
-	smix->xxi = calloc(sizeof (struct xmp_instrument), smp);
+	smix->xxi = (struct xmp_instrument*)calloc(sizeof (struct xmp_instrument), smp);
 	if (smix->xxi == NULL) {
 		goto err;
 	}
-	smix->xxs = calloc(sizeof (struct xmp_sample), smp);
+	smix->xxs = (struct xmp_sample*)calloc(sizeof (struct xmp_sample), smp);
 	if (smix->xxs == NULL) {
 		goto err1;
 	}
@@ -201,7 +201,7 @@ int xmp_smix_load_sample(xmp_context opaque, int num, const char *path)
 		
 	/* Init instrument */
 
-	xxi->sub = calloc(sizeof(struct xmp_subinstrument), 1);
+	xxi->sub = (struct xmp_subinstrument*)calloc(sizeof(struct xmp_subinstrument), 1);
 	if (xxi->sub == NULL) {
 		retval = -XMP_ERROR_SYSTEM;
 		goto err1;
@@ -264,7 +264,7 @@ int xmp_smix_load_sample(xmp_context opaque, int num, const char *path)
 	xxs->lpe = 0;
 	xxs->flg = bits == 16 ? XMP_SAMPLE_16BIT : 0;
 
-	xxs->data = malloc(size + 8);
+	xxs->data = (unsigned char*)malloc(size + 8);
 	if (xxs->data == NULL) {
 		retval = -XMP_ERROR_SYSTEM;
 		goto err2;

--- a/src/smix.c
+++ b/src/smix.c
@@ -72,11 +72,11 @@ int xmp_start_smix(xmp_context opaque, int chn, int smp)
 		return -XMP_ERROR_STATE;
 	}
 
-	smix->xxi = (struct xmp_instrument*)calloc(sizeof (struct xmp_instrument), smp);
+	smix->xxi = (struct xmp_instrument *)calloc(sizeof (struct xmp_instrument), smp);
 	if (smix->xxi == NULL) {
 		goto err;
 	}
-	smix->xxs = (struct xmp_sample*)calloc(sizeof (struct xmp_sample), smp);
+	smix->xxs = (struct xmp_sample *)calloc(sizeof (struct xmp_sample), smp);
 	if (smix->xxs == NULL) {
 		goto err1;
 	}
@@ -201,7 +201,7 @@ int xmp_smix_load_sample(xmp_context opaque, int num, const char *path)
 		
 	/* Init instrument */
 
-	xxi->sub = (struct xmp_subinstrument*)calloc(sizeof(struct xmp_subinstrument), 1);
+	xxi->sub = (struct xmp_subinstrument *)calloc(sizeof(struct xmp_subinstrument), 1);
 	if (xxi->sub == NULL) {
 		retval = -XMP_ERROR_SYSTEM;
 		goto err1;
@@ -264,7 +264,7 @@ int xmp_smix_load_sample(xmp_context opaque, int num, const char *path)
 	xxs->lpe = 0;
 	xxs->flg = bits == 16 ? XMP_SAMPLE_16BIT : 0;
 
-	xxs->data = (unsigned char*)malloc(size + 8);
+	xxs->data = (unsigned char *)malloc(size + 8);
 	if (xxs->data == NULL) {
 		retval = -XMP_ERROR_SYSTEM;
 		goto err2;

--- a/src/virtual.c
+++ b/src/virtual.c
@@ -102,7 +102,7 @@ int libxmp_virt_on(struct context_data *ctx, int num)
 
 	p->virt.maxvoc = libxmp_mixer_numvoices(ctx, num);
 
-	p->virt.voice_array = calloc(p->virt.maxvoc,
+	p->virt.voice_array = (struct mixer_voice*)calloc(p->virt.maxvoc,
 				sizeof(struct mixer_voice));
 	if (p->virt.voice_array == NULL)
 		goto err;
@@ -116,7 +116,7 @@ int libxmp_virt_on(struct context_data *ctx, int num)
 	/* Initialize Paula simulator */
 	if (IS_AMIGA_MOD()) {
 		for (i = 0; i < p->virt.maxvoc; i++) {
-			p->virt.voice_array[i].paula = calloc(1, sizeof (struct paula_state));
+			p->virt.voice_array[i].paula = (struct paula_state*)calloc(1, sizeof (struct paula_state));
 			if (p->virt.voice_array[i].paula == NULL) {
 				goto err2;
 			}
@@ -125,7 +125,7 @@ int libxmp_virt_on(struct context_data *ctx, int num)
 	}
 #endif
 
-	p->virt.virt_channel = malloc(p->virt.virt_channels *
+	p->virt.virt_channel = (struct virt_channel*)malloc(p->virt.virt_channels *
 				sizeof(struct virt_channel));
 	if (p->virt.virt_channel == NULL)
 		goto err2;

--- a/src/virtual.c
+++ b/src/virtual.c
@@ -102,7 +102,7 @@ int libxmp_virt_on(struct context_data *ctx, int num)
 
 	p->virt.maxvoc = libxmp_mixer_numvoices(ctx, num);
 
-	p->virt.voice_array = (struct mixer_voice*)calloc(p->virt.maxvoc,
+	p->virt.voice_array = (struct mixer_voice *)calloc(p->virt.maxvoc,
 				sizeof(struct mixer_voice));
 	if (p->virt.voice_array == NULL)
 		goto err;
@@ -116,7 +116,7 @@ int libxmp_virt_on(struct context_data *ctx, int num)
 	/* Initialize Paula simulator */
 	if (IS_AMIGA_MOD()) {
 		for (i = 0; i < p->virt.maxvoc; i++) {
-			p->virt.voice_array[i].paula = (struct paula_state*)calloc(1, sizeof (struct paula_state));
+			p->virt.voice_array[i].paula = (struct paula_state *)calloc(1, sizeof (struct paula_state));
 			if (p->virt.voice_array[i].paula == NULL) {
 				goto err2;
 			}
@@ -125,7 +125,7 @@ int libxmp_virt_on(struct context_data *ctx, int num)
 	}
 #endif
 
-	p->virt.virt_channel = (struct virt_channel*)malloc(p->virt.virt_channels *
+	p->virt.virt_channel = (struct virt_channel *)malloc(p->virt.virt_channels *
 				sizeof(struct virt_channel));
 	if (p->virt.virt_channel == NULL)
 		goto err2;


### PR DESCRIPTION
Hello! I maintain a shallow fork of libxmp-lite as a built-in library of a project of mine.

In order to compile properly in my project, my fork has had several tweaks and fixes applied to it. Most notably, it is able to compile as valid C++. I figured it would benefit both of us if these modifications were upstreamed: that way, the codebase is made more robust and portable, and I don't have to reapply so many modifications whenever I update my project's copy of the library.

Unfortunately, these modifications _only_ extend to libxmp-lite: my fork isn't based on the regular libxmp, so these changes won't make the entire libxmp library valid C++ nor will it address all of libxmp's uses of absolute include paths.

Hopefully someone more familiar with libxmp than me can apply my modifications to the rest of the codebase. If not, then at least libxmp-lite can benefit from this, even if libxmp doesn't.

I recommend reviewing each commit individually instead of using the 'Files changed' tab: viewing all of the changes at once is pretty messy.