### PR TITLE
stb_vorbis: optionally use C99 VLAs instead of alloca(),

### DIFF
--- a/src/loaders/vorbis.h
+++ b/src/loaders/vorbis.h
@@ -2,6 +2,7 @@
 #define NDEBUG /* disable assert()s */
 #endif
 
+/*#define STB_VORBIS_VAR_ARRAYS*/
 #define STB_VORBIS_NO_PUSHDATA_API
 #define STB_VORBIS_NO_STDIO
 #define STB_VORBIS_NO_COMMENTS


### PR DESCRIPTION
bound to new STB_VORBIS_VAR_ARRAYS macro. Until a better solution is available.

Original discussion was at https://github.com/libxmp/libxmp/pull/549#issuecomment-1014333302
