### PR TITLE
Fix mixer crash from not checking sptr before wraparound init.

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -299,7 +299,7 @@ static void init_sample_wraparound(struct mixer_data *s, struct loop_data *ld,
 	int bidir;
 	int i;
 
-	if (s->interp == XMP_INTERP_NEAREST || (~xxs->flg & XMP_SAMPLE_LOOP)) {
+	if (!vi->sptr || s->interp == XMP_INTERP_NEAREST || (~xxs->flg & XMP_SAMPLE_LOOP)) {
 		ld->active = 0;
 		return;
 	}


### PR DESCRIPTION
There is a `NULL` check for `vi->sptr` before mixing sample data but I forgot to add one before initializing the sample wraparound data. (Found thanks to Win32 text mode `stdout` mangling the module from test-dev/data/arcfsdata.)