### PR TITLE
added -Wall -Wwrite-strings to test-dev CFLAGS and fixed warnings.

### DIFF
--- a/test-dev/compare_mixer_data.c
+++ b/test-dev/compare_mixer_data.c
@@ -4,7 +4,7 @@
 #include "../src/mixer.h"
 #include "../src/virtual.h"
 
-static void _compare_mixer_data(char *mod, char *data, int loops, int ignore_rv)
+static void _compare_mixer_data(const char *mod, const char *data, int loops, int ignore_rv)
 {
 	xmp_context opaque;
 	struct context_data *ctx;
@@ -90,17 +90,17 @@ static void _compare_mixer_data(char *mod, char *data, int loops, int ignore_rv)
 	xmp_free_context(opaque);
 }
 
-void compare_mixer_data(char *mod, char *data)
+void compare_mixer_data(const char *mod, const char *data)
 {
 	_compare_mixer_data(mod, data, 1, 0);
 }
 
-void compare_mixer_data_loops(char *mod, char *data, int loops)
+void compare_mixer_data_loops(const char *mod, const char *data, int loops)
 {
 	_compare_mixer_data(mod, data, loops, 0);
 }
 
-void compare_mixer_data_no_rv(char *mod, char *data)
+void compare_mixer_data_no_rv(const char *mod, const char *data)
 {
 	_compare_mixer_data(mod, data, 1, 1);
 }

--- a/test-dev/configure.ac
+++ b/test-dev/configure.ac
@@ -12,11 +12,23 @@ AC_DEFUN([XMP_TRY_COMPILE],[
     CFLAGS="${oldcflags}"])
   AS_IF([test "x$$2" = xyes], [$5], [$6])])
 
+XMP_TRY_COMPILE(whether compiler understands -Wall,
+  ac_cv_c_flag_w_all,
+  -Wall,[
+  int main(void){return 0;}],
+  CFLAGS="${CFLAGS} -Wall")
+
+XMP_TRY_COMPILE(whether compiler understands -Wwrite-strings,
+  ac_cv_c_flag_w_write_strings,
+  -Wwrite-strings,[
+  int main(void){return 0;}],
+  CFLAGS="${CFLAGS} -Wwrite-strings")
+
 XMP_TRY_COMPILE(whether compiler understands -Wunused-result,
   ac_cv_c_flag_w_unused_result,
   -Wunused-result,[
-  int main(){}],
-  CFLAGS="${CFLAGS} -Wno-unused-result")  
+  int main(void){return 0;}],
+  CFLAGS="${CFLAGS} -Wno-unused-result")
 
 AC_CHECK_LIB(m,pow)
 AC_CHECK_FUNCS(pipe popen mkstemp fnmatch strlcpy strlcat round)

--- a/test-dev/main.c
+++ b/test-dev/main.c
@@ -33,22 +33,22 @@
 
 struct test {
 	struct list_head list;
-	char *name;
+	const char *name;
 	int (*func)(void);
 };
 
 static LIST_HEAD(test_list);
 
-static char *color_fail = "";
-static char *color_pass = "";
-static char *color_test = "";
-static char *color_none = "";
+static const char *color_fail = "";
+static const char *color_pass = "";
+static const char *color_test = "";
+static const char *color_none = "";
 
 static int num_tests = 0;
 
 #define add_test(x) _add_test(#x, _test_func_##x)
 
-void _add_test(char *name, int (*func)(void))
+void _add_test(const char *name, int (*func)(void))
 {
 	struct test *t;
 

--- a/test-dev/test.h
+++ b/test-dev/test.h
@@ -54,13 +54,13 @@ int play_frame(struct context_data *);
 
 int compare_module(struct xmp_module *, FILE *);
 void dump_module(struct xmp_module *, FILE *);
-int compare_md5(unsigned char *, char *);
-int check_md5(char *, char *);
+int compare_md5(const unsigned char *, const char *);
+int check_md5(const char *, const char *);
 int check_randomness(int *, int, double);
 void read_file_to_memory(const char *, void **, long *);
-void compare_mixer_data(char *, char *);
-void compare_mixer_data_loops(char *, char *, int);
-void compare_mixer_data_no_rv(char *, char *);
+void compare_mixer_data(const char *, const char *);
+void compare_mixer_data_loops(const char *, const char *, int);
+void compare_mixer_data_no_rv(const char *, const char *);
 void convert_endian(unsigned char *, int);
 void create_simple_module(struct context_data *, int, int);
 void set_order(struct context_data *, int, int);

--- a/test-dev/util.c
+++ b/test-dev/util.c
@@ -59,7 +59,7 @@ int check_randomness(int *array, int size, double sdev)
 	return dev > sdev;
 }
 
-int compare_md5(unsigned char *d, char *digest)
+int compare_md5(const unsigned char *d, const char *digest)
 {
 	int i;
 
@@ -80,7 +80,7 @@ int compare_md5(unsigned char *d, char *digest)
 	return 0;
 }
 
-int check_md5(char *path, char *digest)
+int check_md5(const char *path, const char *digest)
 {
 	unsigned char buf[BUFLEN];
 	unsigned char d[16];
@@ -407,7 +407,6 @@ static void dump_envelope(struct xmp_envelope *env, FILE *f)
 
 void dump_module(struct xmp_module *mod, FILE *f)
 {
-	char line[1024];
 	int i, j;
 
 	/* Write title and format */

--- a/test/test.c
+++ b/test/test.c
@@ -29,7 +29,7 @@ static void convert_endian(unsigned char *p, int l)
 	}
 }
 
-static int compare_md5(unsigned char *d, const char *digest)
+static int compare_md5(const unsigned char *d, const char *digest)
 {
 	int i;
 
@@ -50,7 +50,7 @@ static int compare_md5(unsigned char *d, const char *digest)
 	return 0;
 }
 
-int main()
+int main(void)
 {
 	int ret;
 	xmp_context c;


### PR DESCRIPTION
zeroes  >=330 kb of warning output from my gcc.