### PR TITLE
Add -Wextra -Wno-unused-parameter -Wno-sign-compare to CFLAGS.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -106,6 +106,12 @@ XMP_TRY_COMPILE(whether compiler understands -Wall,
   int main(void){return 0;}],
   CFLAGS="${CFLAGS} -Wall")
 
+XMP_TRY_COMPILE(whether compiler understands -Wextra,
+  ac_cv_c_flag_w_extra,
+  -Wextra -Wno-unused-parameter -Wno-sign-compare,[
+  int main(void){return 0;}],
+  CFLAGS="${CFLAGS} -Wextra -Wno-unused-parameter -Wno-sign-compare")
+
 XMP_TRY_COMPILE(whether compiler understands -Wwrite-strings,
   ac_cv_c_flag_w_write_strings,
   -Wwrite-strings,[

--- a/lite/configure.ac
+++ b/lite/configure.ac
@@ -109,6 +109,12 @@ XMP_TRY_COMPILE(whether compiler understands -Wall,
   int main(void){return 0;}],
   CFLAGS="${CFLAGS} -Wall")
 
+XMP_TRY_COMPILE(whether compiler understands -Wextra,
+  ac_cv_c_flag_w_extra,
+  -Wextra -Wno-unused-parameter -Wno-sign-compare,[
+  int main(void){return 0;}],
+  CFLAGS="${CFLAGS} -Wextra -Wno-unused-parameter -Wno-sign-compare")
+
 XMP_TRY_COMPILE(whether compiler understands -Wwrite-strings,
   ac_cv_c_flag_w_write_strings,
   -Wwrite-strings,[

--- a/src/depackers/xz_dec_lzma2.c
+++ b/src/depackers/xz_dec_lzma2.c
@@ -1045,6 +1045,8 @@ XZ_EXTERN enum xz_ret xz_dec_lzma2_run(struct xz_dec_lzma2 *s,
 
 			s->lzma2.sequence = SEQ_LZMA_PREPARE;
 
+			/* fall-through */
+
 		case SEQ_LZMA_PREPARE:
 			if (s->lzma2.compressed < RC_INIT_BYTES)
 				return XZ_DATA_ERROR;
@@ -1054,6 +1056,8 @@ XZ_EXTERN enum xz_ret xz_dec_lzma2_run(struct xz_dec_lzma2 *s,
 
 			s->lzma2.compressed -= RC_INIT_BYTES;
 			s->lzma2.sequence = SEQ_LZMA_RUN;
+
+			/* fall-through */
 
 		case SEQ_LZMA_RUN:
 			/*

--- a/src/depackers/xz_dec_stream.c
+++ b/src/depackers/xz_dec_stream.c
@@ -594,6 +594,8 @@ static enum xz_ret dec_main(struct xz_dec *s, struct xz_buf *b)
 			if (ret != XZ_OK)
 				return ret;
 
+			/* fall-through */
+
 		case SEQ_BLOCK_START:
 			/* We need one byte of input to continue. */
 			if (b->in_pos == b->in_size)
@@ -617,6 +619,8 @@ static enum xz_ret dec_main(struct xz_dec *s, struct xz_buf *b)
 			s->temp.pos = 0;
 			s->sequence = SEQ_BLOCK_HEADER;
 
+			/* fall-through */
+
 		case SEQ_BLOCK_HEADER:
 			if (!fill_temp(s, b))
 				return XZ_OK;
@@ -627,12 +631,16 @@ static enum xz_ret dec_main(struct xz_dec *s, struct xz_buf *b)
 
 			s->sequence = SEQ_BLOCK_UNCOMPRESS;
 
+			/* fall-through */
+
 		case SEQ_BLOCK_UNCOMPRESS:
 			ret = dec_block(s, b);
 			if (ret != XZ_STREAM_END)
 				return ret;
 
 			s->sequence = SEQ_BLOCK_PADDING;
+
+			/* fall-through */
 
 		case SEQ_BLOCK_PADDING:
 			/*
@@ -653,6 +661,8 @@ static enum xz_ret dec_main(struct xz_dec *s, struct xz_buf *b)
 			}
 
 			s->sequence = SEQ_BLOCK_CHECK;
+
+			/* fall-through */
 
 		case SEQ_BLOCK_CHECK:
 			if (s->check_type == XZ_CHECK_CRC32) {
@@ -676,6 +686,8 @@ static enum xz_ret dec_main(struct xz_dec *s, struct xz_buf *b)
 
 			s->sequence = SEQ_INDEX_PADDING;
 
+			/* fall-through */
+
 		case SEQ_INDEX_PADDING:
 			while ((s->index.size + (b->in_pos - s->in_start))
 					& 3) {
@@ -698,6 +710,8 @@ static enum xz_ret dec_main(struct xz_dec *s, struct xz_buf *b)
 
 			s->sequence = SEQ_INDEX_CRC32;
 
+			/* fall-through */
+
 		case SEQ_INDEX_CRC32:
 			ret = libxmp_crc32_validate(s, b);
 			if (ret != XZ_STREAM_END)
@@ -705,6 +719,8 @@ static enum xz_ret dec_main(struct xz_dec *s, struct xz_buf *b)
 
 			s->temp.size = STREAM_HEADER_SIZE;
 			s->sequence = SEQ_STREAM_FOOTER;
+
+			/* fall-through */
 
 		case SEQ_STREAM_FOOTER:
 			if (!fill_temp(s, b))

--- a/src/loaders/mod_load.c
+++ b/src/loaders/mod_load.c
@@ -80,7 +80,6 @@ const struct mod_magic mod_magic[] = {
 	{"FA06", 1, TRACKER_DIGITALTRACKER, 6},	/* Atari Falcon */
 	{"FA08", 1, TRACKER_DIGITALTRACKER, 8},	/* Atari Falcon */
 	{"NSMS", 1, TRACKER_UNKNOWN, 4},	/* in Kingdom.mod */
-	{"", 0}
 };
 
 static int mod_test(HIO_HANDLE *, char *, const int);
@@ -137,11 +136,11 @@ static int mod_test(HIO_HANDLE * f, char *t, const int start)
 		}
 	}
 
-	for (i = 0; mod_magic[i].ch; i++) {
+	for (i = 0; i < ARRAY_SIZE(mod_magic); i++) {
 		if (!memcmp(buf, mod_magic[i].magic, 4))
 			break;
 	}
-	if (mod_magic[i].ch == 0) {
+	if (i >= ARRAY_SIZE(mod_magic)) {
 		return -1;
 	}
 
@@ -444,7 +443,7 @@ static int mod_load(struct module_data *m, HIO_HANDLE *f, const int start)
     if (mh.restart != 0)
 	maybe_wow = 0;
 
-    for (i = 0; mod_magic[i].ch; i++) {
+    for (i = 0; i < ARRAY_SIZE(mod_magic); i++) {
 	if (!(strncmp (magic, mod_magic[i].magic, 4))) {
 	    mod->chn = mod_magic[i].ch;
 	    tracker_id = mod_magic[i].id;

--- a/src/loaders/prowizard/prowiz.h
+++ b/src/loaders/prowizard/prowiz.h
@@ -1,7 +1,7 @@
 #ifndef PROWIZ_H
 #define PROWIZ_H
 
-#include "../../list.h"
+/*#include "../../list.h"*/
 #include "../../common.h"
 #include "../../format.h"
 #include "../../hio.h"
@@ -30,7 +30,7 @@ struct pw_format {
 	const char *name;
 	int (*test)(const uint8 *, char *, int);
 	int (*depack)(HIO_HANDLE *, FILE *);
-	struct list_head list;
+	/*struct list_head list;*/
 };
 
 int pw_wizardry(HIO_HANDLE *, FILE *, const char **);

--- a/test-dev/compare_mixer_data.c
+++ b/test-dev/compare_mixer_data.c
@@ -51,7 +51,7 @@ static void _compare_mixer_data(const char *mod, const char *data, int loops, in
 			vi = &p->virt.voice_array[voc];
 
 #if 1
-			fgets(line, 200, f);
+			fail_unless(fgets(line, 200, f) != NULL, "early EOF");
 			num = sscanf(line, "%d %d %d %d %d %d %d %d %d %d %d",
 				&time, &row, &frame, &chan, &period,
 				&note, &ins, &vol, &pan, &pos0, &cutoff);
@@ -82,7 +82,8 @@ static void _compare_mixer_data(const char *mod, const char *data, int loops, in
 		
 	}
 
-	fgets(line, 200, f);
+	if (fgets(line, 200, f) != NULL)
+		fail_unless(line[0] == '\0', "not end of data file");
 	//fail_unless(feof(f), "not end of data file");
 
 	xmp_end_player(opaque);

--- a/test-dev/configure.ac
+++ b/test-dev/configure.ac
@@ -18,6 +18,12 @@ XMP_TRY_COMPILE(whether compiler understands -Wall,
   int main(void){return 0;}],
   CFLAGS="${CFLAGS} -Wall")
 
+XMP_TRY_COMPILE(whether compiler understands -Wextra,
+  ac_cv_c_flag_w_extra,
+  -Wextra -Wno-unused-parameter -Wno-sign-compare,[
+  int main(void){return 0;}],
+  CFLAGS="${CFLAGS} -Wextra -Wno-unused-parameter -Wno-sign-compare")
+
 XMP_TRY_COMPILE(whether compiler understands -Wwrite-strings,
   ac_cv_c_flag_w_write_strings,
   -Wwrite-strings,[

--- a/test-dev/test_api_inject_event.c
+++ b/test-dev/test_api_inject_event.c
@@ -8,7 +8,7 @@ TEST(test_api_inject_event)
 	struct context_data *ctx;
 	struct player_data *p;
 	struct mixer_voice *vi;
-	struct xmp_event event = { 60, 2, 40, 0xf, 3, 0, 0 };
+	struct xmp_event event = { 60, 2, 40, 0xf, 3, 0, 0, 0 };
 	int voc;
 
 	opaque = xmp_create_context();

--- a/test-dev/test_api_play_buffer.c
+++ b/test-dev/test_api_play_buffer.c
@@ -17,7 +17,8 @@ TEST(test_api_play_buffer)
 	ref_buffer = calloc(1, REFBUF_SIZE);
 	fail_unless(ref_buffer != NULL, "buffer allocation error");
 
-	fread(ref_buffer, 1, REFBUF_SIZE, f);
+	ret = fread(ref_buffer, 1, REFBUF_SIZE, f);
+	fail_unless(ret > 0, "read error");
 	if (is_big_endian()) {
 		convert_endian((unsigned char *)ref_buffer, REFBUF_SIZE / 2);
 	}

--- a/test-dev/test_effect_ef_invert_loop.c
+++ b/test-dev/test_effect_ef_invert_loop.c
@@ -40,7 +40,8 @@ TEST(test_effect_ef_invert_loop)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (j = 0; j < info.buffer_size / 2; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(s->buf32[j] == val, "invloop error");
 		}
 	}

--- a/test-dev/test_effect_it_break_to_row.c
+++ b/test-dev/test_effect_it_break_to_row.c
@@ -29,7 +29,8 @@ TEST(test_effect_it_break_to_row)
 			break;
 
 		for (i = 0; i < minfo.mod->chn; i++) {
-			fgets(line, 200, f);
+			char *ret = fgets(line, 200, f);
+			fail_unless(ret == line, "read error");
 			sscanf(line, "%d %d %d %d %d %d %d %d", &time, &row,
 				&frame, &chan, &period, &volume, &ins, &pan);
 

--- a/test-dev/test_effect_it_break_to_row.c
+++ b/test-dev/test_effect_it_break_to_row.c
@@ -12,6 +12,7 @@ TEST(test_effect_it_break_to_row)
 	struct xmp_channel_info *ci;
 	int time, row, frame, chan, period, volume, ins, pan;
 	char line[200];
+	char *ret;
 	FILE *f;
 	int i;
 
@@ -29,7 +30,7 @@ TEST(test_effect_it_break_to_row)
 			break;
 
 		for (i = 0; i < minfo.mod->chn; i++) {
-			char *ret = fgets(line, 200, f);
+			ret = fgets(line, 200, f);
 			fail_unless(ret == line, "read error");
 			sscanf(line, "%d %d %d %d %d %d %d %d", &time, &row,
 				&frame, &chan, &period, &volume, &ins, &pan);
@@ -45,8 +46,8 @@ TEST(test_effect_it_break_to_row)
 		}
 	}
 
-	fgets(line, 200, f);
-	fail_unless(feof(f), "not end of data file");
+	ret = fgets(line, 200, f);
+	fail_unless(ret == NULL && feof(f), "not end of data file");
 
 	xmp_end_player(opaque);
 	xmp_release_module(opaque);

--- a/test-dev/test_mixer_downmix_16bit.c
+++ b/test-dev/test_mixer_downmix_16bit.c
@@ -26,7 +26,8 @@ TEST(test_mixer_downmix_16bit)
 		xmp_get_frame_info(opaque, &info);
 		b = info.buffer;
 		for (j = 0; j < info.buffer_size / 2; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(b[j] == val, "downmix error");
 		}
 	}

--- a/test-dev/test_mixer_downmix_8bit.c
+++ b/test-dev/test_mixer_downmix_8bit.c
@@ -26,7 +26,8 @@ TEST(test_mixer_downmix_8bit)
 		xmp_get_frame_info(opaque, &info);
 		b = info.buffer;
 		for (j = 0; j < info.buffer_size; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			val >>= 8;
 			fail_unless(b[j] == val, "downmix error");
 		}

--- a/test-dev/test_mixer_mono_16bit_linear.c
+++ b/test-dev/test_mixer_mono_16bit_linear.c
@@ -28,7 +28,8 @@ TEST(test_mixer_mono_16bit_linear)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (j = 0; j < info.buffer_size / 2; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(s->buf32[j] == val, "mixing error");
 		}
 	}

--- a/test-dev/test_mixer_mono_16bit_linear_filter.c
+++ b/test-dev/test_mixer_mono_16bit_linear_filter.c
@@ -27,7 +27,8 @@ TEST(test_mixer_mono_16bit_linear_filter)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (j = 0; j < info.buffer_size / 2; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(abs(s->buf32[j] - val) <= 1, "mixing error");
 		}
 	}

--- a/test-dev/test_mixer_mono_16bit_nearest.c
+++ b/test-dev/test_mixer_mono_16bit_nearest.c
@@ -28,7 +28,8 @@ TEST(test_mixer_mono_16bit_nearest)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (j = 0; j < info.buffer_size / 2; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(s->buf32[j] == val, "mixing error");
 		}
 	}

--- a/test-dev/test_mixer_mono_16bit_spline.c
+++ b/test-dev/test_mixer_mono_16bit_spline.c
@@ -28,7 +28,8 @@ TEST(test_mixer_mono_16bit_spline)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (j = 0; j < info.buffer_size / 2; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(s->buf32[j] == val, "mixing error");
 		}
 	}

--- a/test-dev/test_mixer_mono_16bit_spline_filter.c
+++ b/test-dev/test_mixer_mono_16bit_spline_filter.c
@@ -28,7 +28,8 @@ TEST(test_mixer_mono_16bit_spline_filter)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (j = 0; j < info.buffer_size / 2; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(abs(s->buf32[j] - val) <= 1, "mixing error");
 		}
 	}

--- a/test-dev/test_mixer_mono_8bit_linear.c
+++ b/test-dev/test_mixer_mono_8bit_linear.c
@@ -28,7 +28,8 @@ TEST(test_mixer_mono_8bit_linear)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (j = 0; j < info.buffer_size / 2; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(s->buf32[j] == val, "mixing error");
 		}
 	}

--- a/test-dev/test_mixer_mono_8bit_linear_filter.c
+++ b/test-dev/test_mixer_mono_8bit_linear_filter.c
@@ -27,7 +27,8 @@ TEST(test_mixer_mono_8bit_linear_filter)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (j = 0; j < info.buffer_size / 2; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(abs(s->buf32[j] - val) <= 1, "mixing error");
 		}
 	}

--- a/test-dev/test_mixer_mono_8bit_nearest.c
+++ b/test-dev/test_mixer_mono_8bit_nearest.c
@@ -28,7 +28,8 @@ TEST(test_mixer_mono_8bit_nearest)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (j = 0; j < info.buffer_size / 2; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(s->buf32[j] == val, "mixing error");
 		}
 	}

--- a/test-dev/test_mixer_mono_8bit_spline.c
+++ b/test-dev/test_mixer_mono_8bit_spline.c
@@ -28,7 +28,8 @@ TEST(test_mixer_mono_8bit_spline)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (j = 0; j < info.buffer_size / 2; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(s->buf32[j] == val, "mixing error");
 		}
 	}

--- a/test-dev/test_mixer_mono_8bit_spline_filter.c
+++ b/test-dev/test_mixer_mono_8bit_spline_filter.c
@@ -28,7 +28,8 @@ TEST(test_mixer_mono_8bit_spline_filter)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (j = 0; j < info.buffer_size / 2; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(abs(s->buf32[j] - val) <= 1, "mixing error");
 		}
 	}

