### PR TITLE
Allow certain depackers to work without using a temporary file

### DIFF
--- a/src/depackers/bunzip2.c
+++ b/src/depackers/bunzip2.c
@@ -588,5 +588,6 @@ static int decrunch_bzip2(HIO_HANDLE *src, FILE *dst, long inlen)
 
 struct depacker libxmp_depacker_bzip2 = {
 	test_bzip2,
-	decrunch_bzip2
+	decrunch_bzip2,
+	NULL
 };

--- a/src/depackers/depacker.c
+++ b/src/depackers/depacker.c
@@ -291,7 +291,7 @@ static int decrunch_internal_memory(HIO_HANDLE **h, struct depacker *depacker)
 	D_(D_INFO "done");
 
 	hio_close(*h);
-	*h = hio_open_mem2(out, outlen);
+	*h = hio_open_mem(out, outlen, 1);
 
 	return (*h == NULL)? -1 : 0;
 }

--- a/src/depackers/depacker.c
+++ b/src/depackers/depacker.c
@@ -199,11 +199,107 @@ static int execute_command(const char * const cmd[], FILE *t)
 }
 #endif /* USE_FORK */
 
+static int decrunch_command(HIO_HANDLE **h, const char * const cmd[], char **temp)
+{
+#if defined __ANDROID__ || defined __native_client__
+	/* Don't use external helpers in android */
+	return 0;
+#else
+	FILE *t;
+
+	D_(D_WARN "Depacking file... ");
+
+	if ((t = make_temp_file(temp)) == NULL) {
+		goto err;
+	}
+
+	/* Depack file */
+	D_(D_INFO "External depacker: %s", cmd[0]);
+	if (execute_command(cmd, t) < 0) {
+		D_(D_CRIT "failed");
+		goto err2;
+	}
+
+	D_(D_INFO "done");
+
+	if (fseek(t, 0, SEEK_SET) < 0) {
+		D_(D_CRIT "fseek error");
+		goto err2;
+	}
+
+	hio_close(*h);
+	*h = hio_open_file2(t);
+
+	return (*h == NULL)? -1 : 0;
+
+    err2:
+	fclose(t);
+    err:
+	return -1;
+#endif
+}
+
+static int decrunch_internal_tempfile(HIO_HANDLE **h, struct depacker *depacker, char **temp)
+{
+	FILE *t;
+
+	D_(D_WARN "Depacking file... ");
+
+	if ((t = make_temp_file(temp)) == NULL) {
+		goto err;
+	}
+
+	/* Depack file */
+	D_(D_INFO "Internal depacker");
+	if (depacker->depack(*h, t, hio_size(*h)) < 0) {
+		D_(D_CRIT "failed");
+		goto err2;
+	}
+
+	D_(D_INFO "done");
+
+	if (fseek(t, 0, SEEK_SET) < 0) {
+		D_(D_CRIT "fseek error");
+		goto err2;
+	}
+
+	hio_close(*h);
+	*h = hio_open_file2(t);
+
+	return (*h == NULL)? -1 : 0;
+
+    err2:
+	fclose(t);
+    err:
+	return -1;
+}
+
+static int decrunch_internal_memory(HIO_HANDLE **h, struct depacker *depacker)
+{
+	void *out;
+	long outlen;
+
+	D_(D_WARN "Depacking file... ");
+
+	/* Depack file */
+	D_(D_INFO "Internal depacker");
+	if (depacker->depack_mem(*h, &out, hio_size(*h), &outlen) < 0) {
+		D_(D_CRIT "failed");
+		return -1;
+	}
+
+	D_(D_INFO "done");
+
+	hio_close(*h);
+	*h = hio_open_mem2(out, outlen);
+
+	return (*h == NULL)? -1 : 0;
+}
+
 int libxmp_decrunch(HIO_HANDLE **h, const char *filename, char **temp)
 {
 	unsigned char b[1024];
 	const char *cmd[32];
-	FILE *t;
 	int headersize;
 	int i;
 	struct depacker *depacker = NULL;
@@ -255,65 +351,27 @@ int libxmp_decrunch(HIO_HANDLE **h, const char *filename, char **temp)
 	}
 
 	if (hio_seek(*h, 0, SEEK_SET) < 0) {
-		goto err;
-	}
-
-	if (depacker == NULL && cmd[0] == NULL) {
-		D_(D_INFO "Not packed");
-		return 0;
-	}
-
-#if defined __ANDROID__ || defined __native_client__
-	/* Don't use external helpers in android */
-	if (cmd[0]) {
-		return 0;
-	}
-#endif
-
-	/* When the filename is unknown (because it is a stream) don't use
-	 * external helpers
-	 */
-	if (cmd[0] && filename == NULL) {
-		return 0;
-	}
-
-	D_(D_WARN "Depacking file... ");
-
-	if ((t = make_temp_file(temp)) == NULL) {
-		goto err;
+		return -1;
 	}
 
 	/* Depack file */
 	if (cmd[0]) {
-		D_(D_INFO "External depacker: %s", cmd[0]);
-		if (execute_command(cmd, t) < 0) {
-			D_(D_CRIT "failed");
-			goto err2;
+		/* When the filename is unknown (because it is a stream) don't use
+		 * external helpers
+		 */
+		if (filename == NULL) {
+			return 0;
 		}
-	} else if (depacker) {
-		D_(D_INFO "Internal depacker");
-		if (depacker->depack(*h, t, hio_size(*h)) < 0) {
-			D_(D_CRIT "failed");
-			goto err2;
-		}
+
+		return decrunch_command(h, cmd, temp);
+	} else if (depacker && depacker->depack) {
+		return decrunch_internal_tempfile(h, depacker, temp);
+	} else if (depacker && depacker->depack_mem) {
+		return decrunch_internal_memory(h, depacker);
+	} else {
+		D_(D_INFO "Not packed");
+		return 0;
 	}
-
-	D_(D_INFO "done");
-
-	if (fseek(t, 0, SEEK_SET) < 0) {
-		D_(D_CRIT "fseek error");
-		goto err2;
-	}
-
-	hio_close(*h);
-	*h = hio_open_file2(t);
-
-	return (*h == NULL)? -1 : 0;
-
-    err2:
-	fclose(t);
-    err:
-	return -1;
 }
 
 /*

--- a/src/depackers/depacker.h
+++ b/src/depackers/depacker.h
@@ -23,6 +23,7 @@ extern struct depacker libxmp_depacker_xfd;
 struct depacker {
 	int (*test)(unsigned char *);
 	int (*depack)(HIO_HANDLE *, FILE *, long);
+	int (*depack_mem)(HIO_HANDLE *, void **, long, long *);
 };
 
 int	libxmp_decrunch		(HIO_HANDLE **h, const char *filename, char **temp);

--- a/src/depackers/miniz.c
+++ b/src/depackers/miniz.c
@@ -2415,7 +2415,7 @@ tinfl_status tinfl_decompress(tinfl_decompressor *r, const mz_uint8 *pIn_buf_nex
     mz_uint32 num_bits, dist, counter, num_extra;
     tinfl_bit_buf_t bit_buf;
     const mz_uint8 *pIn_buf_cur = pIn_buf_next, *const pIn_buf_end = pIn_buf_next + *pIn_buf_size;
-    mz_uint8 *pOut_buf_cur = pOut_buf_next, *const pOut_buf_end = pOut_buf_next + *pOut_buf_size;
+    mz_uint8 *pOut_buf_cur = pOut_buf_next, *const pOut_buf_end = pOut_buf_next ? pOut_buf_next + *pOut_buf_size : NULL;
     size_t out_buf_size_mask = (decomp_flags & TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF) ? (size_t)-1 : ((pOut_buf_next - pOut_buf_start) + *pOut_buf_size) - 1, dist_from_out_buf_start;
 
     /* Ensure the output buffer's size is a power of 2, unless the output buffer is large enough to hold the entire output file (in which case it doesn't matter). */

