### PR TITLE
Replace unxz.c with an MIT reimplementation, update XZ Embedded.

### DIFF
--- a/src/depackers/unxz.c
+++ b/src/depackers/unxz.c
@@ -1,76 +1,107 @@
 /* Extended Module Player
  * Copyright (C) 1996-2021 Claudio Matsuoka and Hipolito Carraro Jr
  *
- * This file is part of the Extended Module Player and is distributed
- * under the terms of the GNU Lesser General Public License. See COPYING.LIB
- * for more information.
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
 
 #include "depacker.h"
 #include "xz.h"
 #include "crc32.h"
 
-#define BUFFER_SIZE 4096
+#define XZ_MAX_OUTPUT	(512 << 20)
+#define XZ_MAX_DICT	(16 << 20)
+#define XZ_BUFFER_SIZE	4096
+
+static const uint8 XZ_MAGIC[] = { 0xfd, '7', 'z', 'X', 'Z', 0x00 };
 
 static int test_xz(unsigned char *b)
 {
-	return b[0] == 0xfd && b[3] == 'X' && b[4] == 'Z' && b[5] == 0x00;
+	return !memcmp(b, XZ_MAGIC, sizeof(XZ_MAGIC));
 }
 
 static int decrunch_xz(HIO_HANDLE *in, FILE *out, long inlen)
 {
-	struct xz_buf b;
-	struct xz_dec *state;
-	unsigned char *membuf;
-	int ret = 0;
+	struct xz_dec *xz;
+	struct xz_buf buf;
+	enum xz_ret ret = XZ_OK;
+	uint8 *inbuf = NULL;
+	uint8 *tmp;
 
 	libxmp_crc32_init_A();
 
-	memset(&b, 0, sizeof(b));
-	if ((membuf = (unsigned char *)malloc(2 * BUFFER_SIZE)) == NULL)
+	xz = xz_dec_init(XZ_DYNALLOC, XZ_MAX_DICT);
+	if (xz == NULL)
 		return -1;
 
-	b.in = membuf;
-	b.out = membuf + BUFFER_SIZE;
-	b.out_size = BUFFER_SIZE;
+	if ((buf.out = (uint8 *) malloc(XZ_BUFFER_SIZE)) == NULL)
+		goto err;
+	if ((inbuf = (uint8 *) malloc(XZ_BUFFER_SIZE)) == NULL)
+		goto err;
 
-	/* Limit memory usage to 16M */
-	state = xz_dec_init(XZ_DYNALLOC, 16 * 1024 * 1024);
+	buf.in = inbuf;
+	buf.in_pos = 0;
+	buf.in_size = 0;
+	buf.out_pos = 0;
+	buf.out_size = XZ_BUFFER_SIZE;
 
