### PR TITLE
hio_seek should reset the HIO_HANDLE stream error status on success.

### DIFF
--- a/src/hio.c
+++ b/src/hio.c
@@ -287,17 +287,26 @@ int hio_seek(HIO_HANDLE *h, long offset, int whence)
 		if (ret < 0) {
 			h->error = errno;
 		}
+		else if (h->error == EOF) {
+			h->error = 0;
+		}
 		break;
 	case HIO_HANDLE_TYPE_MEMORY:
 		ret = mseek(h->handle.mem, offset, whence);
 		if (ret < 0) {
 			h->error = EINVAL;
 		}
+		else if (h->error == EOF) {
+			h->error = 0;
+		}
 		break;
 	case HIO_HANDLE_TYPE_CBFILE:
 		ret = cbseek(h->handle.cbfile, offset, whence);
 		if (ret < 0) {
 			h->error = EINVAL;
+		}
+		else if (h->error == EOF) {
+			h->error = 0;
 		}
 		break;
 	}

--- a/src/load.c
+++ b/src/load.c
@@ -251,7 +251,6 @@ static int load_module(xmp_context opaque, HIO_HANDLE *h)
 	test_result = load_result = -1;
 	for (i = 0; format_loaders[i] != NULL; i++) {
 		hio_seek(h, 0, SEEK_SET);
-		hio_error(h); /* reset error flag */
 
 		D_(D_WARN "test %s", format_loaders[i]->name);
 		test_result = format_loaders[i]->test(h, NULL, 0);

--- a/src/loaders/mmd1_load.c
+++ b/src/loaders/mmd1_load.c
@@ -515,14 +515,15 @@ static int mmd1_load(struct module_data *m, HIO_HANDLE *f, const int start)
 			exp_smp[i].suppress_midi_off = hio_read8(f);
 			exp_smp[i].finetune = hio_read8(f);
 
+			if (hio_error(f)) {
+				D_(D_CRIT "read error at expsmp");
+				goto err_cleanup;
+			}
+
 			if (skip && hio_seek(f, skip, SEEK_CUR) != 0) {
 				D_(D_CRIT "seek error at expsmp");
 				goto err_cleanup;
 			}
-		}
-		if (hio_error(f)) {
-			D_(D_CRIT "read error at expsmp");
-			goto err_cleanup;
 		}
 	}
 

--- a/src/loaders/mmd3_load.c
+++ b/src/loaders/mmd3_load.c
@@ -492,14 +492,15 @@ static int mmd3_load(struct module_data *m, HIO_HANDLE *f, const int start)
 				skip -= 2;
 			}
 
+			if (hio_error(f)) {
+				D_(D_CRIT "read error at expsmp");
+				goto err_cleanup;
+			}
+
 			if (skip && hio_seek(f, skip, SEEK_CUR) != 0) {
 				D_(D_CRIT "seek error at expsmp");
 				goto err_cleanup;
 			}
-		}
-		if (hio_error(f)) {
-			D_(D_CRIT "read error at expsmp");
-			goto err_cleanup;
 		}
 	}
 

--- a/src/loaders/prowizard/prowiz.c
+++ b/src/loaders/prowizard/prowiz.c
@@ -101,7 +101,6 @@ int pw_wizardry(HIO_HANDLE *file_in, FILE *file_out, const char **name)
 		return -1;
 	}
 
-	hio_error(file_in); /* reset error flag */
 	hio_seek(file_in, 0, SEEK_SET);
 	if (format->depack(file_in, file_out) < 0) {
 		return -1;


### PR DESCRIPTION
See https://github.com/libxmp/libxmp/pull/493#discussion_r738902930. `hio_seek` doesn't clear the error flag (which also stores the `EOF` state), which makes it semantically different from `fseek`, which is guaranteed to clear the `EOF` state. The result is that hitting `EOF` followed by an `hio_seek` will result in `hio_eof` returning 0 and `hio_error` returning `EOF`.

The fix is to just clear the error state on a successful `hio_seek` if it's `EOF`.