### PR TITLE
Increase BPM maximum to 1000 to fix edge case XMs/DTMs/PTMs.

### DIFF
--- a/src/load_helpers.c
+++ b/src/load_helpers.c
@@ -240,7 +240,7 @@ void libxmp_load_epilogue(struct context_data *ctx)
 	if (mod->spd <= 0 || mod->spd > 255) {
 		mod->spd = 6;
 	}
-	CLAMP(mod->bpm, XMP_MIN_BPM, 255);
+	CLAMP(mod->bpm, XMP_MIN_BPM, 1000);
 
 	/* Set appropriate values for instrument volumes and subinstrument
 	 * global volumes when QUIRK_INSVOL is not set, to keep volume values

--- a/src/loaders/dt_load.c
+++ b/src/loaders/dt_load.c
@@ -73,7 +73,7 @@ static int get_d_t_(struct module_data *m, int size, HIO_HANDLE *f, void *parm)
 	hio_read16b(f);			/* reserved */
 	mod->spd = hio_read16b(f);
 	if ((b = hio_read16b(f)) > 0)	/* RAMBO.DTM has bpm 0 */
-		mod->bpm = b;
+		mod->bpm = b;		/* Not clamped by Digital Tracker. */
 	hio_read32b(f);			/* undocumented */
 
 	hio_read(mod->name, 32, 1, f);

--- a/src/loaders/liq_load.c
+++ b/src/loaders/liq_load.c
@@ -283,7 +283,7 @@ static int liq_load(struct module_data *m, HIO_HANDLE *f, const int start)
     }
 
     mod->spd = lh.speed;
-    mod->bpm = lh.bpm;
+    mod->bpm = MIN(lh.bpm, 255);
     mod->chn = lh.chn;
     mod->pat = lh.pat;
     mod->ins = mod->smp = lh.ins;
@@ -366,7 +366,7 @@ static int liq_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	    continue;
 	if (pmag != 0x4c500000)		/* LP\0\0 */
 	    return -1;
-	
+
 	hio_read(lp.name, 30, 1, f);
 	lp.rows = hio_read16l(f);
 	lp.size = hio_read32l(f);
@@ -404,9 +404,9 @@ read_event:
 	if (x2) {
 	    if (decode_event(x1, event, f) < 0)
 		return -1;
-	    xlat_fx (channel, event); 
+	    xlat_fx (channel, event);
 	    x2--;
-	    goto next_row;	
+	    goto next_row;
 	}
 
 	x1 = hio_read8(f);
@@ -454,7 +454,7 @@ test_event:
 	    D_(D_INFO "  [packed data]");
 	    if (decode_event(x1, event, f) < 0)
 		return -1;
-	    xlat_fx (channel, event); 
+	    xlat_fx (channel, event);
 	    goto next_row;
 	}
 
@@ -463,7 +463,7 @@ test_event:
 	    D_(D_INFO "  [packed data - repeat %d times]", x2);
 	    if (decode_event(x1, event, f) < 0)
 		return -1;
-	    xlat_fx (channel, event); 
+	    xlat_fx (channel, event);
 	    goto next_row;
 	}
 
@@ -472,7 +472,7 @@ test_event:
 	    D_(D_INFO "  [packed data - repeat %d times, keep note]", x2);
 	    if (decode_event(x1, event, f) < 0)
 		return -1;
-	    xlat_fx (channel, event); 
+	    xlat_fx (channel, event);
 	    while (x2) {
 	        row++;
 
@@ -517,7 +517,7 @@ test_event:
 		return -1;
 	}
 
-	xlat_fx(channel, event); 
+	xlat_fx(channel, event);
 
 	D_(D_INFO "  event: %02x %02x %02x %02x %02x\n",
 	    event->note, event->ins, event->vol, event->fxt, event->fxp);

--- a/src/loaders/pt3_load.c
+++ b/src/loaders/pt3_load.c
@@ -97,7 +97,7 @@ static int get_info(struct module_data *m, int size, HIO_HANDLE *f, void *parm)
 	mod->len = hio_read16b(f);
 	mod->pat = hio_read16b(f);
 	mod->gvl = hio_read16b(f);
-	mod->bpm = hio_read16b(f);
+	mod->bpm = hio_read16b(f);	/* Not clamped by Protracker 3.6 */
 	/*flags =*/ hio_read16b(f);
 	/*day   =*/ hio_read16b(f);
 	/*month =*/ hio_read16b(f);

--- a/src/loaders/xm_load.c
+++ b/src/loaders/xm_load.c
@@ -821,7 +821,8 @@ static int xm_load(struct module_data *m, HIO_HANDLE * f, const int start)
 		return -1;
 	}
 
-	if (xfh.tempo >= 32 || xfh.bpm < 32 || xfh.bpm > 255) {
+	/* FT2 and MPT allow up to 255 BPM. OpenMPT allows up to 1000 BPM. */
+	if (xfh.tempo >= 32 || xfh.bpm < 32 || xfh.bpm > 1000) {
 		if (memcmp("MED2XM", xfh.tracker, 6)) {
 			D_(D_CRIT "bad tempo or BPM: %d %d", xfh.tempo, xfh.bpm);
 			return -1;


### PR DESCRIPTION
Fixes #604.

Some trackers for formats that save BPM as a word do not bother to clamp BPMs from input files, allowing edge case modules with hex edited high BPMs to play back correctly. Known affected trackers: Fasttracker 2, Digital Tracker, Protracker 3.6. None of these actually allow BPMs this high in the UI. OpenMPT allows up to a maximum of 1000 BPM in XMs it saves, which means some actual modules rely on this behavior and libxmp needs to support it.

Liquid Tracker is the only other tracker format libxmp supports with a 16-bit BPM, but it clamps the input BPM to <=255. The SoundFX loader can produce BPMs higher than 255 but this looks like a maybe intentional design feature. Everything else appears to either set BPM through effects or loads it from a byte.

This makes the minimum tick size to around 10 samples at the default time factor, but since time factor can be set arbitrarily by the user this doesn't really matter that much. The mixer already has limits in place for this so it should be 100% safe.

edit: codecov is lying, there is no coverage change :|