### PR TITLE
Include arch/types.h for KallistiOS.

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -75,6 +75,8 @@
 #  include <SupportDefs.h>
 #elif defined __amigaos4__
 #  include <exec/types.h>
+#elif defined _arch_dreamcast /* KallistiOS */
+#  include <arch/types.h>
 #else
 typedef signed char int8;
 typedef signed short int int16;


### PR DESCRIPTION
KallistiOS is a (the?) Sega Dreamcast toolchain originally made by Dan Potter of Farandole Composer fame : ). It provides a header including all of the fixed width types libxmp defines in common.h, so common.h needs to include that instead of redefining them.

I didn't bother putting it in the list for `uint64`/`int64` even though it defines them—the definitions are identical. I can add that for futureproofing if preferable.

Note just using `sh-elf-gcc` won't work. `_arch_dreamcast` is added to the list of compiler flags by the wrappers `kos-cc` and `kos-c++`. There are no other identifying preprocessor defines as far as I can tell. This configuration seems to work just fine:
```shell
CC=kos-cc ./configure --host=sh-elf --prefix=/home/a/libxmp/kos-testing --disable-shared --enable-static
```