--- a/test-dev/test_mixer_stereo_16bit_linear.c
+++ b/test-dev/test_mixer_stereo_16bit_linear.c
@@ -28,7 +28,8 @@ TEST(test_mixer_stereo_16bit_linear)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (k = j = 0; j < info.buffer_size / 4; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(s->buf32[k++] == val, "mixing error L");
 			fail_unless(s->buf32[k++] == val, "mixing error R");
 		}

--- a/test-dev/test_mixer_stereo_16bit_linear_filter.c
+++ b/test-dev/test_mixer_stereo_16bit_linear_filter.c
@@ -27,7 +27,8 @@ TEST(test_mixer_stereo_16bit_linear_filter)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (k = j = 0; j < info.buffer_size / 4; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(abs(s->buf32[k++] - val) <= 1, "mixing error L");
 			fail_unless(abs(s->buf32[k++] - val) <= 1, "mixing error R");
 		}

--- a/test-dev/test_mixer_stereo_16bit_nearest.c
+++ b/test-dev/test_mixer_stereo_16bit_nearest.c
@@ -28,7 +28,8 @@ TEST(test_mixer_stereo_16bit_nearest)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (k = j = 0; j < info.buffer_size / 4; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(s->buf32[k++] == val, "mixing error");
 			fail_unless(s->buf32[k++] == val, "mixing error");
 		}

