### PR TITLE
Support loading SoundTracker modules using CR terminators

### DIFF
--- a/src/loaders/common.c
+++ b/src/loaders/common.c
@@ -277,6 +277,8 @@ int libxmp_test_name(const uint8 *s, int n, int flags)
 	for (i = 0; i < n; i++) {
 		if (s[i] == '\0' && (flags & TEST_NAME_IGNORE_AFTER_0))
 			break;
+		if (s[i] == '\r' && (flags & TEST_NAME_IGNORE_AFTER_CR))
+			break;
 		if (s[i] > 0x7f)
 			return -1;
 		/* ACS_Team2.mod has a backspace in instrument name */

--- a/src/loaders/loader.h
+++ b/src/loaders/loader.h
@@ -22,6 +22,7 @@
 
 /* libxmp_test_name flags */
 #define TEST_NAME_IGNORE_AFTER_0	0x0001
+#define TEST_NAME_IGNORE_AFTER_CR	0x0002
 
 #define DEFPAN(x) (0x80 + ((x) - 0x80) * m->defpan / 100)
 

--- a/src/loaders/st_load.c
+++ b/src/loaders/st_load.c
@@ -66,7 +66,7 @@ static int st_test(HIO_HANDLE *f, char *t, const int start)
 	struct st_header mh;
 	uint8 mod_event[4];
 	int pattern_errors;
-	int test_flags = 0;
+	int test_flags = TEST_NAME_IGNORE_AFTER_CR;
 	long size;
 
 	size = hio_size(f);


### PR DESCRIPTION
This can be seen in files created using [TrackConv](http://web.archive.org/web/20021108131930/http://listen.to/qtm) on RISC OS.