### PR TITLE
Avoid the dllimport spec being enforced and provide the version calls as the working alternative to variables

### DIFF
--- a/include/xmp.h
+++ b/include/xmp.h
@@ -16,12 +16,13 @@ extern "C" {
 #define XMP_VER_RELEASE 0
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
-# if defined(BUILDING_STATIC)
-#  define LIBXMP_EXPORT
-# elif defined(BUILDING_DLL)
+# if defined(BUILDING_DLL)
 #  define LIBXMP_EXPORT __declspec(dllexport)
 # else
-#  define LIBXMP_EXPORT __declspec(dllimport)
+#  define LIBXMP_EXPORT
+#  if !defined(BUILDING_STATIC)
+#   define LIBXMP_EXPORT_VAR __declspec(dllimport)
+#  endif
 # endif
 #elif defined(__OS2__) && defined(__WATCOMC__) && defined(__SW_BD)
 #  define LIBXMP_EXPORT __declspec(dllexport)

--- a/include/xmp.h
+++ b/include/xmp.h
@@ -336,6 +336,9 @@ typedef char *xmp_context;
 LIBXMP_EXPORT_VAR extern const char *xmp_version;
 LIBXMP_EXPORT_VAR extern const unsigned int xmp_vercode;
 
+LIBXMP_EXPORT const char *xmp_get_version     (void);
+LIBXMP_EXPORT const unsigned int xmp_get_vercode (void);
+
 LIBXMP_EXPORT int         xmp_syserrno        (void);
 
 LIBXMP_EXPORT xmp_context xmp_create_context  (void);

--- a/src/control.c
+++ b/src/control.c
@@ -27,6 +27,16 @@
 const char *xmp_version LIBXMP_EXPORT_VAR = XMP_VERSION;
 const unsigned int xmp_vercode LIBXMP_EXPORT_VAR = XMP_VERCODE;
 
+const char *xmp_get_version(void)
+{
+    return XMP_VERSION;
+}
+
+const unsigned int xmp_get_vercode(void)
+{
+    return XMP_VERCODE;
+}
+
 xmp_context xmp_create_context(void)
 {
 	struct context_data *ctx;


### PR DESCRIPTION
Fixes #427