### PR TITLE
Remove AdLib/OPL formats from formats.txt

### DIFF
--- a/docs/formats.txt
+++ b/docs/formats.txt
@@ -104,13 +104,6 @@ PSM		Protracker Studio	0.01, 1.00
 STIM		Slamtilt		-
 UMX		Epic Games Unreal/UT	IT, S3M, MOD, XM
 
-YM3812 (Adlib) formats:
-
-AMD		Amusic Adlib Tracker	-
-RAD		Reality Adlib Tracker	-
-HSC		NEO soft/HSC-Tracker	1.5
-S3M		Scream Tracker 3	3.00, 3.01+
-
 
 Formats marked with (*) are experimental and are known to have
 replay errors and unimplemented effects.


### PR DESCRIPTION
As mentioned in a few issues (e.g. https://github.com/libxmp/libxmp/issues/460#issuecomment-898948675), fmopl.c is dead code and the AdLib formats are not currently supported.