### PR TITLE
target-specific code / define clean-ups:

### DIFF
--- a/Makefile.vc
+++ b/Makefile.vc
@@ -12,7 +12,7 @@ USE_PROWIZARD	= 1
 
 CC	= cl
 CFLAGS	= /O2 /W3 /MD /Iinclude /DBUILDING_DLL /DWIN32 \
-	  /Dinline=__inline /DPATH_MAX=1024 /D_USE_MATH_DEFINES /D_CRT_SECURE_NO_WARNINGS
+	  /D_USE_MATH_DEFINES /D_CRT_SECURE_NO_WARNINGS
 LD	= link
 LDFLAGS	= /DLL /RELEASE /OUT:$(DLL)
 DLL	= libxmp.dll
@@ -50,10 +50,11 @@ clean:
 	del $(OBJS)
 	del $(DEPACKER_OBJS)
 	del $(PROWIZ_OBJS)
+	del $(TEST)
+	del test\*.dll test\*.exe
 	del $(DLL) *.lib *.exp
 
 check: $(TEST)
 	$(LD) /RELEASE /OUT:test\libxmp-test.exe $(TEST) libxmp.lib
 	copy libxmp.dll test
 	cd test & libxmp-test
-

--- a/Makefile.vc.in
+++ b/Makefile.vc.in
@@ -12,7 +12,7 @@ USE_PROWIZARD	= 1
 
 CC	= cl
 CFLAGS	= /O2 /W3 /MD /Iinclude /DBUILDING_DLL /DWIN32 \
-	  /Dinline=__inline /DPATH_MAX=1024 /D_USE_MATH_DEFINES /D_CRT_SECURE_NO_WARNINGS
+	  /D_USE_MATH_DEFINES /D_CRT_SECURE_NO_WARNINGS
 LD	= link
 LDFLAGS	= /DLL /RELEASE /OUT:$(DLL)
 DLL	= libxmp.dll
@@ -50,10 +50,11 @@ clean:
 	del $(OBJS)
 	del $(DEPACKER_OBJS)
 	del $(PROWIZ_OBJS)
+	del $(TEST)
+	del test\*.dll test\*.exe
 	del $(DLL) *.lib *.exp
 
 check: $(TEST)
 	$(LD) /RELEASE /OUT:test\libxmp-test.exe $(TEST) libxmp.lib
 	copy libxmp.dll test
 	cd test & libxmp-test
-

--- a/lite/Makefile.vc.in
+++ b/lite/Makefile.vc.in
@@ -1,17 +1,16 @@
 # Visual Studio makefile for Windows:
 #	nmake -f Makefile.vc
 #
-
 CC	= cl
 CFLAGS	= /O2 /W3 /MD /Iinclude\libxmp-lite /DBUILDING_DLL /DWIN32 \
-          /Dinline=__inline /D_USE_MATH_DEFINES /D_CRT_SECURE_NO_WARNINGS /DLIBXMP_CORE_PLAYER /DLIBXMP_NO_PROWIZARD /DLIBXMP_NO_DEPACKERS
+	  /D_USE_MATH_DEFINES /D_CRT_SECURE_NO_WARNINGS /DLIBXMP_CORE_PLAYER /DLIBXMP_NO_PROWIZARD /DLIBXMP_NO_DEPACKERS
 LD	= link
 LDFLAGS	= /DLL /RELEASE /OUT:$(DLL)
 DLL	= libxmp-lite.dll
 
 OBJS	= @OBJS@
 
-TEST	= test\md5.obj test\test.obj
+TEST	= src\md5.obj test\test.obj
 
 .c.obj:
 	$(CC) /c /nologo $(CFLAGS) /Fo$*.obj $<
@@ -23,6 +22,8 @@ $(DLL): $(OBJS)
 
 clean:
 	del $(OBJS) $(DLL) *.lib *.exp
+	del $(TEST)
+	del test\*.dll test\*.exe
 
 check: $(TEST)
 	$(LD) /RELEASE /OUT:test\libxmp-lite-test.exe $(TEST) libxmp-lite.lib

