### PR TITLE
Fix Android disable for external depackers.

### DIFF
--- a/src/depackers/depacker.c
+++ b/src/depackers/depacker.c
@@ -272,7 +272,7 @@ int libxmp_decrunch(HIO_HANDLE **h, const char *filename, char **temp)
 
 #if defined __ANDROID__ || defined __native_client__
 	/* Don't use external helpers in android */
-	if (cmd) {
+	if (cmd[0]) {
 		return 0;
 	}
 #endif

--- a/test-dev/test_depack_rar.c
+++ b/test-dev/test_depack_rar.c
@@ -14,7 +14,7 @@ TEST(test_depack_rar)
 	/* This uses an external depacker currently, so if
 	 * depacking fails, it's most likely because unrar isn't
 	 * available. If this happens, just let the test pass. */
-	if (ret != -XMP_ERROR_DEPACK) {
+	if (ret != -XMP_ERROR_DEPACK && ret != -XMP_ERROR_FORMAT) {
 		FILE *f;
 
 		fail_unless(ret == 0, "can't load module");


### PR DESCRIPTION
This variable was changed to an array but I missed fixing the Android check.