### PR TITLE
Fix unused variable warnings in test-dev.

### DIFF
--- a/test-dev/test_api_prev_position.c
+++ b/test-dev/test_api_prev_position.c
@@ -5,7 +5,7 @@ TEST(test_api_prev_position)
 	xmp_context opaque;
 	struct context_data *ctx;
 	struct player_data *p;
-	int state, ret, i;
+	int state, ret;
 
 	opaque = xmp_create_context();
 	ctx = (struct context_data *)opaque;

--- a/test-dev/test_api_set_position.c
+++ b/test-dev/test_api_set_position.c
@@ -5,7 +5,7 @@ TEST(test_api_set_position)
 	xmp_context opaque;
 	struct context_data *ctx;
 	struct player_data *p;
-	int state, ret, i;
+	int state, ret;
 
 	opaque = xmp_create_context();
 	ctx = (struct context_data *)opaque;

--- a/test-dev/test_api_set_row.c
+++ b/test-dev/test_api_set_row.c
@@ -5,7 +5,7 @@ TEST(test_api_set_row)
 	xmp_context opaque;
 	struct context_data *ctx;
 	struct player_data *p;
-	int state, ret, i;
+	int state, ret;
 
 	opaque = xmp_create_context();
 	ctx = (struct context_data *)opaque;

--- a/test-dev/test_api_smix_load_sample.c
+++ b/test-dev/test_api_smix_load_sample.c
@@ -6,8 +6,7 @@ TEST(test_api_smix_load_sample)
 	xmp_context opaque;
 	struct context_data *ctx;
 	struct player_data *p;
-	struct mixer_voice *vi;
-	int voc, ret;
+	int ret;
 
 	opaque = xmp_create_context();
 	ctx = (struct context_data *)opaque;

--- a/test-dev/test_api_test_module_from_callbacks.c
+++ b/test-dev/test_api_test_module_from_callbacks.c
@@ -48,7 +48,7 @@ TEST(test_api_test_module_from_callbacks)
 {
 	struct xmp_test_info tinfo;
 	struct xmp_callbacks t1, t2, t3;
-	int ret, err;
+	int ret;
 	FILE *f;
 
 	/* unsupported format */

--- a/test-dev/test_api_test_module_from_file.c
+++ b/test-dev/test_api_test_module_from_file.c
@@ -15,7 +15,7 @@ static int test_module_from_file_helper(const char* filename, struct xmp_test_in
 TEST(test_api_test_module_from_file)
 {
 	struct xmp_test_info tinfo;
-	int ret, err;
+	int ret;
 
 	/* unsupported format */
 	ret = test_module_from_file_helper("data/storlek_01.data", &tinfo);

--- a/test-dev/test_api_test_module_from_memory.c
+++ b/test-dev/test_api_test_module_from_memory.c
@@ -17,7 +17,7 @@ static int test_module_from_memory_helper(const char* filename, struct xmp_test_
 TEST(test_api_test_module_from_memory)
 {
 	struct xmp_test_info tinfo;
-	int ret, err;
+	int ret;
 	char* buf;
 
 	/* Sufficient to hold all file buffers */

--- a/test-dev/test_fuzzer_669_truncated.c
+++ b/test-dev/test_fuzzer_669_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_669_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_abk_0_instruments.c
+++ b/test-dev/test_fuzzer_abk_0_instruments.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_abk_0_instruments)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_abk_truncated.c
+++ b/test-dev/test_fuzzer_abk_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_abk_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_amf_truncated.c
+++ b/test-dev/test_fuzzer_amf_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_amf_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_amf_truncated2.c
+++ b/test-dev/test_fuzzer_amf_truncated2.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_amf_truncated2)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_arch_invalid_patterns.c
+++ b/test-dev/test_fuzzer_arch_invalid_patterns.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_arch_invalid_patterns)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_chip_truncated.c
+++ b/test-dev/test_fuzzer_chip_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_chip_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_dbm_chunk_order.c
+++ b/test-dev/test_fuzzer_dbm_chunk_order.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_dbm_chunk_order)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_dbm_invalid_instruments.c
+++ b/test-dev/test_fuzzer_dbm_invalid_instruments.c
@@ -9,7 +9,6 @@
 TEST(test_fuzzer_dbm_invalid_instruments)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_dbm_name_buffer_overflow.c
+++ b/test-dev/test_fuzzer_dbm_name_buffer_overflow.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_dbm_name_buffer_overflow)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_dbm_sample_count.c
+++ b/test-dev/test_fuzzer_dbm_sample_count.c
@@ -8,7 +8,6 @@
 TEST(test_fuzzer_dbm_sample_count)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_dbm_truncated.c
