### PR TITLE
more miscellaneous small stuff ...

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -166,7 +166,6 @@ static void __inline D_(const char *text, ...) {
 #define dup _dup
 #define fileno _fileno
 #define strnicmp _strnicmp
-#define strdup _strdup
 #define fdopen _fdopen
 #define open _open
 #define close _close
@@ -486,6 +485,7 @@ uint32	readmem32b		(const uint8 *);
 struct xmp_instrument *libxmp_get_instrument(struct context_data *, int);
 struct xmp_sample *libxmp_get_sample(struct context_data *, int);
 
+char *libxmp_strdup(const char *);
 int libxmp_get_filetype (const char *);
 
 #endif /* LIBXMP_COMMON_H */

--- a/src/control.c
+++ b/src/control.c
@@ -563,7 +563,7 @@ int xmp_set_instrument_path(xmp_context opaque, const char *path)
 	if (m->instrument_path != NULL)
 		free(m->instrument_path);
 
-	m->instrument_path = strdup(path);
+	m->instrument_path = libxmp_strdup(path);
 	if (m->instrument_path == NULL) {
 		return -XMP_ERROR_SYSTEM;
 	}

--- a/src/depackers/readlzw.c
+++ b/src/depackers/readlzw.c
@@ -250,7 +250,6 @@ unsigned char *libxmp_convert_lzw_dynamic(unsigned char *data_in,
 	}
 
 	free(data);
-
 	return d;
 
 err2:	free(data);
@@ -367,7 +366,7 @@ static int oldver_getidx(int oldcode,int chr, struct local_data *data)
 }
 
 /* add a string specified by oldstring + chr to string table */
