### PR TITLE
XM and other misc. loading performance improvements.

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -263,11 +263,6 @@ static int load_module(xmp_context opaque, HIO_HANDLE *h)
 		}
 	}
 
-#ifndef LIBXMP_CORE_PLAYER
-	if (test_result == 0 && load_result == 0)
-		set_md5sum(h, m->md5);
-#endif
-
 	if (test_result < 0) {
 		xmp_release_module(opaque);
 		return -XMP_ERROR_FORMAT;
@@ -315,6 +310,11 @@ static int load_module(xmp_context opaque, HIO_HANDLE *h)
 	for (i = 0; i < mod->smp; i++) {
 		libxmp_adjust_string(mod->xxs[i].name);
 	}
+
+#ifndef LIBXMP_CORE_PLAYER
+	if (test_result == 0 && load_result == 0)
+		set_md5sum(h, m->md5);
+#endif
 
 	libxmp_load_epilogue(ctx);
 


### PR DESCRIPTION
See #400. Fixes the following issues that affected loader performance:

* The XM pattern loader no longer relies on integer division instructions and allocates a single pattern work buffer instead of a new one for every pattern.
* The track pointers for the current pattern are now cached during `scan_module`, significantly improving scan performance by avoiding pointer aliasing overhead.
* The MD5 sum performed in `load_module` is delayed until after several sanity checks. This is mainly intended to help fuzzing performance. (Patch by @debrouxl.)

The XM diff is a little messy, which could maybe be worked around with an indentation hack for now if that's preferable.