### PR TITLE
move USE_VERSIONED_SYMBOLS decision to configuration time:

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -142,13 +142,25 @@ case $host_os in
 	;;
 esac
 
+have_versioned_symbols=no
 if test $ac_cv_c_flag_f_visibility_hidden = no; then
    CFLAGS="${old_CFLAGS}"
 else
    CFLAGS="${old_CFLAGS} -fvisibility=hidden -DXMP_SYM_VISIBILITY"
-   LD_VERSCRIPT="-Wl,--version-script,libxmp.map"
 
-dnl https://github.com/libxmp/libxmp/issues/385
+   if test $ac_cv_prog_gnu_ld = yes; then
+      case "${host_os}" in
+        emscripten*|beos*|atheos*|*mint)
+          ;;
+        *) if test "${enable_shared}" != no; then
+              have_versioned_symbols=yes
+              CFLAGS_SHARED="${CFLAGS_SHARED} -DUSE_VERSIONED_SYMBOLS=1"
+         fi
+         LD_VERSCRIPT="-Wl,--version-script,libxmp.map"
+         ;;
+      esac
+   fi
+
    old_CFLAGS="${CFLAGS}"
    if test $ac_cv_c_flag_w_error = yes; then
       CFLAGS="${CFLAGS} -Werror"
@@ -166,6 +178,9 @@ void foo(void) __attribute__((__symver__("foo@bar")));],
     [CFLAGS="${CFLAGS} -DHAVE_ATTRIBUTE_SYMVER"],
     [CFLAGS="${CFLAGS}"])
 fi
+
+AC_MSG_CHECKING(whether to enable versioned symbols support)
+AC_MSG_RESULT($have_versioned_symbols)
 
 dnl for clang
 XMP_TRY_COMPILE(whether compiler understands -Wunknown-warning-option,

--- a/lite/configure.ac
+++ b/lite/configure.ac
@@ -145,13 +145,25 @@ case $host_os in
 	;;
 esac
 
+have_versioned_symbols=no
 if test $ac_cv_c_flag_f_visibility_hidden = no; then
    CFLAGS="${old_CFLAGS}"
 else
    CFLAGS="${old_CFLAGS} -fvisibility=hidden -DXMP_SYM_VISIBILITY"
-   LD_VERSCRIPT="-Wl,--version-script,libxmp.map"
 
-dnl https://github.com/libxmp/libxmp/issues/385
+   if test $ac_cv_prog_gnu_ld = yes; then
+      case "${host_os}" in
+        emscripten*|beos*|atheos*|*mint)
+          ;;
+        *) if test "${enable_shared}" != no; then
+              have_versioned_symbols=yes
+              CFLAGS_SHARED="${CFLAGS_SHARED} -DUSE_VERSIONED_SYMBOLS=1"
+         fi
+         LD_VERSCRIPT="-Wl,--version-script,libxmp.map"
+         ;;
+      esac
+   fi
+
    old_CFLAGS="${CFLAGS}"
    if test $ac_cv_c_flag_w_error = yes; then
       CFLAGS="${CFLAGS} -Werror"
@@ -169,6 +181,9 @@ void foo(void) __attribute__((__symver__("foo@bar")));],
     [CFLAGS="${CFLAGS} -DHAVE_ATTRIBUTE_SYMVER"],
     [CFLAGS="${CFLAGS}"])
 fi
+
+AC_MSG_CHECKING(whether to enable versioned symbols support)
+AC_MSG_RESULT($have_versioned_symbols)
 
 dnl for clang
 XMP_TRY_COMPILE(whether compiler understands -Wunknown-warning-option,

--- a/src/common.h
+++ b/src/common.h
@@ -42,9 +42,6 @@
 #define LIBXMP_AMIGA	1	/* to identify amiga platforms. */
 #endif
 
-#if (defined(__GNUC__) || defined(__clang__)) && defined(XMP_SYM_VISIBILITY)
-#if !defined(_WIN32) && !defined(__ANDROID__) && !defined(__APPLE__) && !defined(LIBXMP_AMIGA) && !defined(__MSDOS__) && !defined(B_BEOS_VERSION) && !defined(__ATHEOS__) && !defined(EMSCRIPTEN) && !defined(__MINT__)
-#define USE_VERSIONED_SYMBOLS
 #ifdef HAVE_EXTERNAL_VISIBILITY
 #define LIBXMP_EXPORT_VERSIONED __attribute__((visibility("default"),externally_visible))
 #else
@@ -54,8 +51,6 @@
 #define LIBXMP_ATTRIB_SYMVER(_sym) __attribute__((__symver__(_sym)))
 #else
 #define LIBXMP_ATTRIB_SYMVER(_sym)
-#endif
-#endif
 #endif
 
 /* AmigaOS fixes by Chris Young <cdyoung@ntlworld.com>, Nov 25, 2007


### PR DESCRIPTION
Versioned symbols use requires symbols visilibity and GNU ld as linker,
which our configury checks for.  common.h has additional black-listing
against target OSs, like Android, Apple, etc:

- Apple: macOS uses its own non-GNU ld and is detected by configury, so
  it is handled.
- Android: The blacklist should have been because jni/Android.mk is set
  to produce a static library.  There is nothing else preventing it, so
  the new configury doesn't blacklist it.
- Emscripten, BeOS, Atheos, mint: New configury manually blacklists them
  to match original common.h, just in case.
- Win32, amiga: already filtered out by not having symbol visibility.

Differently: the new configury version enables the versioned symbols only
for shared libraries, not static.

Closes: https://github.com/libxmp/libxmp/issues/396