+++ b/test-dev/test_fuzzer_dbm_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_dbm_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_dbm_truncated_inst.c
+++ b/test-dev/test_fuzzer_dbm_truncated_inst.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_dbm_truncated_inst)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_digi_truncated.c
+++ b/test-dev/test_fuzzer_digi_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_digi_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_dt_channels_bound.c
+++ b/test-dev/test_fuzzer_dt_channels_bound.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_dt_channels_bound)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_dt_duplicate_chunk.c
+++ b/test-dev/test_fuzzer_dt_duplicate_chunk.c
@@ -8,7 +8,6 @@
 TEST(test_fuzzer_dt_duplicate_chunk)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_dt_instrument_count.c
+++ b/test-dev/test_fuzzer_dt_instrument_count.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_dt_instrument_count)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_dt_invalid_loop.c
+++ b/test-dev/test_fuzzer_dt_invalid_loop.c
@@ -9,7 +9,6 @@
 TEST(test_fuzzer_dt_invalid_loop)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_dt_truncated.c
+++ b/test-dev/test_fuzzer_dt_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_dt_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_emod_duplicate_chunk.c
+++ b/test-dev/test_fuzzer_emod_duplicate_chunk.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_emod_duplicate_chunk)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_far_truncated.c
+++ b/test-dev/test_fuzzer_far_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_far_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_flt_umr.c
+++ b/test-dev/test_fuzzer_flt_umr.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_flt_umr)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_fnk_channels_bound.c
+++ b/test-dev/test_fuzzer_fnk_channels_bound.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_fnk_channels_bound)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_fnk_invalid_sample_size.c
+++ b/test-dev/test_fuzzer_fnk_invalid_sample_size.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_fnk_invalid_sample_size)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_fnk_patterns_bound.c
+++ b/test-dev/test_fuzzer_fnk_patterns_bound.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_fnk_patterns_bound)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_gal5_channels_bound.c
+++ b/test-dev/test_fuzzer_gal5_channels_bound.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_gal5_channels_bound)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_gal5_duplicate_instrument.c
+++ b/test-dev/test_fuzzer_gal5_duplicate_instrument.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_gal5_duplicate_instrument)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_gal5_invalid_sample_num.c
+++ b/test-dev/test_fuzzer_gal5_invalid_sample_num.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_gal5_invalid_sample_num)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_gal5_truncated_info.c
+++ b/test-dev/test_fuzzer_gal5_truncated_info.c
@@ -8,7 +8,6 @@
 TEST(test_fuzzer_gal5_truncated_info)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	void *buffer;
 	long size;
 	int ret;

--- a/test-dev/test_fuzzer_gdm_invalid_sample_size.c
+++ b/test-dev/test_fuzzer_gdm_invalid_sample_size.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_gdm_invalid_sample_size)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_gdm_samples_bound.c
+++ b/test-dev/test_fuzzer_gdm_samples_bound.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_gdm_samples_bound)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_gdm_truncated.c
+++ b/test-dev/test_fuzzer_gdm_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_gdm_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_gdm_truncated_header.c
+++ b/test-dev/test_fuzzer_gdm_truncated_header.c
@@ -8,7 +8,6 @@
 TEST(test_fuzzer_gdm_truncated_header)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	void *buffer;
 	long size;
 	int ret;

--- a/test-dev/test_fuzzer_hmn_truncated.c
+++ b/test-dev/test_fuzzer_hmn_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_hmn_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_ice_truncated.c
+++ b/test-dev/test_fuzzer_ice_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_ice_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_imf_truncated.c
+++ b/test-dev/test_fuzzer_imf_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_imf_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_ims_scan_loop.c
+++ b/test-dev/test_fuzzer_ims_scan_loop.c
@@ -8,7 +8,6 @@
 TEST(test_fuzzer_ims_scan_loop)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_ims_truncated_magic.c
+++ b/test-dev/test_fuzzer_ims_truncated_magic.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_ims_truncated_magic)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_it_dca_3.c
+++ b/test-dev/test_fuzzer_it_dca_3.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_it_dca_3)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_it_invalid_compressed.c
+++ b/test-dev/test_fuzzer_it_invalid_compressed.c
@@ -6,7 +6,6 @@
 TEST(test_fuzzer_it_invalid_compressed)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_it_long_patterns.c