--- a/lite/src/loaders/mod_load.c
+++ b/lite/src/loaders/mod_load.c
@@ -28,7 +28,6 @@
  */
 
 #include <ctype.h>
-#include <limits.h>
 #include "loader.h"
 #include "mod.h"
 

--- a/src/common.h
+++ b/src/common.h
@@ -2,6 +2,7 @@
 #define LIBXMP_COMMON_H
 
 #include <stdarg.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -21,6 +22,18 @@
 #else
 #define LIBXMP_BEGIN_DECLS	extern "C" {
 #define LIBXMP_END_DECLS	}
+#endif
+
+#if defined(_MSC_VER) && !defined(__cplusplus)
+#define inline __inline
+#endif
+
+#if defined(_MSC_VER) ||  defined(__WATCOMC__) || defined(__EMX__)
+#define XMP_MAXPATH _MAX_PATH
+#elif defined(PATH_MAX)
+#define XMP_MAXPATH  PATH_MAX
+#else
+#define XMP_MAXPATH  1024
 #endif
 
 #if defined(__MORPHOS__) || defined(__AROS__) || defined(AMIGAOS) || \

--- a/src/depackers/bunzip2.c
+++ b/src/depackers/bunzip2.c
@@ -34,7 +34,6 @@
  */
 
 #include <setjmp.h>
-#include <limits.h>
 #include "../common.h"
 #include "depacker.h"
 #include "crc32.h"

--- a/src/list.h
+++ b/src/list.h
@@ -3,11 +3,8 @@
 
 #include <stddef.h> /* offsetof */
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__WATCOMC__)
 #define __inline__ __inline
-#endif
-#ifdef __WATCOMC__
-#define __inline__   inline
 #endif
 
 /*
@@ -145,4 +142,4 @@ static __inline__ void list_splice(struct list_head *list, struct list_head *hea
 #define list_for_each(pos, head) \
 	for (pos = (head)->next; pos != (head); pos = pos->next)
 
-#endif
+#endif  /* LIBXMP_LIST_H */

--- a/src/loaders/masi_load.c
+++ b/src/loaders/masi_load.c
@@ -62,7 +62,6 @@
  * ugly, maybe caused by finetune issues?
  */
 
-#include <limits.h>
 #include "loader.h"
 #include "iff.h"
 #include "../period.h"

--- a/src/loaders/med2_load.c
+++ b/src/loaders/med2_load.c
@@ -24,11 +24,6 @@
  * MED 1.12 is in Fish disk #255
  */
 
-#ifdef __native_client__
-#include <sys/syslimits.h>
-#else
-#include <limits.h>
-#endif
 #include "loader.h"
 #include "../period.h"
 
