### PR TITLE
Replace external unrar support with libunarr-based depacker.

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt install gcovr lcov unrar
+        run: sudo apt install gcovr lcov libunarr-dev
       - name: Create and run configure script
         run: |
           autoconf; ./configure

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -294,7 +294,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt install unrar
+        run: sudo apt install libunarr-dev
       - name: Create and run configure script
         run: |
           export CC=clang
@@ -314,8 +314,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Install dependencies
-        run: sudo apt install unrar
       - name: Create and run configure script
         run: |
           export CC=clang
@@ -336,7 +334,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt install unrar
+        run: sudo apt install libunarr-dev
       - name: Create and run configure script
         run: |
           export CC=clang

--- a/Makefile.vc
+++ b/Makefile.vc
@@ -179,6 +179,7 @@ DEPACKER_OBJS	= \
  src\depackers\unxz.obj \
  src\depackers\xz_dec_lzma2.obj \
  src\depackers\xz_dec_stream.obj \
+ src\depackers\unrar.obj \
  src\depackers\crc32.obj \
  src\depackers\xfnmatch.obj \
  src\depackers\ptpopen.obj \

--- a/cmake/libxmp-sources.cmake
+++ b/cmake/libxmp-sources.cmake
@@ -154,6 +154,7 @@ set(LIBXMP_SRC_LIST_DEPACKERS
     src/depackers/unxz.c
     src/depackers/xz_dec_lzma2.c
     src/depackers/xz_dec_stream.c
+    src/depackers/unrar.c
     src/depackers/crc32.c
     src/depackers/xfnmatch.c
     src/depackers/ptpopen.c

--- a/configure.ac
+++ b/configure.ac
@@ -267,6 +267,9 @@ dnl for depackers/xfd.c
   ;;
 esac
 
+dnl FIXME warn about static linking and LGPL 3+ if found.
+AC_CHECK_LIB(unarr, ar_open_rar_archive)
+
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([libxmp.pc])
 AC_OUTPUT

--- a/src/depackers/Makefile
+++ b/src/depackers/Makefile
@@ -4,7 +4,7 @@ DEPACKERS_OBJS	= depacker.o ppdepack.o unsqsh.o mmcmp.o s404_dec.o \
 		  muse.o miniz_tinfl.o miniz_zip.o \
 		  unzip.o gunzip.o uncompress.o bunzip2.o unlha.o \
 		  unlzx.o unxz.o xz_dec_lzma2.o xz_dec_stream.o \
-		  crc32.o xfnmatch.o ptpopen.o xfd.o xfd_link.o
+		  unrar.o crc32.o xfnmatch.o ptpopen.o xfd.o xfd_link.o
 
 DEPACKERS_DFILES = Makefile $(DEPACKERS_OBJS:.o=.c) depacker.h \
 		  miniz.h miniz_zip.h arc_crc16.h arc_types.h arc_unpack.h \

--- a/src/depackers/depacker.c
+++ b/src/depackers/depacker.c
@@ -71,6 +71,7 @@ static struct depacker *depacker_list[] = {
 	&libxmp_depacker_muse,
 	&libxmp_depacker_lzx,
 	&libxmp_depacker_s404,
+	&libxmp_depacker_rar,
 	NULL
 };
 
@@ -342,21 +343,6 @@ int libxmp_decrunch(HIO_HANDLE **h, const char *filename, char **temp)
 			cmd[i++] = "-s";
 			cmd[i++] = filename;
 			cmd[i++] = "STDOUT";
-			cmd[i++] = NULL;
-		} else if (memcmp(b, "Rar", 3) == 0) {
-			/* rar */
-			D_(D_INFO "rar");
-			i = 0;
-			cmd[i++] = "unrar";
-			cmd[i++] = "p";
-			cmd[i++] = "-inul";
-			cmd[i++] = "-xreadme";
-			cmd[i++] = "-x*.diz";
-			cmd[i++] = "-x*.nfo";
-			cmd[i++] = "-x*.txt";
-			cmd[i++] = "-x*.exe";
-			cmd[i++] = "-x*.com";
-			cmd[i++] = filename;
 			cmd[i++] = NULL;
 		}
 	}

--- a/src/depackers/depacker.h
+++ b/src/depackers/depacker.h
@@ -18,6 +18,7 @@ extern struct depacker libxmp_depacker_mmcmp;
 extern struct depacker libxmp_depacker_muse;
 extern struct depacker libxmp_depacker_lzx;
 extern struct depacker libxmp_depacker_s404;