+++ b/test-dev/test_fuzzer_it_long_patterns.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_it_long_patterns)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_it_truncated_header.c
+++ b/test-dev/test_fuzzer_it_truncated_header.c
@@ -8,7 +8,6 @@
 TEST(test_fuzzer_it_truncated_header)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	void *buffer;
 	long size;
 	int ret;

--- a/test-dev/test_fuzzer_it_truncated_pattern.c
+++ b/test-dev/test_fuzzer_it_truncated_pattern.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_it_truncated_pattern)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_liq_no_valid_orders.c
+++ b/test-dev/test_fuzzer_liq_no_valid_orders.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_liq_no_valid_orders)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_liq_truncated.c
+++ b/test-dev/test_fuzzer_liq_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_liq_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_masi_invalid_length.c
+++ b/test-dev/test_fuzzer_masi_invalid_length.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_masi_invalid_length)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_masi_seek_loop.c
+++ b/test-dev/test_fuzzer_masi_seek_loop.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_masi_seek_loop)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_masi_truncated.c
+++ b/test-dev/test_fuzzer_masi_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_masi_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_mdl_duplicate_chunk.c
+++ b/test-dev/test_fuzzer_mdl_duplicate_chunk.c
@@ -8,7 +8,6 @@
 TEST(test_fuzzer_mdl_duplicate_chunk)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_mdl_duplicate_is_chunk.c
+++ b/test-dev/test_fuzzer_mdl_duplicate_is_chunk.c
@@ -8,7 +8,6 @@
 TEST(test_fuzzer_mdl_duplicate_is_chunk)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_mdl_duplicate_pa_chunk.c
+++ b/test-dev/test_fuzzer_mdl_duplicate_pa_chunk.c
@@ -8,7 +8,6 @@
 TEST(test_fuzzer_mdl_duplicate_pa_chunk)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_mdl_duplicate_sa_chunk.c
+++ b/test-dev/test_fuzzer_mdl_duplicate_sa_chunk.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_mdl_duplicate_sa_chunk)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_mdl_ii_after_is.c
+++ b/test-dev/test_fuzzer_mdl_ii_after_is.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_mdl_ii_after_is)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_mdl_invalid_chunk_order.c
+++ b/test-dev/test_fuzzer_mdl_invalid_chunk_order.c
@@ -8,7 +8,6 @@
 TEST(test_fuzzer_mdl_invalid_chunk_order)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_mdl_invalid_run.c
+++ b/test-dev/test_fuzzer_mdl_invalid_run.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_mdl_invalid_run)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_mdl_invalid_sample.c
+++ b/test-dev/test_fuzzer_mdl_invalid_sample.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_mdl_invalid_sample)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_mdl_truncated.c
+++ b/test-dev/test_fuzzer_mdl_truncated.c
@@ -8,7 +8,6 @@
 TEST(test_fuzzer_mdl_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_mdl_umr.c
+++ b/test-dev/test_fuzzer_mdl_umr.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_mdl_umr)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_med2_truncated.c
+++ b/test-dev/test_fuzzer_med2_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_med2_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_med3_invalid_pattern.c
+++ b/test-dev/test_fuzzer_med3_invalid_pattern.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_med3_invalid_pattern)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_med4_instrument_name.c
+++ b/test-dev/test_fuzzer_med4_instrument_name.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_med4_instrument_name)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_med4_invalid_iff.c
+++ b/test-dev/test_fuzzer_med4_invalid_iff.c
@@ -6,7 +6,6 @@
 TEST(test_fuzzer_med4_invalid_iff)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_med4_invalid_sample.c
+++ b/test-dev/test_fuzzer_med4_invalid_sample.c
@@ -6,7 +6,6 @@
 TEST(test_fuzzer_med4_invalid_sample)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_mfp_truncated.c
+++ b/test-dev/test_fuzzer_mfp_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_mfp_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_mgt_patterns_bound.c
+++ b/test-dev/test_fuzzer_mgt_patterns_bound.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_mgt_patterns_bound)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_misc.c
+++ b/test-dev/test_fuzzer_misc.c
@@ -6,7 +6,6 @@
 TEST(test_fuzzer_misc)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	/* 0x84 is specifically to check for a Coconizer bug. */
 	const char buf[9] = "\x84ZCDEFGH";
 	char msg[32];

