### PR TITLE
Revert parallel builds for macOS workflow test-dev build.

### DIFF
--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -187,10 +187,11 @@ jobs:
       - name: Autotools check
         run: |
           make check
+      # FIXME: parallel builds crash newer Clang versions?!
       - name: Autotools devcheck
         run: |
           (cd test-dev && autoconf && ./configure)
-          (cd test-dev && make -j 4)
+          (cd test-dev && make)
 
   windows-vc:
     strategy:


### PR DESCRIPTION
This is something I've seen in clang on Fedora, and it should have occurred to me before: parallel builds cause clang (newer versions only?) to occasionally catastrophically fail specifically when building test-dev. Reverting the macOS portion of #525.