### PR TITLE
Remove unused sys/stat.h includes in depackers.

### DIFF
--- a/src/depackers/ppdepack.c
+++ b/src/depackers/ppdepack.c
@@ -17,7 +17,6 @@
  * - decryption code removed
  */
 
-#include <sys/stat.h>
 #include "../common.h"
 #include "depacker.h"
 

--- a/src/depackers/s404_dec.c
+++ b/src/depackers/s404_dec.c
@@ -13,7 +13,6 @@
 */
 
 /*#include <assert.h>*/
-#include <sys/stat.h>
 #include "../common.h"
 #include "depacker.h"
 

--- a/src/depackers/unarc.c
+++ b/src/depackers/unarc.c
@@ -24,7 +24,6 @@
 #define NOMARCH_VER	"1.4"
 
 #include <ctype.h>
-#include <sys/stat.h>
 #include "../common.h"
 #include "depacker.h"
 #if 0

--- a/src/depackers/xfd.c
+++ b/src/depackers/xfd.c
@@ -14,7 +14,6 @@
 #include <proto/exec.h>
 #include <proto/xfdmaster.h>
 #include <exec/types.h>
-#include <sys/stat.h>
 #include "depacker.h"
 
 static int _test_xfd(unsigned char *buffer, int length)


### PR DESCRIPTION
Minor cleanup for the patches referenced in #442: these files no longer need to include `sys/stat.h`.