### PR TITLE
Fix >1MB S3M modules relying on the sample segment high byte.

### DIFF
--- a/src/loaders/s3m.h
+++ b/src/loaders/s3m.h
@@ -82,7 +82,8 @@ struct s3m_file_header {
 };
 
 struct s3m_instrument_header {
-	uint8 dosname[13];	/* DOS file name */
+	uint8 dosname[12];	/* DOS file name */
+	uint8 memseg_hi;	/* High byte of sample pointer */
 	uint16 memseg;		/* Pointer to sample data */
 	uint32 length;		/* Length */
 	uint32 loopbeg;		/* Loop begin */

--- a/src/loaders/s3m_load.c
+++ b/src/loaders/s3m_load.c
@@ -487,6 +487,7 @@ static int s3m_load(struct module_data *m, HIO_HANDLE * f, const int start)
 		struct xmp_sample *xxs = &mod->xxs[i];
 		struct xmp_subinstrument *sub;
 		int load_sample_flags;
+		uint32 sample_segment;
 
 		xxi->sub = (struct xmp_subinstrument *) calloc(1, sizeof(struct xmp_subinstrument));
 		if (xxi->sub == NULL) {
@@ -539,7 +540,8 @@ static int s3m_load(struct module_data *m, HIO_HANDLE * f, const int start)
 #endif
 		}
 
-		memcpy(sih.dosname, buf + 1, 13);	/* DOS file name */
+		memcpy(sih.dosname, buf + 1, 12);	/* DOS file name */
+		sih.memseg_hi = buf[13];		/* High byte of sample pointer */
 		sih.memseg = readmem16l(buf + 14);	/* Pointer to sample data */
 		sih.length = readmem32l(buf + 16);	/* Length */
 
@@ -596,7 +598,9 @@ static int s3m_load(struct module_data *m, HIO_HANDLE * f, const int start)
 
 		libxmp_c2spd_to_note(sih.c2spd, &sub->xpo, &sub->fin);
 
-		if (hio_seek(f, start + 16L * sih.memseg, SEEK_SET) < 0) {
+		sample_segment = sih.memseg + ((uint32)sih.memseg_hi << 16);
+
+		if (hio_seek(f, start + 16L * sample_segment, SEEK_SET) < 0) {
 			goto err3;
 		}
 


### PR DESCRIPTION
Found via running checks for #357. libxmp completely ignores the sample segment high byte in S3Ms, leading to large S3Ms sounding very bad.

[Blatant example](http://modland.com/pub/modules/Screamtracker%203/DJ%20Meas/sunday%20train%20ride.s3m), though ModLand has at least 39 of these (and Mod Archive probably has far more).

No test because I don't think Claudio would appreciate me adding a 2.5 MB module to the repository. :-)