### PR TITLE
miscellaneous clean-ups

### DIFF
--- a/lite/watcom.mif.in
+++ b/lite/watcom.mif.in
@@ -65,6 +65,7 @@ clean: .symbolic
 	rm -f $(TEST_OBJS)
 
 distclean: clean .symbolic
+	rm -f *.err
 	rm -f $(DLLNAME) $(EXPNAME) $(MAPNAME) $(LIBNAME) $(LIBSTATIC) test/$(DLLNAME) test/$(TESTNAME)
 
 !ifdef __UNIX__

--- a/src/depackers/miniz_zip.c
+++ b/src/depackers/miniz_zip.c
@@ -35,12 +35,10 @@ extern "C" {
 
 #ifndef MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS
 #define MZ_CRC32_INIT (0)
-/* libxmp hack */
 static mz_ulong mz_crc32(mz_ulong crc, const mz_uint8 *ptr, size_t buf_len)
-{
+{/* libxmp hack: */
     return libxmp_crc32_A(ptr, buf_len, crc);
 }
-/* end libxmp hack */
 #endif /* MINIZ_DISABLE_ZIP_READER_CRC32_CHECKS */
 
 static void *miniz_def_alloc_func(void *opaque, size_t items, size_t size)

--- a/src/depackers/xz.h
+++ b/src/depackers/xz.h
@@ -22,7 +22,7 @@ extern "C" {
 
 /* In Linux, this is used to make extern functions static when needed. */
 #ifndef XZ_EXTERN
-#	define XZ_EXTERN extern
+#	define XZ_EXTERN /*extern*/
 #endif
 
 /**

--- a/src/loaders/digi_load.c
+++ b/src/loaders/digi_load.c
@@ -73,7 +73,7 @@ struct digi_header {
     uint8 ver;			/* Version hi-nibble.lo-nibble */
     uint8 chn;			/* Number of channels */
     uint8 pack;			/* PackEnable */
-    uint8 unknown[19];		/* ??!? */
+    uint8 unknown[19];		/* ?! */
     uint8 pat;			/* Number of patterns */
     uint8 len;			/* Song length */
     uint8 ord[128];		/* Orders */

--- a/src/loaders/imf_load.c
+++ b/src/loaders/imf_load.c
@@ -338,7 +338,7 @@ static int imf_load(struct module_data *m, HIO_HANDLE *f, const int start)
 
 	pat_len = hio_read16l(f) - 4;
 
-        rows = hio_read16l(f);
+	rows = hio_read16l(f);
 
 	/* Sanity check */
 	if (rows > 256) {
@@ -370,7 +370,7 @@ static int imf_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		n = hio_read8(f);
 		switch (n) {
 		case 255:
-		case 160:	/* ??!? */
+		case 160:	/* ?! */
 		    n = XMP_KEY_OFF;
 		    break;	/* Key off */
 		default:
@@ -437,7 +437,7 @@ static int imf_load(struct module_data *m, HIO_HANDLE *f, const int start)
 
 	xxi->nsm = ii.nsm;
 
-        if (xxi->nsm > 0) {
+	if (xxi->nsm > 0) {
 	    if (libxmp_alloc_subinstrument(mod, i, xxi->nsm) < 0)
 		return -1;
 	}
@@ -471,8 +471,8 @@ static int imf_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	}
 
 	for (j = 0; j < ii.nsm; j++, smp_num++) {
-            struct xmp_subinstrument *sub = &xxi->sub[j];
-            struct xmp_sample *xxs = &mod->xxs[smp_num];
+	    struct xmp_subinstrument *sub = &xxi->sub[j];
+	    struct xmp_sample *xxs = &mod->xxs[smp_num];
 	    int sid;
 
 	    hio_read(is.name, 13, 1, f);
@@ -490,8 +490,8 @@ static int imf_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	    is.dram = hio_read32l(f);
 	    is.magic = hio_read32b(f);
 
-            /* Sanity check */
-            if (is.len > 0x100000 || is.lps > 0x100000 || is.lpe > 0x100000)
+	    /* Sanity check */
+	    if (is.len > 0x100000 || is.lps > 0x100000 || is.lpe > 0x100000)
 		return -1;
 
 	    sub->sid = smp_num;

--- a/src/loaders/mod_load.c
+++ b/src/loaders/mod_load.c
@@ -391,7 +391,7 @@ static int get_tracker_id(struct module_data *m, struct mod_header *mh, int id)
 			return TRACKER_FASTTRACKER;
 		}
 
-		id = TRACKER_UNKNOWN;	/* ??!? */
+		id = TRACKER_UNKNOWN;	/* ?! */
 	}
 
 	return id;

--- a/src/loaders/stx_load.c
+++ b/src/loaders/stx_load.c
@@ -42,7 +42,7 @@ struct stx_file_header {
 	uint8 name[20];		/* Song name */
 	uint8 magic[8];		/* !Scream! */
 	uint16 psize;		/* Pattern 0 size? */
-	uint16 unknown1;	/* ??!? */
+	uint16 unknown1;	/* ?! */
 	uint16 pp_pat;		/* Pointer to pattern table */
 	uint16 pp_ins;		/* Pattern to instrument table */
 	uint16 pp_chn;		/* Pointer to channel table (?) */
@@ -201,8 +201,7 @@ static int stx_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	if (bmod2stm)
 		libxmp_set_type(m, "BMOD2STM STX");
 	else
-		snprintf(mod->type, XMP_NAME_SIZE, "STM2STX 1.%d",
-			 broken ? 0 : 1);
+		snprintf(mod->type, XMP_NAME_SIZE, "STM2STX 1.%d", broken ? 0 : 1);
 
 	MODULE_INFO();
 
@@ -286,7 +285,7 @@ static int stx_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		   mod->xxi[i].sub[0].vol, sih.c2spd);
 
 		libxmp_c2spd_to_note(sih.c2spd, &mod->xxi[i].sub[0].xpo,
-			      &mod->xxi[i].sub[0].fin);
+				      &mod->xxi[i].sub[0].fin);
 	}
 
 	if (libxmp_init_pattern(mod) < 0)

--- a/src/loaders/vorbis.c
+++ b/src/loaders/vorbis.c
@@ -645,7 +645,7 @@ enum STBVorbisError
 #include <crtdbg.h>
 #define CHECK(f)   _CrtIsValidHeapPointer(f->channel_buffers[1])
 #else
-#define CHECK(f)   ((void) 0)
+#define CHECK(f)   do {} while(0)
 #endif
 
 #define MAX_BLOCKSIZE_LOG  13   // from specification
@@ -963,7 +963,7 @@ static int error(vorb *f, enum STBVorbisError e)
 #define array_size_required(count,size)  (count*(sizeof(void *)+(size)))
 
 #define temp_alloc(f,size)              (f->alloc.alloc_buffer ? setup_temp_malloc(f,size) : alloca(size))
-#define temp_free(f,p)                  (void)0
+#define temp_free(f,p)                  do {} while (0)
 #define temp_alloc_save(f)              ((f)->temp_offset)
 #define temp_alloc_restore(f,p)         ((f)->temp_offset = (p))
 

--- a/src/loaders/vorbis.c
+++ b/src/loaders/vorbis.c
@@ -601,8 +601,8 @@ enum STBVorbisError
 #else // STB_VORBIS_NO_CRT
    #define NULL 0
    #define malloc(s)   0
-   #define free(s)     ((void) 0)
-   #define realloc(s)  0
+   #define free(p)     ((void) 0)
+   #define realloc(p, s)  0
 #endif // STB_VORBIS_NO_CRT
 
 /* we need alloca() regardless of STB_VORBIS_NO_CRT,

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -941,7 +941,7 @@ int libxmp_mixer_on(struct context_data *ctx, int rate, int format, int c4rate)
 	s->format = format;
 	s->amplify = DEFAULT_AMPLIFY;
 	s->mix = DEFAULT_MIX;
-	/* s->pbase = C4_PERIOD * c4rate / s->freq; */(void) c4rate;
+	/* s->pbase = C4_PERIOD * c4rate / s->freq; */
 	s->interp = XMP_INTERP_LINEAR;	/* default interpolation type */
 	s->dsp = XMP_DSP_LOWPASS;	/* enable filters by default */
 	/* s->numvoc = SMIX_NUMVOC; */

--- a/watcom.mif
+++ b/watcom.mif
@@ -238,6 +238,7 @@ clean: .symbolic
 	rm -f $(TEST_OBJS)
 
 distclean: clean .symbolic
+	rm -f *.err
 	rm -f $(DLLNAME) $(EXPNAME) $(MAPNAME) $(LIBNAME) $(LIBSTATIC) test/$(DLLNAME) test/$(TESTNAME)
 
 !ifdef __UNIX__

--- a/watcom.mif.in
+++ b/watcom.mif.in
@@ -82,6 +82,7 @@ clean: .symbolic
 	rm -f $(TEST_OBJS)
 
 distclean: clean .symbolic
+	rm -f *.err
 	rm -f $(DLLNAME) $(EXPNAME) $(MAPNAME) $(LIBNAME) $(LIBSTATIC) test/$(DLLNAME) test/$(TESTNAME)
 
 !ifdef __UNIX__


### PR DESCRIPTION
This stupid PR is a result after my stupid attempts at building libxmp
with vbcc, which is capable of emiting really annoying warnings. After
this patchset it still emits only a few warnings (from imported sources
i.e. miniz_zip and vorbis), and the build actually fails because I can
not find a way around the missing `alloca` support in vorbis.c (I first
attempted using C99 VLAs but failed doing so - I possibly haven't tried
hard enough.)

Anyways, here it is.