--- a/src/depackers/mmcmp.c
+++ b/src/depackers/mmcmp.c
@@ -463,5 +463,6 @@ static int decrunch_mmcmp(HIO_HANDLE *in, FILE *out, long inlen)
 
 struct depacker libxmp_depacker_mmcmp = {
 	test_mmcmp,
-	decrunch_mmcmp
+	decrunch_mmcmp,
+	NULL
 };

--- a/src/depackers/mmcmp.c
+++ b/src/depackers/mmcmp.c
@@ -310,7 +310,7 @@ static int test_mmcmp(unsigned char *b)
 	return memcmp(b, "ziRCONia", 8) == 0;
 }
 
-static int decrunch_mmcmp(HIO_HANDLE *in, FILE *out, long inlen)
+static int decrunch_mmcmp(HIO_HANDLE *in, void **out, long inlen, long *outlen)
 {
 	struct header h;
 	struct mem_buffer outbuf;
@@ -447,10 +447,9 @@ static int decrunch_mmcmp(HIO_HANDLE *in, FILE *out, long inlen)
 		free(sub_block);
 	}
 
-	if (fwrite(outbuf.buf, 1, h.filesize, out) < h.filesize)
-		goto err2;
+	*out = outbuf.buf;
+	*outlen = h.filesize;
 