--- a/test-dev/test_mixer_stereo_16bit_spline.c
+++ b/test-dev/test_mixer_stereo_16bit_spline.c
@@ -28,7 +28,8 @@ TEST(test_mixer_stereo_16bit_spline)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (k = j = 0; j < info.buffer_size / 4; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(s->buf32[k++] == val, "mixing error L");
 			fail_unless(s->buf32[k++] == val, "mixing error R");
 		}

--- a/test-dev/test_mixer_stereo_16bit_spline_filter.c
+++ b/test-dev/test_mixer_stereo_16bit_spline_filter.c
@@ -28,7 +28,8 @@ TEST(test_mixer_stereo_16bit_spline_filter)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (k = j = 0; j < info.buffer_size / 4; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(abs(s->buf32[k++] - val) <= 1, "mixing error L");
 			fail_unless(abs(s->buf32[k++] - val) <= 1, "mixing error R");
 		}

--- a/test-dev/test_mixer_stereo_8bit_linear.c
+++ b/test-dev/test_mixer_stereo_8bit_linear.c
@@ -28,7 +28,8 @@ TEST(test_mixer_stereo_8bit_linear)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (k = j = 0; j < info.buffer_size / 4; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(s->buf32[k++] == val, "mixing error L");
 			fail_unless(s->buf32[k++] == val, "mixing error R");
 		}

