### PR TITLE
more miscellaneous stuff: dead code

### DIFF
--- a/Makefile.vc
+++ b/Makefile.vc
@@ -58,7 +58,6 @@ OBJS	= \
  src\loaders\common.obj \
  src\loaders\iff.obj \
  src\loaders\itsex.obj \
- src\loaders\asif.obj \
  src\loaders\lzw.obj \
  src\loaders\voltable.obj \
  src\loaders\sample.obj \

--- a/cmake/libxmp-sources.cmake
+++ b/cmake/libxmp-sources.cmake
@@ -31,7 +31,6 @@ set(LIBXMP_SRC_LIST
     src/loaders/common.c
     src/loaders/iff.c
     src/loaders/itsex.c
-    src/loaders/asif.c
     src/loaders/lzw.c
     src/loaders/voltable.c
     src/loaders/sample.c

--- a/lite/watcom.mif.in
+++ b/lite/watcom.mif.in
@@ -7,6 +7,8 @@ STATICFLAGS=-DBUILDING_STATIC
 
 DLLNAME=libxmp.dll
 EXPNAME=libxmp.exp
+# Note: not libxmp.map...
+MAPNAME=xmp-lite.map
 LIBNAME=libxmp.lib
 LIBSTATIC=xmp_static.lib
 TESTNAME=libxmp-test.exe
@@ -41,7 +43,7 @@ test/test.obj: test/test.c
 
 # rely on symbol name, not ordinal: -irn switch of wlib is default, but -inn is not.
 $(DLLNAME) $(LIBNAME) $(EXPNAME): $(OBJS)
-	wlink NAM $(DLLNAME) SYSTEM $(SYSTEM_DLL) INITINSTANCE TERMINSTANCE OP QUIET FIL {$(OBJS)} OPTION IMPF=$(EXPNAME)
+	wlink NAM $(DLLNAME) SYSTEM $(SYSTEM_DLL) INITINSTANCE TERMINSTANCE OP QUIET FIL {$(OBJS)} OP IMPF=$(EXPNAME) OP MAP=$(MAPNAME)
 	wlib -q -b -n -c -pa -s -t -zld -ii -io -inn $(LIBNAME) +$(DLLNAME)
 
 $(LIBSTATIC): $(OBJS)
@@ -63,7 +65,7 @@ clean: .symbolic
 	rm -f $(TEST_OBJS)
 
 distclean: clean .symbolic
-	rm -f $(DLLNAME) $(EXPNAME) $(LIBNAME) $(LIBSTATIC) test/$(DLLNAME) test/$(TESTNAME)
+	rm -f $(DLLNAME) $(EXPNAME) $(MAPNAME) $(LIBNAME) $(LIBSTATIC) test/$(DLLNAME) test/$(TESTNAME)
 
 !ifdef __UNIX__
 CMD_CP=cp

--- a/src/loaders/Makefile
+++ b/src/loaders/Makefile
@@ -9,10 +9,11 @@ LOADERS	= xm_load.o mod_load.o s3m_load.o stm_load.o 669_load.o far_load.o \
 	  gdm_load.o pw_load.o gal5_load.o gal4_load.o mfp_load.o asylum_load.o \
 	  hmn_load.o mgt_load.o chip_load.o abk_load.o coco_load.o
 
-LOADERS_OBJS	= common.o iff.o itsex.o asif.o lzw.o voltable.o sample.o vorbis.o \
+LOADERS_OBJS	= common.o iff.o itsex.o lzw.o voltable.o sample.o vorbis.o \
 		  $(LOADERS)
+
 LOADERS_DFILES	= Makefile $(LOADERS_OBJS:.o=.c) \
-		  asif.h iff.h lzw.h it.h loader.h med.h mod.h s3m.h xm.h vorbis.h
+		  iff.h lzw.h it.h loader.h med.h mod.h s3m.h xm.h vorbis.h
 LOADERS_PATH	= src/loaders
 
 OBJS += $(addprefix $(LOADERS_PATH)/,$(LOADERS_OBJS))

--- a/src/loaders/common.c
+++ b/src/loaders/common.c
@@ -203,6 +203,7 @@ int libxmp_alloc_pattern_tracks(struct xmp_module *mod, int num, int rows)
 	return 0;
 }
 
