### PR TITLE
use LT_PATH_LD to detect GNU ld, which uses compiler's ld program:

### DIFF
--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -143,7 +143,7 @@ jobs:
       - name: Create and run Autotools configure script
         run: |
           source ../emsdk/emsdk_env.sh
-          autoreconf -iv
+          autoconf
           emconfigure ./configure --host=wasm32-unknown-emscripten --enable-static --disable-shared
       - name: Autotools build
         run: |

--- a/Makefile.in
+++ b/Makefile.in
@@ -31,8 +31,8 @@ SHELL		= /bin/sh
 DIST		= libxmp-$(VERSION)
 DFILES		= README INSTALL install-sh configure configure.ac config.sub config.guess    \
 		  Makefile.in Makefile.vc Makefile.os2 Makefile.w32 watcom.mif CMakeLists.txt \
-		  libxmp.map libxmp.pc.in
-DDIRS		= docs include src loaders prowiz depackers test cmake
+		  aclocal.m4 libxmp.map libxmp.pc.in
+DDIRS		= docs include src loaders prowiz depackers test cmake m4
 V		= 0
 LIB		= libxmp.a
 SOLIB		= libxmp.so
@@ -56,6 +56,7 @@ endif
 all: @STATIC@ @SHARED@
 
 include cmake/Makefile
+include m4/Makefile
 include docs/Makefile
 include include/Makefile
 include src/Makefile
@@ -123,7 +124,7 @@ lib/$(DLL): $(LOBJS)
 # The version number checks that dyld performs are limited to ensuring that
 # the compatibility version of the library being loaded is higher than the
 # compatibility version of the library that was used at build time.
-
+#
 lib/$(DYLIB): $(LOBJS)
 	@mkdir -p lib
 	@CMD='$(LD) $(LDFLAGS) -dynamiclib -Wl,-headerpad_max_install_names,$(DYLIB_COMPAT)-current_version,$(VERSION),-install_name,$(prefix)/lib/$(DYLIB) -o $@ $(LOBJS) $(LIBS)'; \

--- a/Makefile.lite
+++ b/Makefile.lite
@@ -3,14 +3,15 @@ DIST		= libxmp-lite-stagedir
 DFILES		= lite/README INSTALL install-sh configure configure.ac \
 		  config.sub config.guess Makefile.in lite/libxmp-lite.pc.in \
 		  libxmp.map lite/Makefile.vc.in lite/Makefile.os2 lite/Makefile.w32 \
-		  lite/watcom.mif.in
-DDIRS		= src loaders test cmake
+		  lite/watcom.mif.in aclocal.m4
+DDIRS		= src loaders test cmake m4
 
 all: dist
 
 include lite/src/Makefile
 include lite/src/loaders/Makefile
 include cmake/Makefile