--- a/test-dev/test_mixer_stereo_8bit_linear_filter.c
+++ b/test-dev/test_mixer_stereo_8bit_linear_filter.c
@@ -27,7 +27,8 @@ TEST(test_mixer_stereo_8bit_linear_filter)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (k = j = 0; j < info.buffer_size / 4; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(abs(s->buf32[k++] - val) <= 1, "mixing error L");
 			fail_unless(abs(s->buf32[k++] - val) <= 1, "mixing error R");
 		}

--- a/test-dev/test_mixer_stereo_8bit_nearest.c
+++ b/test-dev/test_mixer_stereo_8bit_nearest.c
@@ -28,7 +28,8 @@ TEST(test_mixer_stereo_8bit_nearest)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (k = j = 0; j < info.buffer_size / 4; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(s->buf32[k++] == val, "mixing error L");
 			fail_unless(s->buf32[k++] == val, "mixing error R");
 		}

--- a/test-dev/test_mixer_stereo_8bit_spline.c
+++ b/test-dev/test_mixer_stereo_8bit_spline.c
@@ -28,7 +28,8 @@ TEST(test_mixer_stereo_8bit_spline)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (k = j = 0; j < info.buffer_size / 4; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(s->buf32[k++] == val, "mixing error L");
 			fail_unless(s->buf32[k++] == val, "mixing error R");
 		}