+extern struct depacker libxmp_depacker_rar;
 extern struct depacker libxmp_depacker_xfd;
 
 struct depacker {

--- a/src/depackers/unrar.c
+++ b/src/depackers/unrar.c
@@ -1,0 +1,112 @@
+/* Extended Module Player
+ * Copyright (C) 1996-2022 Claudio Matsuoka and Hipolito Carraro Jr
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "depacker.h"
+
+#define RAR_MAX_OUTPUT_SIZE (1 << 29)
+
+#ifdef HAVE_LIBUNARR
+#include <unarr.h>
+#endif
+
+static int test_rar(unsigned char *data)
+{
+	/* The bytes afterward may vary depending on the RAR version. */
+	return !memcmp(data, "Rar!\x1a\x07", 6);
+}
+
+static int decrunch_rar(HIO_HANDLE *in, void **out, long inlen, long *outlen)
+{
+	int ret = -1;
+#ifdef HAVE_LIBUNARR
+	void *in_buf = NULL;
+	ar_stream *stream = NULL;
+	ar_archive *rar = NULL;
+
+	const char *filename;
+	void *out_buf;
+
+	if (in->type != HIO_HANDLE_TYPE_MEMORY) {
+		/* No FILE * or callbacks-based API functions yet. */
+		if ((in_buf = malloc(inlen)) == NULL)
+			return -1;
+
+		if (hio_read(in_buf, 1, inlen, in) < inlen)
+			goto err;
+	} else {
+		in_buf = in->handle.mem;
+	}
+
+	if ((stream = ar_open_memory(in_buf, inlen)) == NULL)
+		goto err;
+
+	if ((rar = ar_open_rar_archive(stream)) == NULL) {
+		D_(D_CRIT "failed to open RAR archive");
+		goto err;
+	}
+
+	while (ar_parse_entry(rar)) {
+		long size = ar_entry_get_size(rar);
+
+		if (size <= 0 || size > RAR_MAX_OUTPUT_SIZE) {
+			D_(D_INFO "Skipping unsupported size %ld", size);
+			continue;
+		}
+
+		filename = ar_entry_get_name(rar);
+		if (libxmp_exclude_match(filename)) {
+			D_(D_INFO "Skipping file %s", filename);
+			continue;
+		}
+
+		if ((out_buf = malloc(size)) == NULL)
+			goto err;
+
+		if (!ar_entry_uncompress(rar, out_buf, size)) {
+			D_(D_CRIT "uncompress error");
+			free(out_buf);
+			goto err;
+		}
+
+		*out = out_buf;
+		*outlen = size;
+		ret = 0;
+		break;
+	}
+
+    err:
+	if (rar)
+		ar_close_archive(rar);
+	if (stream)
+		ar_close(stream);
+
+	if (in->type != HIO_HANDLE_TYPE_MEMORY)
+		free(in_buf);
+#endif
+	return ret;
+}
+
+struct depacker libxmp_depacker_rar = {
+	test_rar,
+	NULL,
+	decrunch_rar
+};

--- a/test-dev/configure.ac
+++ b/test-dev/configure.ac
@@ -43,6 +43,7 @@ XMP_TRY_COMPILE(whether compiler understands -Wwrite-strings,
   CFLAGS="${CFLAGS} -Wwrite-strings")
 
 AC_CHECK_LIB(m,pow)
+AC_CHECK_LIB(unarr,ar_open_rar_archive)
 AC_CHECK_FUNCS(pipe popen mkstemp fnmatch)
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/test-dev/test_depack_rar.c
+++ b/test-dev/test_depack_rar.c
@@ -3,30 +3,26 @@
 
 TEST(test_depack_rar)
 {
+#ifdef HAVE_LIBUNARR
 	xmp_context c;
 	struct xmp_module_info info;
+	FILE *f;
 	int ret;
 
 	c = xmp_create_context();
 	fail_unless(c != NULL, "can't create context");
 	ret = xmp_load_module(c, "data/ponylips.rar");
+	fail_unless(ret == 0, "can't load module");
 
-	/* This uses an external depacker currently, so if
-	 * depacking fails, it's most likely because unrar isn't
-	 * available. If this happens, just let the test pass. */
-	if (ret != -XMP_ERROR_DEPACK && ret != -XMP_ERROR_FORMAT) {
-		FILE *f;
+	xmp_get_module_info(c, &info);
 
-		fail_unless(ret == 0, "can't load module");
+	f = fopen("data/format_mod_notawow.data", "r");
 
-		xmp_get_module_info(c, &info);
+	ret = compare_module(info.mod, f);
+	fail_unless(ret == 0, "RARed module not correctly loaded");
 
-		f = fopen("data/format_mod_notawow.data", "r");
-
-		ret = compare_module(info.mod, f);
-		fail_unless(ret == 0, "RARed module not correctly loaded");
-	}
 	xmp_release_module(c);
 	xmp_free_context(c);
+#endif
 }
 END_TEST

--- a/watcom.mif
+++ b/watcom.mif
@@ -184,6 +184,7 @@ DEPACKER_OBJS= &
  src/depackers/unxz.obj &
  src/depackers/xz_dec_lzma2.obj &
  src/depackers/xz_dec_stream.obj &
+ src/depackers/unrar.obj &
  src/depackers/crc32.obj &
  src/depackers/xfnmatch.obj &
  src/depackers/ptpopen.obj &


### PR DESCRIPTION
This isn't great, but it seemed like the path of least resistance re: getting rid of this external depacker. libunarr is LGPL 3+, is available for pretty much every Linux distribution I've checked (edit: not Alpine), and seems to work fine with the RAR 4 test file that was already packed with the regression tests.

The external depacker system as a whole still can't be removed due to MO3, which will be much more annoying to replace.

edit: this can wait until after 4.5.1 if that would be preferable, I'm just waiting on ARC/ArcFS fuzzing and this was quick to put together.

TODO:

- [ ] `./configure` flag to turn this off?
- [ ] `./configure` should *probably* output a warning that this dependency is LGPL 3+ and statically linking it will LGPL 3+ the entire libxmp build.
- [ ] This should *probably* be declared in docs/CREDITS too.
- [ ] someone else figure out CMake