+include m4/Makefile
 include test/Makefile
 
 dist: dist-prepare dist-subdirs cmake-prepare vc-prepare watcom-prepare dist-dist check-no-it

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1,0 +1,1 @@
+m4_include([m4/ld.m4])

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+autoconf

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-dnl AC_CONFIG_AUX_DIR(scripts)
+AC_PREREQ(2.60)
 AC_INIT
 AC_ARG_ENABLE(depackers, [  --disable-depackers     Don't build depackers])
 AC_ARG_ENABLE(prowizard, [  --disable-prowizard     Don't build ProWizard])
@@ -9,13 +9,7 @@ AC_SUBST(LIBM)
 AC_SUBST(DARWIN_VERSION)
 AC_CANONICAL_HOST
 AC_PROG_CC
-AC_CHECK_TOOL(LD, [ld], [:])
-AC_CACHE_CHECK([whether $LD is GNU ld], ac_cv_prog_gnu_ld,
-[case `$LD -v 2>&1 </dev/null` in
-  *GNU* | *'with BFD'*)
-     ac_cv_prog_gnu_ld=yes ;;
-  *) ac_cv_prog_gnu_ld=no ;;
-esac])
+LT_PATH_LD
 AC_CHECK_TOOL(AR, [ar], [:])
 AC_PROG_RANLIB
 AC_PROG_INSTALL
@@ -172,7 +166,7 @@ if test $ac_cv_c_flag_f_visibility_hidden = no; then
 else
    CFLAGS="${old_CFLAGS} -fvisibility=hidden -DXMP_SYM_VISIBILITY"
 
-   if test $ac_cv_prog_gnu_ld = yes; then
+   if test $lt_cv_prog_gnu_ld = yes; then
       case "${host_os}" in
         emscripten*|beos*|atheos*|*mint)
           ;;

--- a/lite/Makefile.in.in
+++ b/lite/Makefile.in.in
@@ -28,8 +28,8 @@ SHELL		= /bin/sh
 DIST		= libxmp-lite-$(VERSION)
 DFILES		= README INSTALL install-sh configure configure.ac config.sub config.guess    \
 		  Makefile.in Makefile.vc Makefile.os2 Makefile.w32 watcom.mif CMakeLists.txt \
-		  libxmp.map libxmp-lite.pc.in Changelog
-DDIRS		= include src loaders test cmake
+		  aclocal.m4 libxmp.map libxmp-lite.pc.in Changelog
+DDIRS		= include src loaders test cmake m4
 V		= 0
 LIB		= libxmp-lite.a
 SOLIB		= libxmp-lite.so
@@ -54,6 +54,7 @@ all: @STATIC@ @SHARED@
 
 include include/libxmp-lite/Makefile
 include cmake/Makefile
+include m4/Makefile
 include src/Makefile
 include src/loaders/Makefile
 include test/Makefile
@@ -116,7 +117,7 @@ lib/$(DLL): $(LOBJS)
 # The version number checks that dyld performs are limited to ensuring that
 # the compatibility version of the library being loaded is higher than the
 # compatibility version of the library that was used at build time.
-
+#
 lib/$(DYLIB): $(LOBJS)
 	@mkdir -p lib
 	@CMD='$(LD) $(LDFLAGS) -dynamiclib -Wl,-headerpad_max_install_names,$(DYLIB_COMPAT)-current_version,$(VERSION),-install_name,$(prefix)/lib/$(DYLIB) -o $@ $(LOBJS) $(LIBS)'; \

--- a/lite/configure.ac
+++ b/lite/configure.ac
@@ -1,4 +1,4 @@
-dnl AC_CONFIG_AUX_DIR(scripts)
+AC_PREREQ(2.60)
 AC_INIT
 AC_ARG_ENABLE(it,        [  --disable-it            Don't build IT format support])
 AC_ARG_ENABLE(static,    [  --enable-static         Build static library])
@@ -8,13 +8,7 @@ AC_SUBST(LIBM)
 AC_SUBST(DARWIN_VERSION)
 AC_CANONICAL_HOST
 AC_PROG_CC
-AC_CHECK_TOOL(LD, [ld], [:])
-AC_CACHE_CHECK([whether $LD is GNU ld], ac_cv_prog_gnu_ld,
-[case `$LD -v 2>&1 </dev/null` in
-  *GNU* | *'with BFD'*)
-     ac_cv_prog_gnu_ld=yes ;;
-  *) ac_cv_prog_gnu_ld=no ;;
-esac])
+LT_PATH_LD
 AC_CHECK_TOOL(AR, [ar], [:])
 AC_PROG_RANLIB
 AC_PROG_INSTALL
@@ -175,7 +169,7 @@ if test $ac_cv_c_flag_f_visibility_hidden = no; then
 else
    CFLAGS="${old_CFLAGS} -fvisibility=hidden -DXMP_SYM_VISIBILITY"
 
-   if test $ac_cv_prog_gnu_ld = yes; then
+   if test $lt_cv_prog_gnu_ld = yes; then
       case "${host_os}" in
         emscripten*|beos*|atheos*|*mint)
           ;;

--- a/m4/Makefile
+++ b/m4/Makefile
@@ -1,0 +1,7 @@
+
+M4_DFILES	= Makefile ld.m4
+M4_PATH		= m4
+
+dist-m4:
+	mkdir -p $(DIST)/$(M4_PATH)
+	cp -RPp $(addprefix $(M4_PATH)/,$(M4_DFILES)) $(DIST)/$(M4_PATH)