--- a/test-dev/test_mixer_stereo_8bit_spline_filter.c
+++ b/test-dev/test_mixer_stereo_8bit_spline_filter.c
@@ -28,7 +28,8 @@ TEST(test_mixer_stereo_8bit_spline_filter)
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
 		for (k = j = 0; j < info.buffer_size / 4; j++) {
-			fscanf(f, "%d", &val);
+			int ret = fscanf(f, "%d", &val);
+			fail_unless(ret == 1, "read error");
 			fail_unless(abs(s->buf32[k++] - val) <= 1, "mixing error L");
 			fail_unless(abs(s->buf32[k++] - val) <= 1, "mixing error R");
 		}

--- a/test-dev/test_player_hmn_extras.c
+++ b/test-dev/test_player_hmn_extras.c
@@ -7,6 +7,7 @@ TEST(test_player_hmn_extras)
 	struct xmp_channel_info *ci;
 	int time, row, frame, chan, period, volume, ins, pan, smp;
 	char line[200];
+	char *ret;
 	FILE *f;
 	int i, j;
 
@@ -22,7 +23,9 @@ TEST(test_player_hmn_extras)
 
 		for (j = 0; j < 4; j++) {
 			ci = &info.channel_info[j];
-			fgets(line, 200, f);
+			ret = fgets(line, 200, f);
+			fail_unless(ret == line, "read error");
+
 			sscanf(line, "%d %d %d %d %d %d %d %d %d",
 					&time, &row, &frame, &chan, &period,
 					&volume, &ins, &pan, &smp);
@@ -34,8 +37,8 @@ TEST(test_player_hmn_extras)
 		}
 	}
 
