### PR TITLE
Add hio_reopen_* functions for #586.

### DIFF
--- a/src/depackers/depacker.h
+++ b/src/depackers/depacker.h
@@ -41,7 +41,7 @@ struct depacker {
 	int (*depack_mem)(HIO_HANDLE *, void **, long, long *);
 };
 
-int	libxmp_decrunch		(HIO_HANDLE **h, const char *filename, char **temp);
+int	libxmp_decrunch		(HIO_HANDLE *h, const char *filename, char **temp);
 int	libxmp_exclude_match	(const char *);
 
 #endif /* LIBXMP_DEPACKER_H */

--- a/src/hio.h
+++ b/src/hio.h
@@ -42,6 +42,8 @@ HIO_HANDLE *hio_open_mem  (const void *, long, int);
 HIO_HANDLE *hio_open_file (FILE *);
 HIO_HANDLE *hio_open_file2 (FILE *);/* allows fclose()ing the file by libxmp */
 HIO_HANDLE *hio_open_callbacks (void *, struct xmp_callbacks);
+int	hio_reopen_mem	(const void *, long, int, HIO_HANDLE *);
+int	hio_reopen_file	(FILE *, int, HIO_HANDLE *);
 int	hio_close	(HIO_HANDLE *);
 long	hio_size	(HIO_HANDLE *);
 

--- a/src/load.c
+++ b/src/load.c
@@ -156,7 +156,7 @@ int xmp_test_module(const char *path, struct xmp_test_info *info)
 		return -XMP_ERROR_SYSTEM;
 
 #ifndef LIBXMP_NO_DEPACKERS
-	if (libxmp_decrunch(&h, path, &temp) < 0) {
+	if (libxmp_decrunch(h, path, &temp) < 0) {
 		ret = -XMP_ERROR_DEPACK;
 		goto err;
 	}
@@ -204,7 +204,7 @@ int xmp_test_module_from_file(void *file, struct xmp_test_info *info)
 		return -XMP_ERROR_SYSTEM;
 
 #ifndef LIBXMP_NO_DEPACKERS
-	if (libxmp_decrunch(&h, NULL, &temp) < 0) {
+	if (libxmp_decrunch(h, NULL, &temp) < 0) {
 		ret = -XMP_ERROR_DEPACK;
 		goto err;
 	}
@@ -368,7 +368,7 @@ int xmp_load_module(xmp_context opaque, const char *path)
 
 #ifndef LIBXMP_NO_DEPACKERS
 	D_(D_INFO "decrunch");
-	if (libxmp_decrunch(&h, path, &temp_name) < 0) {
+	if (libxmp_decrunch(h, path, &temp_name) < 0) {
 		ret = -XMP_ERROR_DEPACK;
 		goto err;
 	}


### PR DESCRIPTION
These new hio.c functions act as a combined `hio_close` + `hio_open_*` which does not free or allocate a new `HIO_HANDLE *`, allowing the depackers system and loaders (#586) to replace an `HIO_HANDLE *` without being passed a `HIO_HANDLE **`. This cleans up some ugly code in the depackers.

This could *probably* be improved further by making the `MFILE` and `CBFILE` part of `HIO_HANDLE` instead of separately allocating them, which would eliminate some error paths, but I don't think it's really necessary right now.

Also worth nothing that once the LHA, RAR, and MO3 depackers are replaced, `hio_reopen_file` can be removed.