--- a/test-dev/test_fuzzer_mmd0_sample_count.c
+++ b/test-dev/test_fuzzer_mmd0_sample_count.c
@@ -8,7 +8,6 @@
 TEST(test_fuzzer_mmd0_sample_count)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_mmd1_channel_count.c
+++ b/test-dev/test_fuzzer_mmd1_channel_count.c
@@ -8,7 +8,6 @@
 TEST(test_fuzzer_mmd1_channel_count)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_mmd3_invalid_mmdinfo.c
+++ b/test-dev/test_fuzzer_mmd3_invalid_mmdinfo.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_mmd3_invalid_mmdinfo)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_mmd3_invalid_sample_size.c
+++ b/test-dev/test_fuzzer_mmd3_invalid_sample_size.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_mmd3_invalid_sample_size)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_mod_no_null_terminator.c
+++ b/test-dev/test_fuzzer_mod_no_null_terminator.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_mod_no_null_terminator)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_mod_no_valid_orders.c
+++ b/test-dev/test_fuzzer_mod_no_valid_orders.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_mod_no_valid_orders)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_mod_scan_row_limit.c
+++ b/test-dev/test_fuzzer_mod_scan_row_limit.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_mod_scan_row_limit)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_mtm_channels_bound.c
+++ b/test-dev/test_fuzzer_mtm_channels_bound.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_mtm_channels_bound)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_okt_duplicate_chunk.c
+++ b/test-dev/test_fuzzer_okt_duplicate_chunk.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_okt_duplicate_chunk)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_okt_invalid_chunk_order.c
+++ b/test-dev/test_fuzzer_okt_invalid_chunk_order.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_okt_invalid_chunk_order)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_okt_sbod_leak.c
+++ b/test-dev/test_fuzzer_okt_sbod_leak.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_okt_sbod_leak)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_prowizard_di_invalid_offsets.c
+++ b/test-dev/test_fuzzer_prowizard_di_invalid_offsets.c
@@ -6,7 +6,6 @@
 TEST(test_fuzzer_prowizard_di_invalid_offsets)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_prowizard_di_patterns_bound.c
+++ b/test-dev/test_fuzzer_prowizard_di_patterns_bound.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_prowizard_di_patterns_bound)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_prowizard_di_patterns_test.c
+++ b/test-dev/test_fuzzer_prowizard_di_patterns_test.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_prowizard_di_patterns_test)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_prowizard_di_truncated.c
+++ b/test-dev/test_fuzzer_prowizard_di_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_prowizard_di_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_prowizard_pha_patterns_bound.c
+++ b/test-dev/test_fuzzer_prowizard_pha_patterns_bound.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_prowizard_pha_patterns_bound)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_prowizard_tp1_invalid_length.c
+++ b/test-dev/test_fuzzer_prowizard_tp1_invalid_length.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_prowizard_tp1_invalid_length)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_prowizard_tp1_invalid_paddr.c
+++ b/test-dev/test_fuzzer_prowizard_tp1_invalid_paddr.c
@@ -8,7 +8,6 @@
 TEST(test_fuzzer_prowizard_tp1_invalid_paddr)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_prowizard_tp3_patterns_bound.c
+++ b/test-dev/test_fuzzer_prowizard_tp3_patterns_bound.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_prowizard_tp3_patterns_bound)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_prowizard_tp3_samples_bound.c
+++ b/test-dev/test_fuzzer_prowizard_tp3_samples_bound.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_prowizard_tp3_samples_bound)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_psm_samples_bound.c
+++ b/test-dev/test_fuzzer_psm_samples_bound.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_psm_samples_bound)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_pt3_ptdt_leak.c
+++ b/test-dev/test_fuzzer_pt3_ptdt_leak.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_pt3_ptdt_leak)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_pt3_truncated.c
+++ b/test-dev/test_fuzzer_pt3_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_pt3_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_ptm_truncated.c
+++ b/test-dev/test_fuzzer_ptm_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_ptm_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_rtm_truncated.c
+++ b/test-dev/test_fuzzer_rtm_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_rtm_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_rtm_zero_samples.c
+++ b/test-dev/test_fuzzer_rtm_zero_samples.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_rtm_zero_samples)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_s3m_invalid_sample_size.c
+++ b/test-dev/test_fuzzer_s3m_invalid_sample_size.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_s3m_invalid_sample_size)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_s3m_invalid_sample_size2.c
+++ b/test-dev/test_fuzzer_s3m_invalid_sample_size2.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_s3m_invalid_sample_size2)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_sfx_truncated.c
+++ b/test-dev/test_fuzzer_sfx_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_sfx_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_st_invalid_sample_count.c
+++ b/test-dev/test_fuzzer_st_invalid_sample_count.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_st_invalid_sample_count)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_st_truncated.c
+++ b/test-dev/test_fuzzer_st_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_st_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_stim_truncated.c
+++ b/test-dev/test_fuzzer_stim_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_stim_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_stm_patterns_bound.c
+++ b/test-dev/test_fuzzer_stm_patterns_bound.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_stm_patterns_bound)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_stx_instruments_bound.c
+++ b/test-dev/test_fuzzer_stx_instruments_bound.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_stx_instruments_bound)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_stx_truncated.c
+++ b/test-dev/test_fuzzer_stx_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_stx_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_sym_truncated_lzw.c
+++ b/test-dev/test_fuzzer_sym_truncated_lzw.c
@@ -9,7 +9,6 @@
 TEST(test_fuzzer_sym_truncated_lzw)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_ult_channels_bound.c