-	fgets(line, 200, f);
-	fail_unless(feof(f), "not end of data file");
+	ret = fgets(line, 200, f);
+	fail_unless(ret == NULL && feof(f), "not end of data file");
 
 	xmp_end_player(opaque);
 	xmp_release_module(opaque);

--- a/test-dev/test_player_med_synth.c
+++ b/test-dev/test_player_med_synth.c
@@ -7,6 +7,7 @@ TEST(test_player_med_synth)
 	struct xmp_channel_info *ci;
 	int time, row, frame, chan, period, volume, ins, pan, smp;
 	char line[200];
+	char *ret;
 	FILE *f;
 	int i, j;
 
@@ -22,7 +23,8 @@ TEST(test_player_med_synth)
 
 		for (j = 0; j < 4; j++) {
 			ci = &info.channel_info[j];
-			fgets(line, 200, f);
+			ret = fgets(line, 200, f);
+			fail_unless(ret == line, "read error");
 			sscanf(line, "%d %d %d %d %d %d %d %d %d",
 					&time, &row, &frame, &chan, &period,
 					&volume, &ins, &pan, &smp);
@@ -34,8 +36,8 @@ TEST(test_player_med_synth)
 		}
 	}
 
-	fgets(line, 200, f);
-	fail_unless(feof(f), "not end of data file");
+	ret = fgets(line, 200, f);
+	fail_unless(ret == NULL && feof(f), "not end of data file");
 
 	xmp_end_player(opaque);
 	xmp_release_module(opaque);

--- a/test-dev/test_player_med_synth_2.c
+++ b/test-dev/test_player_med_synth_2.c
@@ -7,6 +7,7 @@ TEST(test_player_med_synth_2)
 	struct xmp_channel_info *ci;
 	int time, row, frame, chan, period, volume, ins, pan, smp;
 	char line[200];
+	char *ret;
 	FILE *f;
 	int i, j;
 
@@ -22,7 +23,8 @@ TEST(test_player_med_synth_2)
 
 		for (j = 0; j < 4; j++) {
 			ci = &info.channel_info[j];
-			fgets(line, 200, f);
+			ret = fgets(line, 200, f);
+			fail_unless(ret == line, "read error");
 
 			sscanf(line, "%d %d %d %d %d %d %d %d %d",
 					&time, &row, &frame, &chan, &period,
@@ -35,8 +37,8 @@ TEST(test_player_med_synth_2)
 		}
 	}
 
