### PR TITLE
Add AmigaOS 4 and MorphOS builds to GitHub Actions

### DIFF
--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -268,6 +268,26 @@ jobs:
           cd build
           ctest --output-on-failure
 
+  amiga:
+    strategy:
+       matrix:
+         include: [
+           {host: "ppc-amigaos"},
+           {host: "ppc-morphos", buildflags: "-noixemul"},
+         ]
+    runs-on: ubuntu-latest
+    container: amigadev/crosstools:${{ matrix.host }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Create and run Autotools configure script
+        run: |
+          autoconf
+          CC="${{ matrix.host }}-gcc ${{ matrix.buildflags }}" ./configure --host=${{ matrix.host }}
+      - name: Autotools build
+        run: |
+          make -j 3
+
   AddressSanitizer:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Since libxmp contains Amiga-specific code, it's useful to be able to have Amiga builds in CI. This uses the [amigadev/crosstools](https://hub.docker.com/r/amigadev/crosstools) Docker images.