-int addstring(int oldcode,int chr, struct local_data *data)
+static int addstring(int oldcode,int chr, struct local_data *data)
 {
 	int idx;
 

--- a/src/list.h
+++ b/src/list.h
@@ -3,10 +3,6 @@
 
 #include <stddef.h> /* offsetof */
 
-#if defined(_MSC_VER) || defined(__WATCOMC__)
-#define __inline__ __inline
-#endif
-
 /*
  * Simple doubly linked list implementation.
  *
@@ -36,7 +32,7 @@ struct list_head {
  * This is only for internal list manipulation where we know
  * the prev/next entries already!
  */
-static __inline__ void __list_add(struct list_head *_new,
+static inline void __list_add(struct list_head *_new,
 	struct list_head * prev,
 	struct list_head * next)
 {
@@ -54,7 +50,7 @@ static __inline__ void __list_add(struct list_head *_new,
  * Insert a new entry after the specified head.
  * This is good for implementing stacks.
  */
-static __inline__ void list_add(struct list_head *_new, struct list_head *head)
+static inline void list_add(struct list_head *_new, struct list_head *head)
 {
 	__list_add(_new, head, head->next);
 }
@@ -67,7 +63,7 @@ static __inline__ void list_add(struct list_head *_new, struct list_head *head)
  * Insert a new entry before the specified head.
  * This is useful for implementing queues.
  */
-static __inline__ void list_add_tail(struct list_head *_new, struct list_head *head)
+static inline void list_add_tail(struct list_head *_new, struct list_head *head)
 {
 	__list_add(_new, head->prev, head);
 }
@@ -79,7 +75,7 @@ static __inline__ void list_add_tail(struct list_head *_new, struct list_head *h
  * This is only for internal list manipulation where we know
  * the prev/next entries already!
  */
-static __inline__ void __list_del(struct list_head * prev,
+static inline void __list_del(struct list_head * prev,
 				  struct list_head * next)
 {
 	next->prev = prev;
@@ -90,7 +86,7 @@ static __inline__ void __list_del(struct list_head * prev,
  * list_del - deletes entry from list.
  * @entry: the element to delete from the list.
  */
-static __inline__ void list_del(struct list_head *entry)
+static inline void list_del(struct list_head *entry)
 {
 	__list_del(entry->prev, entry->next);
 }
@@ -99,7 +95,7 @@ static __inline__ void list_del(struct list_head *entry)
  * list_empty - tests whether a list is empty
  * @head: the list to test.
  */
-static __inline__ int list_empty(struct list_head *head)
+static inline int list_empty(struct list_head *head)
 {
 	return head->next == head;
 }
@@ -109,7 +105,7 @@ static __inline__ int list_empty(struct list_head *head)
  * @list: the new list to add.
  * @head: the place to add it in the first list.
  */
-static __inline__ void list_splice(struct list_head *list, struct list_head *head)
+static inline void list_splice(struct list_head *list, struct list_head *head)
 {
 	struct list_head *first = list->next;
 

--- a/src/load.c
+++ b/src/load.c
@@ -76,7 +76,7 @@ static char *get_dirname(const char *name)
 			dirname[len] = 0;
 		}
 	} else {
-		dirname = strdup("");
+		dirname = libxmp_strdup("");
 	}
 
 	return dirname;
@@ -88,9 +88,9 @@ static char *get_basename(const char *name)
 	char *basename;
 
 	if ((p = strrchr(name, '/')) != NULL) {
-		basename = strdup(p + 1);
+		basename = libxmp_strdup(p + 1);
 	} else {
-		basename = strdup(name);
+		basename = libxmp_strdup(name);
 	}
 
 	return basename;

--- a/src/loaders/common.c
+++ b/src/loaders/common.c
@@ -530,3 +530,13 @@ void libxmp_schism_tracker_string(char *buf, size_t size, int s_ver, int l_ver)
 	}
 }
 #endif
+
+char *libxmp_strdup(const char *src)
+{
+	size_t len = strlen(src) + 1;
+	char *buf = (char *) malloc(len);
+	if (buf) {
+		memcpy(buf, src, len);
+	}
+	return buf;
+}

--- a/src/loaders/iff.h
+++ b/src/loaders/iff.h
@@ -1,8 +1,8 @@
 #ifndef LIBXMP_IFF_H
 #define LIBXMP_IFF_H
 
-#include "../list.h"
 #include "../hio.h"
+#include "../list.h"
 
 #define IFF_NOBUFFER 0x0001
 

--- a/src/loaders/med2_load.c
+++ b/src/loaders/med2_load.c
@@ -44,13 +44,12 @@ static int med2_test(HIO_HANDLE *f, char *t, const int start)
 	if (hio_read32b(f) !=  MAGIC_MED2)
 		return -1;
 
-        libxmp_read_title(f, t, 0);
+	libxmp_read_title(f, t, 0);
 
-        return 0;
+	return 0;
 }
 
-
-int med2_load(struct module_data *m, HIO_HANDLE *f, const int start)
+static int med2_load(struct module_data *m, HIO_HANDLE *f, const int start)
 {
 	struct xmp_module *mod = &m->mod;
 	int i, j, k;

--- a/src/loaders/prowizard/prowiz.h
+++ b/src/loaders/prowizard/prowiz.h
@@ -1,10 +1,10 @@
 #ifndef PROWIZ_H
 #define PROWIZ_H
 
-/*#include "../../list.h"*/
 #include "../../common.h"
 #include "../../format.h"
 #include "../../hio.h"
+/*#include "../../list.h"*/
 
 #define MIN_FILE_LENGHT 2048
 

--- a/src/loaders/vorbis.c
+++ b/src/loaders/vorbis.c
@@ -628,7 +628,7 @@ enum STBVorbisError
     #elif (defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 2))) || defined(__clang__)
         #define STB_FORCEINLINE static __inline __attribute__((always_inline))
     #else
-        #define STB_FORCEINLINE static __inline
+        #define STB_FORCEINLINE static inline
     #endif
 #endif
 

--- a/src/tempfile.c
+++ b/src/tempfile.c
@@ -126,7 +126,7 @@ FILE *make_temp_file(char **filename) {
 
 	strncat(tmp, "xmp_XXXXXX", XMP_MAXPATH - 10);
 
-	if ((*filename = strdup(tmp)) == NULL)
+	if ((*filename = libxmp_strdup(tmp)) == NULL)
 		goto err;
 
 #ifdef HAVE_UMASK


### PR DESCRIPTION
- list.h, vorbis.h: use inline instead of `__inline__`
  common.h already has fixes for it where necessary.
- add a libxmp_strdup() helper procedure.
- med2_load.c: fix static declaration followed by non-static definition.
- readlzw.c: fix static declaration followed by non-static definition.

