### PR TITLE
Disable building shared for PSP by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ else()
 endif()
 # -----------------------------------
 
-if(EMSCRIPTEN OR VITA)
+if(EMSCRIPTEN OR VITA OR PSP)
     set(BUILD_SHARED_DEFAULT OFF)
 else()
     set(BUILD_SHARED_DEFAULT ON)

--- a/lite/CMakeLists.txt
+++ b/lite/CMakeLists.txt
@@ -15,7 +15,7 @@ else()
 endif()
 # -----------------------------------
 
-if(EMSCRIPTEN OR VITA)
+if(EMSCRIPTEN OR VITA OR PSP)
     set(BUILD_SHARED_DEFAULT OFF)
 else()
     set(BUILD_SHARED_DEFAULT ON)


### PR DESCRIPTION
The Playstation Portable actually does not support building shared libraries. We currently build with ``BUILD_SHARED=OFF``, but it would be nice if we didn't need to set that.