-	free(outbuf.buf);
 	free(table);
 	return 0;
 
@@ -463,6 +462,6 @@ static int decrunch_mmcmp(HIO_HANDLE *in, FILE *out, long inlen)
 
 struct depacker libxmp_depacker_mmcmp = {
 	test_mmcmp,
-	decrunch_mmcmp,
-	NULL
+	NULL,
+	decrunch_mmcmp
 };

--- a/src/depackers/muse.c
+++ b/src/depackers/muse.c
@@ -37,15 +37,11 @@ static int test_muse(unsigned char *b)
 	return 0;
 }
 
-static int tinfl_put_buf_func(const void* pBuf, int len, void *pUser)
-{
-	return len == (int)fwrite(pBuf, 1, len, (FILE*)pUser);
-}
-
-static int decrunch_muse(HIO_HANDLE *f, FILE *fo, long inlen)
+static int decrunch_muse(HIO_HANDLE *f, void **out, long inlen, long *outlen)
 {
 	size_t in_buf_size = inlen - 24;
-	uint8 *pCmp_data;
+	void *pCmp_data, *pOut_buf;
+	size_t pOut_len;
 
 	if (hio_seek(f, 24, SEEK_SET) < 0) {
 		D_(D_CRIT "hio_seek() failed");
@@ -64,17 +60,23 @@ static int decrunch_muse(HIO_HANDLE *f, FILE *fo, long inlen)
 		return -1;
 	}
 
-	if (tinfl_decompress_mem_to_callback(pCmp_data, &in_buf_size, tinfl_put_buf_func, fo, TINFL_FLAG_PARSE_ZLIB_HEADER) == 0) {
-		D_(D_CRIT "tinfl_decompress_mem_to_callback() failed");
+	pOut_buf = tinfl_decompress_mem_to_heap(pCmp_data, in_buf_size, &pOut_len, TINFL_FLAG_PARSE_ZLIB_HEADER);
+	if (!pOut_buf) {
+		D_(D_CRIT "tinfl_decompress_mem_to_heap() failed");
 		free(pCmp_data);
 		return -1;
 	}
 
 	free(pCmp_data);
+
+	*out = pOut_buf;
+	*outlen = pOut_len;
+
 	return 0;
 }
 
 struct depacker libxmp_depacker_muse = {
 	test_muse,
+	NULL,
 	decrunch_muse
 };

--- a/src/depackers/s404_dec.c
+++ b/src/depackers/s404_dec.c
@@ -364,7 +364,7 @@ static int test_s404(unsigned char *b)
 	return memcmp(b, "S404", 4) == 0;
 }
 
-static int decrunch_s404(HIO_HANDLE *in, FILE *out, long inlen)
+static int decrunch_s404(HIO_HANDLE *in, void **out, long inlen, long *outlen)
 {
   int32 oLen, sLen, pLen;
   uint8 *dst = NULL;
@@ -411,13 +411,11 @@ static int decrunch_s404(HIO_HANDLE *in, FILE *out, long inlen)
       goto error1;
   }
 
-  if (fwrite(dst, oLen, 1, out) == 0) {
-      /*fprintf(stderr,"S404 Error: fwrite() failed..\n");*/
-      goto error1;
-  }
-
-  free(dst);
   free(src);
+
+  *out = dst;
+  *outlen = oLen;
+
   return 0;
 
  error1:
@@ -429,5 +427,6 @@ static int decrunch_s404(HIO_HANDLE *in, FILE *out, long inlen)
 
 struct depacker libxmp_depacker_s404 = {
 	test_s404,
+	NULL,
 	decrunch_s404
 };