-	fgets(line, 200, f);
-	fail_unless(feof(f), "not end of data file");
+	ret = fgets(line, 200, f);
+	fail_unless(ret == NULL && feof(f), "not end of data file");
 
 	xmp_end_player(opaque);
 	xmp_release_module(opaque);

--- a/test-dev/test_player_period_amiga.c
+++ b/test-dev/test_player_period_amiga.c
@@ -5,7 +5,7 @@ TEST(test_player_period_amiga)
 	xmp_context opaque;
 	struct context_data *ctx;
 	struct xmp_frame_info info;
-	int i, p0, p1;
+	int i, p0, p1, ret;
 	FILE *f;
 
 	f = fopen("data/periods.data", "r");
@@ -27,7 +27,8 @@ TEST(test_player_period_amiga)
 	for (i = 0; i < 60; i++) {
 		xmp_play_frame(opaque);
 		xmp_get_frame_info(opaque, &info);
-		fscanf(f, "%d %d", &p0, &p1);
+		ret = fscanf(f, "%d %d", &p0, &p1);
+		fail_unless(ret == 2, "read error");
 		fail_unless(info.channel_info[0].period == p0, "Bad period");
 		fail_unless(info.channel_info[1].period == p1, "Bad period");
 	}

--- a/test-dev/test_player_period_amiga.c
+++ b/test-dev/test_player_period_amiga.c
@@ -33,8 +33,8 @@ TEST(test_player_period_amiga)
 		fail_unless(info.channel_info[1].period == p1, "Bad period");
 	}
 
-	fscanf(f, "%d %d", &p0, &p1);
-	//fail_unless(feof(f), "not end of data file");
+	ret = fscanf(f, "%d %d", &p0, &p1);
+	fail_unless(ret == 0, "not end of data file");
 
 	xmp_release_module(opaque);
 	xmp_free_context(opaque);

--- a/test-dev/test_write_file_move_data.c
+++ b/test-dev/test_write_file_move_data.c
@@ -5,6 +5,7 @@ TEST(test_write_file_move_data)
 	FILE *f1, *f2;
 	uint8 b1[4000], b2[4000];
 	long size;
+	int ret;
 
 	f1 = fopen("data/bzip2data", "rb");
 	fail_unless(f1 != NULL, "can't open source file");
@@ -19,8 +20,10 @@ TEST(test_write_file_move_data)
 	f1 = fopen("data/bzip2data", "rb");
 	f2 = fopen("write_test", "rb");
 
-	fread(b1, 1, 4000, f1);
-	fread(b2, 1, 4000, f2);
+	ret = fread(b1, 1, 4000, f1);
+	fail_unless(ret == 4000, "read error (f1)");
+	ret = fread(b2, 1, 4000, f2);
+	fail_unless(ret == 4000, "read error (f2)");
 	fseek(f2, 0, SEEK_END);
 	size = ftell(f2);
 	fclose(f1);

--- a/test-dev/util.c
+++ b/test-dev/util.c
@@ -136,7 +136,10 @@ static int read_line(char *line, int size, FILE *f)
 {
 	int pos;
 
-	fgets(line, size, f);
+	if (!fgets(line, size, f)) {
+		line[0] = '\0';
+		return 0;
+	}
 	pos = strlen(line);
 
 	if (pos > 0 && line[pos - 1] == '\n')


### PR DESCRIPTION
Adds -Wextra, minus the warnings it enables that are useless (-Wunused-parameter) or too hard to fix right now (-Wsign-compare), to CFLAGS.

Warning fixes required for the new warnings:
* The non-lite Protracker MOD loader used a sentinel for the MOD magic list that wasn't fully defined. I replaced the sentinel with `ARRAY_SIZE()`. (-Wmissing-field-initializers)
* The `xmp_inject_event` regression test had the same warning for the `xmp_event` it defines.
* Every ProWizard loader had the same warning for a `list_head` field in the loader definition. I just commented out the field because nothing uses it.
* Misc. places in the XZ depacker required `/* fall-through */` to silence `-Wimplicit-fallthrough`. The copy of this depacker in the Linux kernel does something similar.