+++ b/test-dev/test_fuzzer_ult_channels_bound.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_ult_channels_bound)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_ult_invalid_tracks.c
+++ b/test-dev/test_fuzzer_ult_invalid_tracks.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_ult_invalid_tracks)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_ult_truncated.c
+++ b/test-dev/test_fuzzer_ult_truncated.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_ult_truncated)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_ult_v000.c
+++ b/test-dev/test_fuzzer_ult_v000.c
@@ -8,7 +8,6 @@
 TEST(test_fuzzer_ult_v000)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_umx_invalid_names.c
+++ b/test-dev/test_fuzzer_umx_invalid_names.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_umx_invalid_names)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_xm_negative_instsize.c
+++ b/test-dev/test_fuzzer_xm_negative_instsize.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_xm_negative_instsize)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_xm_vorbis_crash.c
+++ b/test-dev/test_fuzzer_xm_vorbis_crash.c
@@ -6,7 +6,6 @@
 TEST(test_fuzzer_xm_vorbis_crash)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_fuzzer_xm_zero_samples.c
+++ b/test-dev/test_fuzzer_xm_zero_samples.c
@@ -7,7 +7,6 @@
 TEST(test_fuzzer_xm_zero_samples)
 {
 	xmp_context opaque;
-	struct xmp_module_info info;
 	int ret;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_openmpt_it_randompan.c
+++ b/test-dev/test_openmpt_it_randompan.c
@@ -13,7 +13,6 @@ TEST(test_openmpt_it_randompan)
 	struct xmp_frame_info info;
 	struct xmp_channel_info *ci;
 	int values[64];
-	int i;
 
 	opaque = xmp_create_context();
 	xmp_load_module(opaque, "openmpt/it/RandomPan.it");

--- a/test-dev/test_openmpt_it_swing1.c
+++ b/test-dev/test_openmpt_it_swing1.c
@@ -11,7 +11,6 @@ TEST(test_openmpt_it_swing1)
 	xmp_context opaque;
 	struct xmp_frame_info info;
 	struct xmp_channel_info *ci;
-	int i;
 
 	opaque = xmp_create_context();
 	xmp_load_module(opaque, "openmpt/it/swing1.it");

--- a/test-dev/test_openmpt_it_swing2.c
+++ b/test-dev/test_openmpt_it_swing2.c
@@ -10,7 +10,6 @@ TEST(test_openmpt_it_swing2)
 	xmp_context opaque;
 	struct xmp_frame_info info;
 	struct xmp_channel_info *ci;
-	int i;
 
 	opaque = xmp_create_context();
 	xmp_load_module(opaque, "openmpt/it/swing2.it");

--- a/test-dev/test_openmpt_it_swing3.c
+++ b/test-dev/test_openmpt_it_swing3.c
@@ -12,7 +12,6 @@ TEST(test_openmpt_it_swing3)
 	struct xmp_frame_info info;
 	struct xmp_channel_info *ci;
 	int values[64];
-	int i;
 
 	opaque = xmp_create_context();
 	xmp_load_module(opaque, "openmpt/it/swing3.it");


### PR DESCRIPTION
Fixes numerous warnings MSVC emits when building test-dev. These are mostly my fault from copying old tests as templates. (GCC should also warn about these but I think the normal build system doesn't use -Wextra currently.)