+#ifndef LIBXMP_CORE_PLAYER
 /* Some formats explicitly allow more than 256 rows (e.g. OctaMED). This function
  * allows those formats to work without disrupting the sanity check for other formats.
  */
@@ -222,6 +223,7 @@ int libxmp_alloc_pattern_tracks_long(struct xmp_module *mod, int num, int rows)
 
 	return 0;
 }
+#endif
 
 char *libxmp_instrument_name(struct xmp_module *mod, int i, uint8 *r, int n)
 {
@@ -476,6 +478,7 @@ void libxmp_set_type(struct module_data *m, const char *fmt, ...)
 	va_end(ap);
 }
 
+#ifndef LIBXMP_CORE_PLAYER
 static int schism_tracker_date(int year, int month, int day)
 {
 	int mm = (month + 9) % 12;
@@ -526,3 +529,4 @@ void libxmp_schism_tracker_string(char *buf, size_t size, int s_ver, int l_ver)
 		snprintf(buf, size, "Schism Tracker 0.%x", s_ver);
 	}
 }
+#endif

--- a/src/loaders/loader.h
+++ b/src/loaders/loader.h
@@ -30,7 +30,9 @@ int	libxmp_alloc_pattern		(struct xmp_module *, int);
 int	libxmp_alloc_track		(struct xmp_module *, int, int);
 int	libxmp_alloc_tracks_in_pattern	(struct xmp_module *, int);
 int	libxmp_alloc_pattern_tracks	(struct xmp_module *, int, int);
+#ifndef LIBXMP_CORE_PLAYER
 int	libxmp_alloc_pattern_tracks_long(struct xmp_module *, int, int);
+#endif
 char	*libxmp_instrument_name		(struct xmp_module *, int, uint8 *, int);
 
 char	*libxmp_copy_adjust		(char *, uint8 *, int);
@@ -47,7 +49,9 @@ void	libxmp_set_type			(struct module_data *, const char *, ...);
 int	libxmp_load_sample		(struct module_data *, HIO_HANDLE *, int,
 					 struct xmp_sample *, const void *);
 void	libxmp_free_sample		(struct xmp_sample *);
+#ifndef LIBXMP_CORE_PLAYER
 void	libxmp_schism_tracker_string	(char *, size_t, int, int);
+#endif
 
 extern uint8		libxmp_ord_xlat[];
 extern const int	libxmp_arch_vol_table[];

--- a/src/loaders/med4_load.c
+++ b/src/loaders/med4_load.c
@@ -52,8 +52,6 @@ static int med4_test(HIO_HANDLE *f, char *t, const int start)
 	return 0;
 }
 
