### PR TITLE
miscellaneous small stuff

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -22,14 +22,24 @@ run:
 
 Use ./configure --help to see more options.
 
+For emscripten, remember to pass the correct host os to configure, e.g.:
+
+  $ emconfigure ./configure --host=wasm32-unknown-emscripten
+
+
+You can also use the CMake build system to build libxmp, which requires
+cmake versions 3.2 or newer ( https://cmake.org )
+
 
 To build for Windows using Visual Studio, use Makefile.vc:
 
   nmake -f Makefile.vc   (read/edit Makefile.vc as necessary.)
 
+
 To build for Windows using OpenWatcom, use Makefile.w32:
 
   wmake -f Makefile.w32  (read/edit Makefile.w32 as necessary.)
+
 
 To build for OS/2 using OpenWatcom, use Makefile.os2:
 

--- a/src/hio.c
+++ b/src/hio.c
@@ -403,6 +403,11 @@ HIO_HANDLE *hio_open_mem(const void *ptr, long size)
 	h->handle.mem = mopen(ptr, size);
 	h->size = size;
 
+	if (!h->handle.mem) {
+		free(h);
+		h = NULL;
+	}
+
 	return h;
 }
 

--- a/src/loaders/umx_load.c
+++ b/src/loaders/umx_load.c
@@ -28,11 +28,6 @@
 #define strcasecmp _stricmp
 #endif
 
-extern const struct format_loader libxmp_loader_xm;
-extern const struct format_loader libxmp_loader_it;
-extern const struct format_loader libxmp_loader_s3m;
-extern const struct format_loader libxmp_loader_mod;
-
 static int umx_test (HIO_HANDLE *, char *, const int);
 static int umx_load (struct module_data *, HIO_HANDLE *, const int);
 
@@ -344,9 +339,7 @@ static int process_upkg (HIO_HANDLE *f, int32 *ofs, int32 *objsize)
 	struct upkg_hdr header;
 
 	memset(&header, 0, sizeof(header));
-	if (probe_header(f, &header) < 0)
-		return -1;
-
+	if (probe_header(f, &header) < 0) return -1;
 	return probe_umx(f, &header, ofs, objsize);
 }
 


### PR DESCRIPTION
1. umx_load.c: remove extern declarations of format loaders
   since commit 79c801493, format.h has them already.
2. hio_open_mem: add missing NULL-check for the returned ptr from mopen().
3. add notes to INSTALL file about emscripten configuration and also cmake.
   (see https://github.com/libxmp/libxmp/issues/467)