-	while (1) {
-		enum xz_ret r;
+	while (ret != XZ_STREAM_END) {
+		if (buf.out_pos == buf.out_size) {
+			/* Allocate more output space. */
+			buf.out_size <<= 1;
+			if (buf.out_size > XZ_MAX_OUTPUT)
+				goto err;
 
-		if (b.in_pos == b.in_size) {
-			int rd = hio_read(membuf, 1, BUFFER_SIZE, in);
-			if (rd < 0) {
-				ret = -1;
-				break;
-			}
-			b.in_size = rd;
-			b.in_pos = 0;
+			if ((tmp = (uint8 *) realloc(buf.out, buf.out_size)) == NULL)
+				goto err;
+			buf.out = tmp;
+		}
+		else if (buf.in_pos == buf.in_size) {
+			/* Read input. */
+			buf.in_pos = 0;
+			buf.in_size = hio_read(inbuf, 1, XZ_BUFFER_SIZE, in);
+			if (buf.in_size == 0)
+				goto err;
 		}
 
-		r = xz_dec_run(state, &b);
-
-		if (b.out_pos) {
-			fwrite(b.out, 1, b.out_pos, out);
-			b.out_pos = 0;
-		}
-
-		if (r == XZ_STREAM_END) {
-			break;
-		}
-
-		if (r != XZ_OK && r != XZ_UNSUPPORTED_CHECK) {
-			ret = -1;
-			break;
-		}
+		ret = xz_dec_run(xz, &buf);
+		if (ret != XZ_OK && ret != XZ_STREAM_END && ret != XZ_UNSUPPORTED_CHECK)
+			goto err;
 	}
 
-	xz_dec_end(state);
-	free(membuf);
+	xz_dec_end(xz);
 
-	return ret;
+	/*
+	if ((tmp = (uint8 *) realloc(buf.out, buf.out_pos)) == NULL)
+		goto err;
+	*/
+
+	fwrite(buf.out, 1, buf.out_pos, out);
+
+	free(buf.out);
+	free(inbuf);
+	return 0;
+
+    err:
+	xz_dec_end(xz);
+	free(buf.out);
+	free(inbuf);
+	return -1;
 }
 
 struct depacker libxmp_depacker_xz = {

--- a/src/depackers/xz.h
+++ b/src/depackers/xz.h
@@ -2,7 +2,7 @@
  * XZ decompressor
  *
  * Authors: Lasse Collin <lasse.collin@tukaani.org>
- *          Igor Pavlov <http://7-zip.org/>
+ *          Igor Pavlov <https://7-zip.org/>
  *
  * This file has been put into the public domain.
  * You can do whatever you want with this file.
@@ -29,7 +29,7 @@ extern "C" {
  * enum xz_mode - Operation mode
  *
  * @XZ_SINGLE:              Single-call mode. This uses less RAM than
- *                          than multi-call modes, because the LZMA2
+ *                          multi-call modes, because the LZMA2
  *                          dictionary doesn't need to be allocated as
  *                          part of the decoder state. All required data
  *                          structures are allocated at initialization,
@@ -244,6 +244,18 @@ XZ_EXTERN void xz_dec_end(struct xz_dec *s);
 #		define XZ_INTERNAL_CRC32 1
 #endif
 
+/*
+ * If CRC64 support has been enabled with XZ_USE_CRC64, a CRC64
+ * implementation is needed too.
+ */
+#ifndef XZ_USE_CRC64
+#	undef XZ_INTERNAL_CRC64
+#	define XZ_INTERNAL_CRC64 0
+#endif
+#ifndef XZ_INTERNAL_CRC64
+#		define XZ_INTERNAL_CRC64 1
+#endif
+
 #if XZ_INTERNAL_CRC32
 /*
  * This must be called before any other xz_* function to initialize
@@ -257,6 +269,21 @@ XZ_EXTERN void xz_crc32_init(void);
  * the previously returned value is passed as the third argument.
  */
 XZ_EXTERN uint32 xz_crc32(const uint8 *buf, size_t size, uint32 crc);
+#endif
+
+#if XZ_INTERNAL_CRC64
+/*
+ * This must be called before any other xz_* function (except xz_crc32_init())
+ * to initialize the CRC64 lookup table.
+ */
+XZ_EXTERN void xz_crc64_init(void);
+
+/*
+ * Update CRC64 value using the polynomial from ECMA-182. To start a new
+ * calculation, the third argument must be zero. To continue the calculation,
+ * the previously returned value is passed as the third argument.
+ */
+XZ_EXTERN uint64_t xz_crc64(const uint8_t *buf, size_t size, uint64_t crc);
 #endif
 
 #ifdef __cplusplus

--- a/src/depackers/xz_config.h
+++ b/src/depackers/xz_config.h
@@ -10,6 +10,9 @@
 #ifndef XZ_CONFIG_H
 #define XZ_CONFIG_H
 
+/* Uncomment to enable CRC64 support. */
+/* #define XZ_USE_CRC64 */
+
 /* Uncomment as needed to enable BCJ filter decoders. */
 /* #define XZ_DEC_X86 */
 /* #define XZ_DEC_POWERPC */
@@ -98,7 +101,7 @@ static inline void put_unaligned_be32(uint32 val, uint8 *buf)
 
 /*
  * Use get_unaligned_le32() also for aligned access for simplicity. On
- * little endian systems, #define get_le32(ptr) (*(const uint32 *)(ptr))
+ * little endian systems, #define get_le32(ptr) (*(const uint32_t *)(ptr))
  * could save a few bytes in code size.
  */
 #ifndef get_le32

--- a/src/depackers/xz_dec_lzma2.c
+++ b/src/depackers/xz_dec_lzma2.c
@@ -2,7 +2,7 @@
  * LZMA2 decoder
  *
  * Authors: Lasse Collin <lasse.collin@tukaani.org>
- *          Igor Pavlov <http://7-zip.org/>
+ *          Igor Pavlov <https://7-zip.org/>
  *
  * This file has been put into the public domain.
  * You can do whatever you want with this file.
@@ -389,7 +389,14 @@ static void dict_uncompressed(struct dictionary *dict, struct xz_buf *b,
 
 		*left -= copy_size;
 
-		memcpy(dict->buf + dict->pos, b->in + b->in_pos, copy_size);
+		/*
+		 * If doing in-place decompression in single-call mode and the
+		 * uncompressed size of the file is larger than the caller
+		 * thought (i.e. it is invalid input!), the buffers below may
+		 * overlap and cause undefined behavior with memcpy().
+		 * With valid inputs memcpy() would be fine here.
+		 */
+		memmove(dict->buf + dict->pos, b->in + b->in_pos, copy_size);
 		dict->pos += copy_size;
 
 		if (dict->full < dict->pos)
@@ -399,7 +406,11 @@ static void dict_uncompressed(struct dictionary *dict, struct xz_buf *b,
 			if (dict->pos == dict->end)
 				dict->pos = 0;
 
-			memcpy(b->out + b->out_pos, b->in + b->in_pos,
+			/*
+			 * Like above but for multi-call mode: use memmove()
+			 * to avoid undefined behavior with invalid input.
+			 */
+			memmove(b->out + b->out_pos, b->in + b->in_pos,
 					copy_size);
 		}
 
@@ -423,6 +434,12 @@ static uint32 dict_flush(struct dictionary *dict, struct xz_buf *b)
 		if (dict->pos == dict->end)
 			dict->pos = 0;
 
+		/*
+		 * These buffers cannot overlap even if doing in-place
+		 * decompression because in multi-call mode dict->buf
+		 * has been allocated by us in this file; it's not
+		 * provided by the caller like in single-call mode.
+		 */
 		memcpy(b->out + b->out_pos, dict->buf + dict->start,
 				copy_size);
 	}
@@ -1045,7 +1062,7 @@ XZ_EXTERN enum xz_ret xz_dec_lzma2_run(struct xz_dec_lzma2 *s,
 
 			s->lzma2.sequence = SEQ_LZMA_PREPARE;
 
-			/* fall-through */
+		/* Fall through */
 
 		case SEQ_LZMA_PREPARE:
 			if (s->lzma2.compressed < RC_INIT_BYTES)
@@ -1057,7 +1074,7 @@ XZ_EXTERN enum xz_ret xz_dec_lzma2_run(struct xz_dec_lzma2 *s,
 			s->lzma2.compressed -= RC_INIT_BYTES;
 			s->lzma2.sequence = SEQ_LZMA_RUN;
 
-			/* fall-through */
+		/* Fall through */
 
 		case SEQ_LZMA_RUN:
 			/*
@@ -1148,6 +1165,7 @@ XZ_EXTERN enum xz_ret xz_dec_lzma2_reset(struct xz_dec_lzma2 *s, uint8 props)
 
 		if (DEC_IS_DYNALLOC(s->dict.mode)) {
 			if (s->dict.allocated < s->dict.size) {
+				s->dict.allocated = s->dict.size;
 				vfree(s->dict.buf);
 				s->dict.buf = (uint8 *) vmalloc(s->dict.size);
 				if (s->dict.buf == NULL) {

--- a/src/depackers/xz_lzma2.h
+++ b/src/depackers/xz_lzma2.h
@@ -2,7 +2,7 @@
  * LZMA2 definitions
  *
  * Authors: Lasse Collin <lasse.collin@tukaani.org>
- *          Igor Pavlov <http://7-zip.org/>
+ *          Igor Pavlov <https://7-zip.org/>
  *
  * This file has been put into the public domain.
  * You can do whatever you want with this file.

--- a/src/depackers/xz_stream.h
+++ b/src/depackers/xz_stream.h
@@ -12,7 +12,7 @@
 
 /*
  * See the .xz file format specification at
- * http://tukaani.org/xz/xz-file-format.txt
+ * https://tukaani.org/xz/xz-file-format.txt
  * to understand the container format.
  */
 
@@ -28,7 +28,7 @@
  * Variable-length integer can hold a 63-bit unsigned integer or a special
  * value indicating that the value is unknown.
  *
- * Experimental: vli_type can be defined to uint32 to save a few bytes
+ * Experimental: vli_type can be defined to uint32_t to save a few bytes
  * in code size (no effect on speed). Doing so limits the uncompressed and
  * compressed size of the file to less than 256 MiB and may also weaken
  * error detection slightly.


### PR DESCRIPTION
Since unxz.c was LGPL and didn't support extracting to a buffer, I went ahead and rewrote it to address both issues.

I also updated XZ Embedded to the latest version, but there's not a whole lot different: CRC-64 support we don't really care about, a small handful of minor(?) bugfixes, and some commenting. I reverted some stylistic changes to be closer to their original counterparts (like the CRC function names), but left everything that looked like a portability hack.

Some extra testing should be done on this before it's merged.