### PR TITLE
Allow xmp_smix_play_* to play key off, cut, and fade events.

### DIFF
--- a/src/smix.c
+++ b/src/smix.c
@@ -110,7 +110,7 @@ int xmp_smix_play_instrument(xmp_context opaque, int ins, int note, int vol, int
 		return -XMP_ERROR_STATE;
 	}
 
-	if (chn >= smix->chn || ins >= mod->ins) {
+	if (chn >= smix->chn || chn < 0 || ins >= mod->ins || ins < 0) {
 		return -XMP_ERROR_INVALID;
 	}
 
@@ -120,7 +120,7 @@ int xmp_smix_play_instrument(xmp_context opaque, int ins, int note, int vol, int
 
 	event = &p->inject_event[mod->chn + chn];
 	memset(event, 0, sizeof (struct xmp_event));
-	event->note = note + 1;
+	event->note = (note < XMP_MAX_KEYS) ? note + 1 : note;
 	event->ins = ins + 1;
 	event->vol = vol + 1;
 	event->_flag = 1;
@@ -141,7 +141,7 @@ int xmp_smix_play_sample(xmp_context opaque, int ins, int note, int vol, int chn
 		return -XMP_ERROR_STATE;
 	}
 
-	if (chn >= smix->chn || ins >= smix->ins) {
+	if (chn >= smix->chn || chn < 0 || ins >= smix->ins || ins < 0) {
 		return -XMP_ERROR_INVALID;
 	}
 
@@ -151,7 +151,7 @@ int xmp_smix_play_sample(xmp_context opaque, int ins, int note, int vol, int chn
 
 	event = &p->inject_event[mod->chn + chn];
 	memset(event, 0, sizeof (struct xmp_event));
-	event->note = note + 1;
+	event->note = (note < XMP_MAX_KEYS) ? note + 1 : note;
 	event->ins = mod->ins + ins + 1;
 	event->vol = vol + 1;
 	event->_flag = 1;

--- a/test-dev/test_api_smix_play_sample.c
+++ b/test-dev/test_api_smix_play_sample.c
@@ -1,6 +1,8 @@
-#include "test.h"
+#include "../src/common.h"
 #include "../src/mixer.h"
+#include "../src/player.h"
 #include "../src/virtual.h"
+#include "test.h"
 
 TEST(test_api_smix_play_sample)
 {
@@ -8,6 +10,7 @@ TEST(test_api_smix_play_sample)
 	struct context_data *ctx;
 	struct player_data *p;
 	struct mixer_voice *vi;
+	struct channel_data *xc;
 	int voc, ret;
 
 	opaque = xmp_create_context();
@@ -60,6 +63,29 @@ TEST(test_api_smix_play_sample)
 	fail_unless(vi->ins  ==  32, "set instrument");
 	fail_unless(vi->vol / 16 == 40, "set volume");
 	fail_unless(vi->pos0 ==  0, "sample position");
+
+	/* key off, fade, and cut */
+	xc = &p->xc_data[ctx->m.mod.chn];
+	ret = xmp_smix_play_sample(opaque, 1, XMP_KEY_OFF, 0, 0);
+	fail_unless(ret == 0, "play key off");
+	xmp_play_frame(opaque);
+
+	fail_unless(vi->flags & VOICE_RELEASE, "voice release");
+	fail_unless(!TEST_NOTE(NOTE_FADEOUT), "no note fadeout");
+	fail_unless(xc->period, "no note end");
+
+	ret = xmp_smix_play_sample(opaque, 1, XMP_KEY_FADE, 0, 0);
+	fail_unless(ret == 0, "play key fade");
+	xmp_play_frame(opaque);
+
+	fail_unless(TEST_NOTE(NOTE_FADEOUT), "note fadeout");
+	fail_unless(xc->period, "no note end");
+
+	ret = xmp_smix_play_sample(opaque, 1, XMP_KEY_CUT, 0, 0);
+	fail_unless(ret == 0, "play key cut");
+	xmp_play_frame(opaque);
+
+	fail_unless(!xc->period, "note end");
 
 	xmp_smix_release_sample(opaque, 0);
 	xmp_smix_release_sample(opaque, 1);


### PR DESCRIPTION
Fixes #106. This needs better testing and is probably not 100% correct currently.