@@ -190,7 +185,7 @@ int med2_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	D_(D_INFO "Instruments    : %d ", mod->ins);
 
 	for (i = 0; i < 31; i++) {
-		char path[PATH_MAX];
+		char path[XMP_MAXPATH];
 		char ins_path[256];
 		char ins_name[32];
 		char name[256];
@@ -202,14 +197,14 @@ int med2_load(struct module_data *m, HIO_HANDLE *f, const int start)
 
 		libxmp_get_instrument_path(m, ins_path, 256);
 		if (libxmp_check_filename_case(ins_path, ins_name, name, 256)) {
-			snprintf(path, PATH_MAX, "%s/%s", ins_path, name);
+			snprintf(path, XMP_MAXPATH, "%s/%s", ins_path, name);
 			found = 1;
 		}
 
 		/* Try the module dir if the instrument path didn't work. */
 		if (!found && m->dirname != NULL &&
 		    libxmp_check_filename_case(m->dirname, ins_name, name, 256)) {
-			snprintf(path, PATH_MAX, "%s%s", m->dirname, name);
+			snprintf(path, XMP_MAXPATH, "%s%s", m->dirname, name);
 			found = 1;
 		}
 

--- a/src/loaders/mfp_load.c
+++ b/src/loaders/mfp_load.c
@@ -27,11 +27,6 @@
  */
 
 #include "loader.h"
-#ifdef __native_client__
-#include <sys/syslimits.h>
-#else
-#include <limits.h>
-#endif
 
 static int mfp_test(HIO_HANDLE *, char *, const int);
 static int mfp_load(struct module_data *, HIO_HANDLE *, const int);
@@ -101,7 +96,7 @@ static int mfp_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	struct xmp_module *mod = &m->mod;
 	int i, j, k, x, y;
 	struct xmp_event *event;
-	char smp_filename[PATH_MAX];
+	char smp_filename[XMP_MAXPATH];
 	HIO_HANDLE *s;
 	int size1 /*, size2*/;
 	int pat_addr, pat_table[128][4];
@@ -220,7 +215,7 @@ static int mfp_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	m->basename[0] = 's';
 	m->basename[1] = 'm';
 	m->basename[2] = 'p';
-	snprintf(smp_filename, PATH_MAX, "%s%s", m->dirname, m->basename);
+	snprintf(smp_filename, XMP_MAXPATH, "%s%s", m->dirname, m->basename);
 	if ((s = hio_open(smp_filename, "rb")) == NULL) {
 		/* handle .set filenames like in Kid Chaos*/
 		if (strchr(m->basename, '-')) {

--- a/src/loaders/mod_load.c
+++ b/src/loaders/mod_load.c
@@ -36,7 +36,6 @@
  */
 
 #include <ctype.h>
-#include <limits.h>
 #include "loader.h"
 #include "mod.h"
 
@@ -526,9 +525,7 @@ static int mod_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	}
     }
 
-    /*
-     * Experimental tracker-detection routine
-     */
+    /* Experimental tracker-detection routine */
 
     if (detected)
 	goto skip_test;
@@ -772,7 +769,7 @@ skip_test:
 
 	if (ptsong) {
 	    HIO_HANDLE *s;
-	    char sn[PATH_MAX];
+	    char sn[XMP_MAXPATH];
 	    char tmpname[32];
 	    const char *instname = mod->xxi[i].name;
 
@@ -782,7 +779,7 @@ skip_test:
 	    if (libxmp_copy_name_for_fopen(tmpname, instname, 32))
 		continue;
 
-	    snprintf(sn, PATH_MAX, "%s%s", m->dirname, tmpname);
+	    snprintf(sn, XMP_MAXPATH, "%s%s", m->dirname, tmpname);
 
 	    if ((s = hio_open(sn, "rb")) != NULL) {
 	        if (libxmp_load_sample(m, s, flags, &mod->xxs[i], NULL) < 0) {

--- a/src/loaders/stm_load.c
+++ b/src/loaders/stm_load.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <limits.h>
 #include "loader.h"
 #include "../period.h"
 
@@ -364,7 +363,7 @@ static int stm_load(struct module_data *m, HIO_HANDLE * f, const int start)
 
 		if (sfh.type == STM_TYPE_SONG) {
 			HIO_HANDLE *s;
-			char sn[PATH_MAX];
+			char sn[XMP_MAXPATH];
 			char tmpname[32];
 			const char *instname = mod->xxi[i].name;
 
@@ -374,7 +373,7 @@ static int stm_load(struct module_data *m, HIO_HANDLE * f, const int start)
 			if (libxmp_copy_name_for_fopen(tmpname, instname, 32))
 				continue;
 
-			snprintf(sn, PATH_MAX, "%s%s", m->dirname, tmpname);
+			snprintf(sn, XMP_MAXPATH, "%s%s", m->dirname, tmpname);
 
 			if ((s = hio_open(sn, "rb"))) {
 				if (libxmp_load_sample(m, s, SAMPLE_FLAG_UNS, &mod->xxs[i], NULL) < 0) {

--- a/src/mdataio.h
+++ b/src/mdataio.h
@@ -2,7 +2,6 @@
 #define LIBXMP_MDATAIO_H
 
 #include <stddef.h>
-#include <limits.h>
 #include "common.h"
 
 static inline ptrdiff_t CAN_READ(MFILE *m)

--- a/src/tempfile.c
+++ b/src/tempfile.c
@@ -26,19 +26,16 @@
 
 #ifndef LIBXMP_CORE_PLAYER
 
-#include <limits.h>
-
 #if defined(_MSC_VER) || defined(__WATCOMC__)
 #include <io.h>
 #else
 #include <unistd.h>
 #endif
-
 #ifdef HAVE_UMASK
 #include <sys/stat.h>
 #endif
 
-#include "common.h" /* for libxmp_snprintf */
+#include "common.h"
 #include "tempfile.h"
 
 #ifdef _WIN32
@@ -67,7 +64,7 @@ static int get_temp_dir(char *buf, size_t size)
 
 static int get_temp_dir(char *buf, size_t size)
 {
-	strcpy(buf, "C:\\"); /* size-safe against PATH_MAX */
+	strcpy(buf, "C:\\"); /* size-safe against XMP_MAXPATH */
 	return 0;
 }
 
@@ -75,7 +72,7 @@ static int get_temp_dir(char *buf, size_t size)
 
 static int get_temp_dir(char *buf, size_t size)
 {
-	strcpy(buf, "T:"); /* size-safe against PATH_MAX */
+	strcpy(buf, "T:"); /* size-safe against XMP_MAXPATH */
 	return 0;
 }
 
@@ -120,14 +117,14 @@ static int get_temp_dir(char *buf, size_t size)
 
 
 FILE *make_temp_file(char **filename) {
-	char tmp[PATH_MAX];
+	char tmp[XMP_MAXPATH];
 	FILE *temp;
 	int fd;
 
-	if (get_temp_dir(tmp, PATH_MAX) < 0)
+	if (get_temp_dir(tmp, XMP_MAXPATH) < 0)
 		return NULL;
 
-	strncat(tmp, "xmp_XXXXXX", PATH_MAX - 10);
+	strncat(tmp, "xmp_XXXXXX", XMP_MAXPATH - 10);
 
 	if ((*filename = strdup(tmp)) == NULL)
 		goto err;

--- a/src/virtual.c
+++ b/src/virtual.c
@@ -20,7 +20,6 @@
  * THE SOFTWARE.
  */
 
-#include <limits.h>
 #include "common.h"
 #include "virtual.h"
 #include "mixer.h"

--- a/test-dev/Makefile.in
+++ b/test-dev/Makefile.in
@@ -623,7 +623,8 @@ TEST_PATH	= .
 SRC_PATH	= ../src
 
 TEST_INTERNAL	= md5.o win32.o hio.o load_helpers.o loaders/itsex.o dataio.o scan.o \
-		  loaders/sample.o loaders/common.o period.o depackers/xfnmatch.o memio.o
+		  loaders/sample.o loaders/common.o filetype.o period.o memio.o \
+		  depackers/xfnmatch.o
 
 T_OBJS 		= $(addprefix $(TEST_PATH)/,$(TEST_OBJS)) \
 		  $(addprefix $(SRC_PATH)/,$(TEST_INTERNAL))

--- a/test-dev/Makefile.vc
+++ b/test-dev/Makefile.vc
@@ -1,11 +1,11 @@
 CC	= cl
 CFLAGS	= /O2 /W3 /MD /I..\include /I..\src /DWIN32 \
-	  /Dinline=__inline /DPATH_MAX=1024 /D_USE_MATH_DEFINES /D_CRT_SECURE_NO_WARNINGS
+	  /D_USE_MATH_DEFINES /D_CRT_SECURE_NO_WARNINGS
 LDFLAGS = /RELEASE /OUT:$(EXE)
 EXE	= libxmp-tests.exe
 
 TEST_SOURCES	= util.c main.c simple_module.c compare_mixer_data.c
-XMP_SOURCES	= ..\src\md5.c ..\src\win32.c ..\src\hio.c ..\src\load_helpers.c ..\src\loaders\itsex.c ..\src\dataio.c ..\src\scan.c ..\src\loaders\sample.c ..\src\loaders\common.c ..\src\period.c ..\src\depackers\xfnmatch.c ..\src\memio.c
+XMP_SOURCES	= ..\src\md5.c ..\src\win32.c ..\src\hio.c ..\src\load_helpers.c ..\src\loaders\itsex.c ..\src\dataio.c ..\src\scan.c ..\src\loaders\sample.c ..\src\loaders\common.c ..\src\filetype.c ..\src\period.c ..\src\memio.c ..\src\depackers\xfnmatch.c
 ALL_SOURCES	= $(SOURCES) $(TEST_SOURCES) $(XMP_SOURCES)
 
 TEMP_MAKEFILE	= Makefile.vc.tmp

--- a/test-dev/Makefile.vc.in
+++ b/test-dev/Makefile.vc.in
@@ -1,6 +1,6 @@
 CC	= cl
 CFLAGS	= /O2 /W3 /MD /I..\include /I..\src /DWIN32 \
-	  /Dinline=__inline /DPATH_MAX=1024 /D_USE_MATH_DEFINES /D_CRT_SECURE_NO_WARNINGS
+	  /D_USE_MATH_DEFINES /D_CRT_SECURE_NO_WARNINGS
 LDFLAGS = /RELEASE /OUT:$(EXE)
 EXE	= libxmp-tests.exe
 

--- a/vc/libxmp.vcproj.in
+++ b/vc/libxmp.vcproj.in
@@ -33,15 +33,12 @@
 				Name="VCXMLDataGeneratorTool"
 			/>
 			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
 				Name="VCMIDLTool"
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalIncludeDirectories="..\include"
-				PreprocessorDefinitions="WIN32;NDEBUG;_WINDOWS;BUILDING_DLL;inline=__inline;PATH_MAX=1024;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES"
+				PreprocessorDefinitions="WIN32;NDEBUG;_WINDOWS;BUILDING_DLL;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES"
 				ExceptionHandling="0"
 				RuntimeLibrary="2"
 				UsePrecompiledHeader="0"
@@ -107,16 +104,13 @@
 				Name="VCXMLDataGeneratorTool"
 			/>
 			<Tool
-				Name="VCWebServiceProxyGeneratorTool"
-			/>
-			<Tool
 				Name="VCMIDLTool"
 				TargetEnvironment="3"
 			/>
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalIncludeDirectories="..\include"
-				PreprocessorDefinitions="WIN32;NDEBUG;_WINDOWS;BUILDING_DLL;inline=__inline;PATH_MAX=1024;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES"
+				PreprocessorDefinitions="WIN32;NDEBUG;_WINDOWS;BUILDING_DLL;_CRT_SECURE_NO_WARNINGS;_USE_MATH_DEFINES"
 				ExceptionHandling="0"
 				RuntimeLibrary="2"
 				UsePrecompiledHeader="0"


### PR DESCRIPTION
- change libxmp_check_filename_case to call libxmp_get_filetype
  for case-insensitive targets - removes all of target-specific
  ifdef dance from common.c.  filetype.o added to TEST_INTERNAL
  in test-dev to satisfy the libxmp_get_filetype dependency() of
  common.o.
- add XMP_MAXPATH, default to _MAX_PATH for MSVC and Watcom, to
  PATH_MAX if it's defined, to 1024 if not.  change all uses of
  PATH_MAX to XMP_MAXPATH.
- common.h now includes limit.h for PATH_MAX: remove individual
  limits.h includes. remove the only-two-remaining nacl-specific
  sys/syslimits.h includes.
- simplify the __inline define in list.h.
- move /Dinline=__inline from VC makefiles to common.h for MSVC
- fix 'make check' in lite/Makefile.vc.
- properly clean test/* binaries in Makefile.vc.