### PR TITLE
cmake fixes and improvements:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,14 +52,12 @@ endif()
 
 set(XMP_INSTALLS)
 
-# ============= FULL =============
 if(BUILD_STATIC)
     add_library(xmp_static STATIC ${LIBXMP_SRC_LIST})
     list(APPEND XMP_INSTALLS xmp_static)
     set_target_properties(xmp_static PROPERTIES C_STANDARD 90)
-
-    if(MSVC AND BUILD_SHARED)
-        set_target_properties(xmp_static PROPERTIES OUTPUT_NAME xmp-static)
+    if(MSVC)
+        set_target_properties(xmp_static PROPERTIES OUTPUT_NAME libxmp-static)
     else()
         set_target_properties(xmp_static PROPERTIES OUTPUT_NAME xmp)
     endif()
@@ -82,7 +80,12 @@ endif()
 if(BUILD_SHARED)
     add_library(xmp_shared SHARED ${LIBXMP_SRC_LIST})
     list(APPEND XMP_INSTALLS xmp_shared)
-    set_target_properties(xmp_shared PROPERTIES OUTPUT_NAME xmp C_STANDARD 90)
+    set_target_properties(xmp_shared PROPERTIES C_STANDARD 90)
+    if(MSVC)
+        set_target_properties(xmp_shared PROPERTIES OUTPUT_NAME libxmp)
+    else()
+        set_target_properties(xmp_shared PROPERTIES OUTPUT_NAME xmp)
+    endif()
 
     if(HAVE_GCC OR HAVE_CLANG)
         if(APPLE)
@@ -151,12 +154,26 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/examples/CMakeLists.txt")
 endif()
 
 
-install(TARGETS ${XMP_INSTALLS}
-        RUNTIME DESTINATION "bin"
-        LIBRARY DESTINATION "lib"
-        ARCHIVE DESTINATION "lib"
-        INCLUDES DESTINATION "include")
+# === Install ====
+include(GNUInstallDirs)
 
+set(prefix ${CMAKE_INSTALL_PREFIX})
+set(exec_prefix "\${prefix}")
+set(includedir "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+set(libdir     "${CMAKE_INSTALL_FULL_LIBDIR}")
+set(bindir     "${CMAKE_INSTALL_FULL_BINDIR}")
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/libxmp.pc.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/libxmp.pc" @ONLY
+)
+install(TARGETS ${XMP_INSTALLS}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
 install(FILES
         include/xmp.h
-        DESTINATION include/)
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libxmp.pc"
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)

--- a/cmake/libxmp-checks.cmake
+++ b/cmake/libxmp-checks.cmake
@@ -116,6 +116,7 @@ if(UNIX AND NOT (WIN32 OR APPLE OR HAIKU OR EMSCRIPTEN OR BEOS))
     if(LIBM_LIBRARY) # No need to link it by an absolute path
         set(LIBM_REQUIRED 1)
         set(LIBM_LIBRARY m)
+        set(LIBM "-lm") # for pkgconfig file.
         list(APPEND CMAKE_REQUIRED_LIBRARIES m)
     endif()
     mark_as_advanced(LIBM_LIBRARY)

--- a/lite/CMakeLists.txt
+++ b/lite/CMakeLists.txt
@@ -49,14 +49,12 @@ endif()
 
 set(XMP_INSTALLS)
 
-# ============= LITE =============
 if(BUILD_STATIC)
     add_library(xmp_lite_static STATIC ${LIBXMP_SRC_LIST})
     list(APPEND XMP_INSTALLS xmp_lite_static)
     set_target_properties(xmp_lite_static PROPERTIES C_STANDARD 90)
-
-    if(MSVC AND BUILD_SHARED)
-        set_target_properties(xmp_lite_static PROPERTIES OUTPUT_NAME xmp-lite-static)
+    if(MSVC)
+        set_target_properties(xmp_lite_static PROPERTIES OUTPUT_NAME libxmp-lite-static)
     else()
         set_target_properties(xmp_lite_static PROPERTIES OUTPUT_NAME xmp-lite)
     endif()
@@ -79,7 +77,12 @@ endif()
 if(BUILD_SHARED)
     add_library(xmp_lite_shared SHARED ${LIBXMP_SRC_LIST})
     list(APPEND XMP_INSTALLS xmp_lite_shared)
-    set_target_properties(xmp_lite_shared PROPERTIES OUTPUT_NAME xmp-lite C_STANDARD 90)
+    set_target_properties(xmp_lite_shared PROPERTIES C_STANDARD 90)
+    if(MSVC)
+        set_target_properties(xmp_lite_shared PROPERTIES OUTPUT_NAME libxmp-lite)
+    else()
+        set_target_properties(xmp_lite_shared PROPERTIES OUTPUT_NAME xmp-lite)
+    endif()
 
     if(HAVE_GCC OR HAVE_CLANG)
         if(APPLE)
@@ -145,12 +148,26 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/build_examples.cmake")
 endif()
 
 
-install(TARGETS ${XMP_INSTALLS}
-        RUNTIME DESTINATION "bin"
-        LIBRARY DESTINATION "lib"
-        ARCHIVE DESTINATION "lib"
-        INCLUDES DESTINATION "include")
+# === Install ====
+include(GNUInstallDirs)
 
+set(prefix ${CMAKE_INSTALL_PREFIX})
+set(exec_prefix "\${prefix}")
+set(includedir "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+set(libdir     "${CMAKE_INSTALL_FULL_LIBDIR}")
+set(bindir     "${CMAKE_INSTALL_FULL_BINDIR}")
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/libxmp-lite.pc.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/libxmp-lite.pc" @ONLY
+)
+install(TARGETS ${XMP_INSTALLS}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
 install(FILES
         include/libxmp-lite/xmp.h
-        DESTINATION include/libxmp-lite/)
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libxmp-lite
+)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libxmp-lite.pc"
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)

--- a/lite/libxmp-lite.pc.in
+++ b/lite/libxmp-lite.pc.in
@@ -1,7 +1,7 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@/libxmp-lite
+includedir=@includedir@
 
 Name: libxmp-lite
 Description: Xmp lite module player library
@@ -9,5 +9,5 @@ Version: 4.5.0
 
 Requires:
 Libs: -L${libdir} -lxmp-lite
-Cflags: -I${includedir}
+Cflags: -I${includedir}/libxmp-lite
 Libs.private: @LIBM@


### PR DESCRIPTION
- Use GNUInstallDirs, replace hardcoded install destinations
  with CMAKE_INSTALL_xxxDIR
- Generate and install libxmp.pc (bug #474)
- MSVC now outputs libxmp.dll as it should, not xmp.dll
- MSVC now outputs libxmp-static.lib not xmp-static.lib
- Tweak libxmp-lite.pc installdir