### PR TITLE
vorbis: fix warnings for targets where uint32_t is an unsigned long

### DIFF
--- a/src/depackers/vorbis.c
+++ b/src/depackers/vorbis.c
@@ -4778,7 +4778,8 @@ static int get_seek_page_info(stb_vorbis *f, ProbedPage *z)
 // start of a packet
 static int go_to_page_before(stb_vorbis *f, unsigned int limit_offset)
 {
-   unsigned int previous_safe, end;
+   unsigned int previous_safe;
+   uint32 end;
 
    // now we want to seek back 64K from the limit
    if (limit_offset >= 65536 && limit_offset-65536 >= f->first_audio_page_offset)
@@ -5052,11 +5053,11 @@ int stb_vorbis_seek_start(stb_vorbis *f)
 unsigned int stb_vorbis_stream_length_in_samples(stb_vorbis *f)
 {
    unsigned int restore_offset, previous_safe;
-   unsigned int end, last_page_loc;
+   unsigned int last_page_loc;
 
    if (IS_PUSH_MODE(f)) return error(f, VORBIS_invalid_api_mixing);
    if (!f->total_samples) {
-      unsigned int last;
+      uint32 end,last;
       uint32 lo,hi;
       char header[6];
 


### PR DESCRIPTION
src/depackers/vorbis.c: In function 'go_to_page_before':
src/depackers/vorbis.c:4791: warning: passing argument 2 of 'vorbis_find_page' from incompatible pointer type
src/depackers/vorbis.c: In function 'stb_vorbis_stream_length_in_samples':
src/depackers/vorbis.c:5077: warning: passing argument 2 of 'vorbis_find_page' from incompatible pointer type
src/depackers/vorbis.c:5077: warning: passing argument 3 of 'vorbis_find_page' from incompatible pointer type
src/depackers/vorbis.c:5092: warning: passing argument 2 of 'vorbis_find_page' from incompatible pointer type
src/depackers/vorbis.c:5092: warning: passing argument 3 of 'vorbis_find_page' from incompatible pointer type