--- a/m4/ld.m4
+++ b/m4/ld.m4
@@ -1,0 +1,145 @@
+# LT_PATH_LD and its dependencies adapted with minor modifications
+# from libtool.m4 for use in libxmp:
+
+# libtool.m4 - Configure libtool for the host system. -*-Autoconf-*-
+#
+#   Copyright (C) 1996-2001, 2003-2015 Free Software Foundation, Inc.
+#   Written by Gordon Matzigkeit, 1996
+#
+# This file is free software; the Free Software Foundation gives
+# unlimited permission to copy and/or distribute it, with or without
+# modifications, as long as this notice is preserved.
+
+# _LT_PROG_ECHO_BACKSLASH
+# -----------------------
+# Find how we can fake an echo command that does not interpret backslash.
+m4_defun([_LT_PROG_ECHO_BACKSLASH],
+[ECHO='\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
+ECHO=$ECHO$ECHO$ECHO$ECHO$ECHO
+ECHO=$ECHO$ECHO$ECHO$ECHO$ECHO$ECHO
+
+AC_MSG_CHECKING([how to print strings])
+# Test print first, because it will be a builtin if present.
+if test "X`( print -r -- -n ) 2>/dev/null`" = X-n && \
+   test "X`print -r -- $ECHO 2>/dev/null`" = "X$ECHO"; then
+  ECHO='print -r --'
+elif test "X`printf %s $ECHO 2>/dev/null`" = "X$ECHO"; then
+  ECHO='printf %s\n'
+else
+  # Use this function as a fallback that always works.
+  func_fallback_echo ()
+  {
+    eval 'cat <<_LTECHO_EOF
+$[]1
+_LTECHO_EOF'
+  }
+  ECHO='func_fallback_echo'
+fi
+
+case $ECHO in
+  printf*) AC_MSG_RESULT([printf]) ;;
+  print*) AC_MSG_RESULT([print -r]) ;;
+  *) AC_MSG_RESULT([cat]) ;;
+esac
+])# _LT_PROG_ECHO_BACKSLASH
+
+# LT_PATH_LD
+# ----------
+# find the pathname to the GNU or non-GNU linker
+AC_DEFUN([LT_PATH_LD],
+[AC_REQUIRE([AC_PROG_CC])dnl
+AC_REQUIRE([AC_CANONICAL_HOST])dnl
+AC_REQUIRE([AC_CANONICAL_BUILD])dnl
+AC_REQUIRE([AC_PROG_SED])dnl
+AC_REQUIRE([AC_PROG_GREP])dnl
+m4_require([_LT_PROG_ECHO_BACKSLASH])dnl
+
+AC_ARG_WITH([gnu-ld],
+    [AS_HELP_STRING([--with-gnu-ld],
+	[assume the C compiler uses GNU ld @<:@default=no@:>@])],
+    [test no = "$withval" || with_gnu_ld=yes],
+    [with_gnu_ld=no])dnl
+
+ac_prog=ld
+if test yes = "$GCC"; then
+  # Check if gcc -print-prog-name=ld gives a path.
+  # lose posssible carriage return from output.
+  AC_MSG_CHECKING([for ld used by $CC])
+  ac_prog=`($CC -print-prog-name=ld) 2>&5 | tr -d '\015'`
+  case $ac_prog in
+    # Accept absolute paths.
+    [[\\/]]* | ?:[[\\/]]*)
+      re_direlt='/[[^/]][[^/]]*/\.\./'
+      # Canonicalize the pathname of ld
+      ac_prog=`$ECHO "$ac_prog"| $SED 's%\\\\%/%g'`
+      while $ECHO "$ac_prog" | $GREP "$re_direlt" > /dev/null 2>&1; do
+	ac_prog=`$ECHO $ac_prog| $SED "s%$re_direlt%/%"`
+      done
+      test -z "$LD" && LD=$ac_prog
+      ;;
+  "")
+    # If it fails, then pretend we aren't using GCC.
+    ac_prog=ld
+    ;;
+  *)
+    # If it is relative, then search for the first ld in PATH.
+    with_gnu_ld=unknown
+    ;;
+  esac
+elif test yes = "$with_gnu_ld"; then
+  AC_MSG_CHECKING([for GNU ld])
+else
+  AC_MSG_CHECKING([for non-GNU ld])
+fi
+AC_CACHE_VAL(lt_cv_path_LD,
+[if test -z "$LD"; then
+  lt_save_ifs=$IFS; IFS=$PATH_SEPARATOR
+  for ac_dir in $PATH; do
+    IFS=$lt_save_ifs
+    test -z "$ac_dir" && ac_dir=.
+    if test -f "$ac_dir/$ac_prog" || test -f "$ac_dir/$ac_prog$ac_exeext"; then
+      lt_cv_path_LD=$ac_dir/$ac_prog
+      # Check to see if the program is GNU ld.  I'd rather use --version,
+      # but apparently some variants of GNU ld only accept -v.
+      # Break only if it was the GNU/non-GNU ld that we prefer.
+      case `"$lt_cv_path_LD" -v 2>&1 </dev/null` in
+      *GNU* | *'with BFD'*)
+	test no != "$with_gnu_ld" && break
+	;;
+      *)
+	test yes != "$with_gnu_ld" && break
+	;;
+      esac
+    fi
+  done
+  IFS=$lt_save_ifs
+else
+  lt_cv_path_LD=$LD # Let the user override the test with a path.
+fi])
+LD=$lt_cv_path_LD
+if test -n "$LD"; then
+  AC_MSG_RESULT($LD)
+else
+  AC_MSG_RESULT(no)
+  AC_MSG_WARN([no acceptable ld found in \$PATH])
+  LD=:
+fi
+_LT_PATH_LD_GNU
+AC_SUBST([LD])
+])# LT_PATH_LD
+
+# _LT_PATH_LD_GNU
+#- --------------
+m4_defun([_LT_PATH_LD_GNU],
+[AC_CACHE_CHECK([if the linker ($LD) is GNU ld], lt_cv_prog_gnu_ld,
+[# I'd rather use --version here, but apparently some GNU lds only accept -v.
+case `$LD -v 2>&1 </dev/null` in
+*GNU* | *'with BFD'*)
+  lt_cv_prog_gnu_ld=yes
+  ;;
+*)
+  lt_cv_prog_gnu_ld=no
+  ;;
+esac])
+with_gnu_ld=$lt_cv_prog_gnu_ld
+])# _LT_PATH_LD_GNU


### PR DESCRIPTION
extracted LT_PATH_LD and its dependencies with minor modifications
from libtool for use in libxmp and placed as m4/ld.m4, and with an
aclocal.m4 pointing to it.  generating the configure script is the
same as before, simply running 'autoconf' (and _not_ autoreconf .)