### PR TITLE
Replace alloca() usage in stb_vorbis with setup_malloc().

### DIFF
--- a/cmake/libxmp-checks.cmake
+++ b/cmake/libxmp-checks.cmake
@@ -135,7 +135,6 @@ endif()
 xmp_check_function(powf "math.h" HAVE_POWF)
 cmake_pop_check_state()
 
-xmp_check_include(alloca.h HAVE_ALLOCA_H)
 xmp_check_function(popen "stdio.h" HAVE_POPEN)
 xmp_check_function(fnmatch "fnmatch.h" HAVE_FNMATCH)
 xmp_check_function(umask "sys/stat.h" HAVE_UMASK)
@@ -165,7 +164,6 @@ endif()
 
 # Symbol visibility attributes check
 if(NOT (WIN32 OR CYGWIN OR AMIGA OR OS2))
-
     cmake_push_check_state()
     set(CMAKE_REQUIRED_FLAGS "-fvisibility=hidden -Werror")
 

--- a/configure.ac
+++ b/configure.ac
@@ -221,12 +221,6 @@ else
 fi
 AC_SUBST(PROWIZARD_OBJS)
 
-XMP_TRY_COMPILE(whether alloca() needs alloca.h,
-  ac_cv_c_flag_w_have_alloca_h,,[
-  #include <alloca.h>
-  int main(void){return 0;}],
-  AC_DEFINE(HAVE_ALLOCA_H, 1, [ ]))
-
 LIBM=
 case "${host_os}" in
 dnl These systems don't have libm or don't need it (list based on libtool)
@@ -262,7 +256,6 @@ esac
 
 case "${host_os}" in
 amigaos*|aros*|morphos*)
-dnl for depackers/xfd.c
   AC_CHECK_HEADERS(proto/xfdmaster.h)
   ;;
 esac


### PR DESCRIPTION
Alternative patch to #551: instead of using `alloca` or a VLA, this patch instead uses a temporary memory bound that stb_vorbis *already calculated* to `setup_malloc` a correctly-sized work buffer for `inverse_mdct` and `decode_residue`.

I'm going to fuzz it a little bit just to be sure the bound isn't missing anything.