-const unsigned MAX_CHANNELS = 16;
-
 static void fix_effect(struct xmp_event *event, int hexvol)
 {
 	switch (event->fxt) {

--- a/src/loaders/vorbis.c
+++ b/src/loaders/vorbis.c
@@ -302,6 +302,7 @@ extern stb_vorbis * stb_vorbis_open_file_section(FILE *f, int close_handle_on_cl
 // confused.
 #endif
 
+#ifndef STB_VORBIS_NO_SEEK_API
 extern int stb_vorbis_seek_frame(stb_vorbis *f, unsigned int sample_number);
 extern int stb_vorbis_seek(stb_vorbis *f, unsigned int sample_number);
 // these functions seek in the Vorbis file to (approximately) 'sample_number'.
@@ -313,6 +314,7 @@ extern int stb_vorbis_seek(stb_vorbis *f, unsigned int sample_number);
 
 extern int stb_vorbis_seek_start(stb_vorbis *f);
 // this function is equivalent to stb_vorbis_seek(f,0)
+#endif
 
 extern unsigned int stb_vorbis_stream_length_in_samples(stb_vorbis *f);
 extern float        stb_vorbis_stream_length_in_seconds(stb_vorbis *f);
@@ -4699,6 +4701,7 @@ static uint32 vorbis_find_page(stb_vorbis *f, uint32 *end, uint32 *last)
 
 #define SAMPLE_unknown  0xffffffff
 
+#ifndef STB_VORBIS_NO_SEEK_API
 // seeking is implemented with a binary search, which narrows down the range to
 // 64K, before using a linear search (because finding the synchronization
 // pattern can be expensive, and the chance we'd find the end page again is
@@ -5013,6 +5016,7 @@ int stb_vorbis_seek_start(stb_vorbis *f)
    f->next_seg = -1;
    return vorbis_pump_first_frame(f);
 }
+#endif /* STB_VORBIS_NO_SEEK_API */
 
 unsigned int stb_vorbis_stream_length_in_samples(stb_vorbis *f)
 {

--- a/src/loaders/vorbis.h
+++ b/src/loaders/vorbis.h
@@ -1,9 +1,11 @@
 #ifndef NDEBUG
 #define NDEBUG /* disable assert()s */
 #endif
+
 #define STB_VORBIS_NO_PUSHDATA_API
 #define STB_VORBIS_NO_STDIO
 #define STB_VORBIS_NO_COMMENTS
+#define STB_VORBIS_NO_SEEK_API
 #define STB_VORBIS_NO_FLOAT_CONVERSION
 
 #ifndef STB_VORBIS_C

--- a/src/period.c
+++ b/src/period.c
@@ -262,6 +262,7 @@ void libxmp_c2spd_to_note(int c2spd, int *n, int *f)
 	*f = c % 128;
 }
 
+#ifndef LIBXMP_CORE_PLAYER
 /* Gravis Ultrasound frequency increments in steps of Hz/1024, where Hz is the
  * current rate of the card and is dependent on the active channel count.
  * For <=14 channels, the rate is 44100. For 15 to 32 channels, the rate is
@@ -281,3 +282,4 @@ double libxmp_gus_frequency_steps(int num_steps, int num_channels_active)
 	CLAMP(num_channels_active, 14, 32);
 	return (num_steps * GUS_rates[num_channels_active - 14]) / 1024.0;
 }
+#endif

--- a/src/period.h
+++ b/src/period.h
@@ -20,6 +20,8 @@ double	libxmp_note_to_period_mix (int, int);
 int	libxmp_period_to_note	(int);
 int	libxmp_period_to_bend	(struct context_data *, double, int, double);
 void	libxmp_c2spd_to_note	(int, int *, int *);
+#ifndef LIBXMP_CORE_PLAYER
 double	libxmp_gus_frequency_steps (int, int);
+#endif
 
 #endif /* LIBXMP_PERIOD_H */

--- a/watcom.mif
+++ b/watcom.mif
@@ -63,7 +63,6 @@ OBJS= &
  src/loaders/common.obj &
  src/loaders/iff.obj &
  src/loaders/itsex.obj &
- src/loaders/asif.obj &
  src/loaders/lzw.obj &
  src/loaders/voltable.obj &
  src/loaders/sample.obj &

--- a/watcom.mif
+++ b/watcom.mif
@@ -13,6 +13,8 @@ STATICFLAGS=-DBUILDING_STATIC
 
 DLLNAME=libxmp.dll
 EXPNAME=libxmp.exp
+# Note: not libxmp.map...
+MAPNAME=xmp.map
 LIBNAME=libxmp.lib
 LIBSTATIC=xmp_static.lib
 TESTNAME=libxmp-test.exe
@@ -213,7 +215,7 @@ test/test.obj: test/test.c
 
 # rely on symbol name, not ordinal: -irn switch of wlib is default, but -inn is not.
 $(DLLNAME) $(LIBNAME) $(EXPNAME): $(ALL_OBJS)
-	wlink NAM $(DLLNAME) SYSTEM $(SYSTEM_DLL) INITINSTANCE TERMINSTANCE OP QUIET FIL {$(ALL_OBJS)} OPTION IMPF=$(EXPNAME)
+	wlink NAM $(DLLNAME) SYSTEM $(SYSTEM_DLL) INITINSTANCE TERMINSTANCE OP QUIET FIL {$(ALL_OBJS)} OP IMPF=$(EXPNAME) OP MAP=$(MAPNAME)
 	wlib -q -b -n -c -pa -s -t -zld -ii -io -inn $(LIBNAME) +$(DLLNAME)
 
 $(LIBSTATIC): $(ALL_OBJS)
@@ -237,7 +239,7 @@ clean: .symbolic
 	rm -f $(TEST_OBJS)
 
 distclean: clean .symbolic
-	rm -f $(DLLNAME) $(EXPNAME) $(LIBNAME) $(LIBSTATIC) test/$(DLLNAME) test/$(TESTNAME)
+	rm -f $(DLLNAME) $(EXPNAME) $(MAPNAME) $(LIBNAME) $(LIBSTATIC) test/$(DLLNAME) test/$(TESTNAME)
 
 !ifdef __UNIX__
 CMD_CP=cp

--- a/watcom.mif.in
+++ b/watcom.mif.in
@@ -13,6 +13,8 @@ STATICFLAGS=-DBUILDING_STATIC
 
 DLLNAME=libxmp.dll
 EXPNAME=libxmp.exp
+# Note: not libxmp.map...
+MAPNAME=xmp.map
 LIBNAME=libxmp.lib
 LIBSTATIC=xmp_static.lib
 TESTNAME=libxmp-test.exe
@@ -56,7 +58,7 @@ test/test.obj: test/test.c
 
 # rely on symbol name, not ordinal: -irn switch of wlib is default, but -inn is not.
 $(DLLNAME) $(LIBNAME) $(EXPNAME): $(ALL_OBJS)
-	wlink NAM $(DLLNAME) SYSTEM $(SYSTEM_DLL) INITINSTANCE TERMINSTANCE OP QUIET FIL {$(ALL_OBJS)} OPTION IMPF=$(EXPNAME)
+	wlink NAM $(DLLNAME) SYSTEM $(SYSTEM_DLL) INITINSTANCE TERMINSTANCE OP QUIET FIL {$(ALL_OBJS)} OP IMPF=$(EXPNAME) OP MAP=$(MAPNAME)
 	wlib -q -b -n -c -pa -s -t -zld -ii -io -inn $(LIBNAME) +$(DLLNAME)
 
 $(LIBSTATIC): $(ALL_OBJS)
@@ -80,7 +82,7 @@ clean: .symbolic
 	rm -f $(TEST_OBJS)
 
 distclean: clean .symbolic
-	rm -f $(DLLNAME) $(EXPNAME) $(LIBNAME) $(LIBSTATIC) test/$(DLLNAME) test/$(TESTNAME)
+	rm -f $(DLLNAME) $(EXPNAME) $(MAPNAME) $(LIBNAME) $(LIBSTATIC) test/$(DLLNAME) test/$(TESTNAME)
 
 !ifdef __UNIX__
 CMD_CP=cp


### PR DESCRIPTION
1. generate a map file from watcom builds.
2. remove asif.c from build:
   It is only used by ssmt_load.c, which hasn't been built since commit 34354ab7
3. med4_load: remove global symbol MAX_CHANNELS
   its use has been removed as of commit 246b7c7
4. disable alloc_pattern_tracks_long & schism_tracker_string in lite builds
5. disable the seek api in stb_vorbis for libxmp
   Bound to the new STB_VORBIS_NO_SEEK_API define.
   The rest of the libxmp-unused functions in stb_vorbis are:
   stb_vorbis_get_info, stb_vorbis_get_error`, stb_vorbis_get_sample_offset,
   stb_vorbis_get_samples_short, stb_vorbis_get_samples_short_interleaved,
   and stb_vorbis_stream_length_in_seconds, which possibly aren't worth the
   trouble.  (Also see: https://github.com/libxmp/libxmp/issues/481)

There are also other code-dead-to-lite builds, such as `libxmp_virt_setnote`
and `hio_open_file2`, but they aren't worth the trouble of making an effort.

Real dead code is `move_data`: It's now only used by `test_write_file_move_data.c`.
Otherwise, the prowizard code is using `pw_move_data` and the depacker code
is using `depacker_move_data`, which are actually identical. What to do about
that?
