### PR TITLE
Make cmake build the documentation:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,10 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/examples/CMakeLists.txt")
 endif()
 
 
+# === Documentation ====
+add_subdirectory(docs)
+
+
 # === Install ====
 include(GNUInstallDirs)
 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,0 +1,55 @@
+option(LIBXMP_DOCS "Build the library documentation" ON)
+
+set(libxmp_man_rst ${CMAKE_CURRENT_SOURCE_DIR}/manpage.rst)
+set(libxmp_html_rst ${CMAKE_CURRENT_SOURCE_DIR}/pdfdoc.rst)
+set(libxmp_man ${CMAKE_CURRENT_BINARY_DIR}/libxmp.3)
+set(libxmp_html ${CMAKE_CURRENT_BINARY_DIR}/libxmp.html)
+set(libxmp_pdf ${CMAKE_CURRENT_BINARY_DIR}/libxmp.pdf)
+
+if(LIBXMP_DOCS)
+  find_program(RST2MAN_EXE rst2man)
+  find_program(RST2HTML_EXE rst2html)
+  find_program(RST2PDF_EXE rst2pdf)
+
+  if(NOT RST2MAN_EXE)
+    message(STATUS "Manpage generation disabled: rst2man not found")
+  else()
+    message(STATUS "Found ${RST2MAN_EXE}")
+    add_custom_command(OUTPUT ${libxmp_man}
+      COMMAND ${RST2MAN_EXE} ${libxmp_man_rst} ${libxmp_man}
+      DEPENDS ${libxmp_rst}
+      COMMENT "Creating Info file ${libxmp_man}"
+      VERBATIM)
+    add_custom_target(libxmp_gen_man ALL DEPENDS ${libxmp_man})
+    if(UNIX OR MINGW OR CYGWIN)
+      include(GNUInstallDirs)
+      install(FILES "${libxmp_man}"
+              DESTINATION ${CMAKE_INSTALL_MANDIR}/man3
+      )
+    endif()
+  endif()
+
+  if(NOT RST2HTML_EXE)
+    message(STATUS "HTML doc generation disabled: rst2html not found")
+  else()
+    message(STATUS "Found ${RST2HTML_EXE}")
+    add_custom_command(OUTPUT ${libxmp_html}
+      COMMAND ${RST2HTML_EXE} --stylesheet ${CMAKE_CURRENT_SOURCE_DIR}/style.css ${libxmp_html_rst} ${libxmp_html}
+      DEPENDS ${libxmp_html_rst}
+      COMMENT "Creating HTML file ${libxmp_html}"
+      VERBATIM)
+    add_custom_target(libxmp_gen_html ALL DEPENDS ${libxmp_html})
+  endif()
+
+  if(NOT RST2PDF_EXE)
+    message(STATUS "PDF doc generation disabled: rst2pdf not found")
+  else()
+    message(STATUS "Found ${RST2PDF_EXE}")
+    add_custom_command(OUTPUT ${libxmp_pdf}
+      COMMAND ${RST2PDF_EXE} -c --smart-quotes=1 -s ${CMAKE_CURRENT_SOURCE_DIR}/custom.style --footer=\#\#\#Page\#\#\# ${libxmp_html_rst} -o ${libxmp_pdf}
+      DEPENDS ${libxmp_html_rst}
+      COMMENT "Creating HTML file ${libxmp_pdf}"
+      VERBATIM)
+    add_custom_target(libxmp_gen_pdf ALL DEPENDS ${libxmp_pdf})
+  endif()
+endif()

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,9 @@
 
-DOCS_DFILES	= Makefile COPYING.LIB CREDITS Changelog formats.txt \
-		  fixloop.txt libxmp.rst custom.style $(DOCS_FILES)
+DOCS_DFILES	= Makefile CMakeLists.txt           \
+		  COPYING.LIB CREDITS Changelog     \
+		  formats.txt fixloop.txt           \
+		  libxmp.rst manpage.rst pdfdoc.rst \
+		  custom.style style.css $(DOCS_FILES)
 
 DOCS_PATH	= docs
 
@@ -21,16 +24,12 @@ dist-docs:
 	mkdir -p $(DIST)/$(DOCS_PATH)
 	cp -RPp $(addprefix $(DOCS_PATH)/,$(DOCS_DFILES)) $(DIST)/$(DOCS_PATH)
 
-docs/libxmp.3: docs/libxmp.man.rst
-	rst2man docs/libxmp.man.rst > $@
+docs/libxmp.3: docs/libxmp.rst docs/manpage.rst
+	rst2man docs/manpage.rst > $@
 
-docs/libxmp.man.rst: docs/libxmp.rst docs/manpage-header.rst docs/Makefile
-	cp docs/manpage-header.rst $@
-	sed -n '/^Introduction/,$$p' docs/libxmp.rst >> $@
+docs/libxmp.html: docs/libxmp.rst docs/pdfdoc.rst docs/style.css
+	rst2html docs/pdfdoc.rst --stylesheet docs/style.css > $@
 
-docs/libxmp.html: docs/libxmp.rst
-	rst2html docs/libxmp.rst --stylesheet docs/style.css > $@
-
-docs/libxmp.pdf: docs/libxmp.rst docs/custom.style
-	rst2pdf docs/libxmp.rst -c --smart-quotes=1 -s docs/custom.style --footer="###Page###" -o $@
+docs/libxmp.pdf: docs/libxmp.rst docs/pdfdoc.rst docs/custom.style
+	rst2pdf docs/pdfdoc.rst -c --smart-quotes=1 -s docs/custom.style --footer="###Page###" -o $@
 

--- a/docs/libxmp.rst
+++ b/docs/libxmp.rst
@@ -1,14 +1,3 @@
-
-Libxmp 4.5 API documentation
-============================
-
-.. contents:: `Contents`
-   :depth: 3
-
-.. raw:: pdf
-
-    PageBreak
-
 Introduction
 ------------
 

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -11,3 +11,4 @@ A tracker module player library
 :Manual section: 3
 :Manual group: Extended Module Player
 
+.. include:: libxmp.rst

--- a/docs/pdfdoc.rst
+++ b/docs/pdfdoc.rst
@@ -1,0 +1,11 @@
+Libxmp 4.5 API documentation
+============================
+
+.. contents:: `Contents`
+   :depth: 3
+
+.. raw:: pdf
+
+    PageBreak
+
+.. include:: libxmp.rst


### PR DESCRIPTION
Also update docs distfiles so that style.css goes into the tarball.
Changed the existing docs build, where we maintain two headers i.e.
manpage.rst and pdfdoc.rst which include libxmp.rst, so the tricky
sed machinery is no longer needed.

Closes: https://github.com/libxmp/libxmp/issues/477

Please test and review. CC: @Wohlstand