--- a/src/depackers/uncompress.c
+++ b/src/depackers/uncompress.c
@@ -267,5 +267,6 @@ static int decrunch_compress(HIO_HANDLE * in, FILE * out, long inlen)
 
 struct depacker libxmp_depacker_compress = {
 	test_compress,
-	decrunch_compress
+	decrunch_compress,
+	NULL
 };

--- a/src/depackers/unlha.c
+++ b/src/depackers/unlha.c
@@ -1861,5 +1861,6 @@ static int decrunch_lha(HIO_HANDLE *in, FILE *out, long inlen)
 
 struct depacker libxmp_depacker_lha = {
 	test_lha,
-	decrunch_lha
+	decrunch_lha,
+	NULL
 };

--- a/src/depackers/unlzx.c
+++ b/src/depackers/unlzx.c
@@ -1126,5 +1126,6 @@ static int decrunch_lzx(HIO_HANDLE *f, FILE *fo, long inlen)
 
 struct depacker libxmp_depacker_lzx = {
 	test_lzx,
-	decrunch_lzx
+	decrunch_lzx,
+	NULL
 };

--- a/src/depackers/unsqsh.c
+++ b/src/depackers/unsqsh.c
@@ -380,7 +380,7 @@ static int test_sqsh(unsigned char *b)
 	return memcmp(b, "XPKF", 4) == 0 && memcmp(b + 8, "SQSH", 4) == 0;
 }
 
-static int decrunch_sqsh(HIO_HANDLE * f, FILE * fo, long inlen)
+static int decrunch_sqsh(HIO_HANDLE * f, void ** outbuf, long inlen, long * outlen)
 {
 	unsigned char *src, *dest;
 	int srclen, destlen;
@@ -413,11 +413,10 @@ static int decrunch_sqsh(HIO_HANDLE * f, FILE * fo, long inlen)
 	if (unsqsh(src, srclen, dest, destlen) != destlen)
 		goto err3;
 
-	if (fwrite(dest, destlen, 1, fo) != 1)
-		goto err3;
-
-	free(dest);
 	free(src);
+
+	*outbuf = dest;
+	*outlen = destlen;
 
 	return 0;
 
@@ -431,5 +430,6 @@ static int decrunch_sqsh(HIO_HANDLE * f, FILE * fo, long inlen)
 
 struct depacker libxmp_depacker_sqsh = {
 	test_sqsh,
+	NULL,
 	decrunch_sqsh
 };

--- a/src/depackers/unxz.c
+++ b/src/depackers/unxz.c
@@ -106,5 +106,6 @@ static int decrunch_xz(HIO_HANDLE *in, FILE *out, long inlen)
 
 struct depacker libxmp_depacker_xz = {
 	test_xz,
-	decrunch_xz
+	decrunch_xz,
+	NULL
 };

--- a/src/depackers/unxz.c
+++ b/src/depackers/unxz.c
@@ -35,7 +35,7 @@ static int test_xz(unsigned char *b)
 	return !memcmp(b, XZ_MAGIC, sizeof(XZ_MAGIC));
 }
 
-static int decrunch_xz(HIO_HANDLE *in, FILE *out, long inlen)
+static int decrunch_xz(HIO_HANDLE *in, void **out, long inlen, long *outlen)
 {
 	struct xz_dec *xz;
 	struct xz_buf buf;
@@ -91,9 +91,9 @@ static int decrunch_xz(HIO_HANDLE *in, FILE *out, long inlen)
 		goto err;
 	*/
 
-	fwrite(buf.out, 1, buf.out_pos, out);
+	*out = buf.out;
+	*outlen = buf.out_pos;
 
-	free(buf.out);
 	free(inbuf);
 	return 0;
 
@@ -106,6 +106,6 @@ static int decrunch_xz(HIO_HANDLE *in, FILE *out, long inlen)
 
 struct depacker libxmp_depacker_xz = {
 	test_xz,
-	decrunch_xz,
-	NULL
+	NULL,
+	decrunch_xz
 };

--- a/src/depackers/unxz.c
+++ b/src/depackers/unxz.c
@@ -86,10 +86,8 @@ static int decrunch_xz(HIO_HANDLE *in, void **out, long inlen, long *outlen)
 
 	xz_dec_end(xz);
 
-	/*
-	if ((tmp = (uint8 *) realloc(buf.out, buf.out_pos)) == NULL)
-		goto err;
-	*/
+	if ((tmp = (uint8 *) realloc(buf.out, buf.out_pos)) != NULL)
+		buf.out = tmp;
 
 	*out = buf.out;
 	*outlen = buf.out_pos;

--- a/src/depackers/xfd.c
+++ b/src/depackers/xfd.c
@@ -88,7 +88,8 @@ static int decrunch_xfd(HIO_HANDLE *f1, FILE *f2, long inlen)
 
 struct depacker libxmp_depacker_xfd = {
 	test_xfd,
-	decrunch_xfd
+	decrunch_xfd,
+	NULL
 };
 
 #endif /* AMIGA */

--- a/src/hio.c
+++ b/src/hio.c
@@ -400,7 +400,28 @@ HIO_HANDLE *hio_open_mem(const void *ptr, long size)
 		return NULL;
 
 	h->type = HIO_HANDLE_TYPE_MEMORY;
-	h->handle.mem = mopen(ptr, size);
+	h->handle.mem = mopen(ptr, size, 0);
+	h->size = size;
+
+	if (!h->handle.mem) {
+		free(h);
+		h = NULL;
+	}
+
+	return h;
+}
+
+HIO_HANDLE *hio_open_mem2(const void *ptr, long size)
+{
+	HIO_HANDLE *h;
+
+	if (size <= 0) return NULL;
+	h = (HIO_HANDLE *) calloc(1, sizeof(HIO_HANDLE));
+	if (h == NULL)
+		return NULL;
+
+	h->type = HIO_HANDLE_TYPE_MEMORY;
+	h->handle.mem = mopen(ptr, size, 1);
 	h->size = size;
 
 	if (!h->handle.mem) {

--- a/src/hio.c
+++ b/src/hio.c
@@ -390,7 +390,7 @@ HIO_HANDLE *hio_open(const char *path, const char *mode)
 	return NULL;
 }
 
-HIO_HANDLE *hio_open_mem(const void *ptr, long size)
+HIO_HANDLE *hio_open_mem(const void *ptr, long size, int free_after_use)
 {
 	HIO_HANDLE *h;
 
@@ -400,28 +400,7 @@ HIO_HANDLE *hio_open_mem(const void *ptr, long size)
 		return NULL;
 
 	h->type = HIO_HANDLE_TYPE_MEMORY;
-	h->handle.mem = mopen(ptr, size, 0);
-	h->size = size;
-
-	if (!h->handle.mem) {
-		free(h);
-		h = NULL;
-	}
-
-	return h;
-}
-
-HIO_HANDLE *hio_open_mem2(const void *ptr, long size)
-{
-	HIO_HANDLE *h;
-
-	if (size <= 0) return NULL;
-	h = (HIO_HANDLE *) calloc(1, sizeof(HIO_HANDLE));
-	if (h == NULL)
-		return NULL;
-
-	h->type = HIO_HANDLE_TYPE_MEMORY;
-	h->handle.mem = mopen(ptr, size, 1);
+	h->handle.mem = mopen(ptr, size, free_after_use);
 	h->size = size;
 
 	if (!h->handle.mem) {

--- a/src/hio.h
+++ b/src/hio.h
@@ -38,8 +38,7 @@ long	hio_tell	(HIO_HANDLE *);
 int	hio_eof		(HIO_HANDLE *);
 int	hio_error	(HIO_HANDLE *);
 HIO_HANDLE *hio_open	(const char *, const char *);
-HIO_HANDLE *hio_open_mem  (const void *, long);
-HIO_HANDLE *hio_open_mem2  (const void *, long);/* allows free()ing the memory by libxmp */
+HIO_HANDLE *hio_open_mem  (const void *, long, int);
 HIO_HANDLE *hio_open_file (FILE *);
 HIO_HANDLE *hio_open_file2 (FILE *);/* allows fclose()ing the file by libxmp */
 HIO_HANDLE *hio_open_callbacks (void *, struct xmp_callbacks);

--- a/src/hio.h
+++ b/src/hio.h
@@ -39,6 +39,7 @@ int	hio_eof		(HIO_HANDLE *);
 int	hio_error	(HIO_HANDLE *);
 HIO_HANDLE *hio_open	(const char *, const char *);
 HIO_HANDLE *hio_open_mem  (const void *, long);
+HIO_HANDLE *hio_open_mem2  (const void *, long);/* allows free()ing the memory by libxmp */
 HIO_HANDLE *hio_open_file (FILE *);
 HIO_HANDLE *hio_open_file2 (FILE *);/* allows fclose()ing the file by libxmp */
 HIO_HANDLE *hio_open_callbacks (void *, struct xmp_callbacks);

--- a/src/load.c
+++ b/src/load.c
@@ -183,7 +183,7 @@ int xmp_test_module_from_memory(const void *mem, long size, struct xmp_test_info
 		return -XMP_ERROR_INVALID;
 	}
 
-	if ((h = hio_open_mem(mem, size)) == NULL)
+	if ((h = hio_open_mem(mem, size, 0)) == NULL)
 		return -XMP_ERROR_SYSTEM;
 
 	ret = test_module(info, h);
@@ -428,7 +428,7 @@ int xmp_load_module_from_memory(xmp_context opaque, const void *mem, long size)
 		return -XMP_ERROR_INVALID;
 	}
 
-	if ((h = hio_open_mem(mem, size)) == NULL)
+	if ((h = hio_open_mem(mem, size, 0)) == NULL)
 		return -XMP_ERROR_SYSTEM;
 
 	if (ctx->state > XMP_STATE_UNLOADED)

--- a/src/memio.c
+++ b/src/memio.c
@@ -92,7 +92,7 @@ int meof(MFILE *m)
 	return CAN_READ(m) <= 0;
 }
 
-MFILE *mopen(const void *ptr, long size)
+MFILE *mopen(const void *ptr, long size, int free_after_use)
 {
 	MFILE *m;
 
@@ -103,12 +103,15 @@ MFILE *mopen(const void *ptr, long size)
 	m->start = (const unsigned char *)ptr;
 	m->pos = 0;
 	m->size = size;
+	m->free_after_use = free_after_use;
 
 	return m;
 }
 
 int mclose(MFILE *m)
 {
+	if (m->free_after_use)
+		free((void *)m->start);
 	free(m);
 	return 0;
 }

--- a/src/memio.h
+++ b/src/memio.h
@@ -8,11 +8,12 @@ typedef struct {
 	const unsigned char *start;
 	ptrdiff_t pos;
 	ptrdiff_t size;
+	int free_after_use;
 } MFILE;
 
 LIBXMP_BEGIN_DECLS
 
-MFILE  *mopen(const void *, long);
+MFILE  *mopen(const void *, long, int);
 int     mgetc(MFILE *stream);
 size_t  mread(void *, size_t, size_t, MFILE *);
 int     mseek(MFILE *, long, int);

--- a/test-dev/test_read_mem_hio.c
+++ b/test-dev/test_read_mem_hio.c
@@ -11,7 +11,7 @@ TEST(test_read_mem_hio)
 	for (i = 0; i < 100; i++)
 		mem[i] = i;
 
-	h = hio_open_mem(mem, 100);
+	h = hio_open_mem(mem, 100, 0);
 	fail_unless(h != NULL, "hio_open");
 
 	x = hio_size(h);

--- a/test-dev/test_read_mem_hio_nosize.c
+++ b/test-dev/test_read_mem_hio_nosize.c
@@ -6,10 +6,10 @@ TEST(test_read_mem_hio_nosize)
 	HIO_HANDLE *h;
 	char mem = 0; /* suppress warning */
 
-	h = hio_open_mem(&mem, -1);
+	h = hio_open_mem(&mem, -1, 0);
 	fail_unless(h == NULL, "hio_open");
 
-	h = hio_open_mem(&mem, 0);
+	h = hio_open_mem(&mem, 0, 0);
 	fail_unless(h == NULL, "hio_open");
 }
 END_TEST


### PR DESCRIPTION
This affects the ppdepack, s404, sqsh, muse, zip, gzip, arc and arcfs depackers. The rest still require a temporary file for now.

TODO:
 - [x] Fix the UBSan errors.
 - [x] Adapt the mmcmp depacker.
 - [x] Adapt the xz depacker.
 - [x] Adapt and test the xfd depacker.
 - [ ] Adapt the other depackers? (bzip2, compress, lha, lzx, rar, mo3)