### PR TITLE
Detect S3M files made with Graoumf Tracker, and use full OpenMPT version

### DIFF
--- a/src/loaders/s3m_load.c
+++ b/src/loaders/s3m_load.c
@@ -381,8 +381,15 @@ static int s3m_load(struct module_data *m, HIO_HANDLE * f, const int start)
 		}
 		break;
 	case 5:
-		snprintf(tracker_name, 40, "OpenMPT %d.%02x",
-			 (sfh.version & 0x0f00) >> 8, sfh.version & 0xff);
+		if (sfh.version == 0x5447) {
+			strcpy(tracker_name, "Graoumf Tracker");
+		} else if (sfh.rsvd2[0] || sfh.rsvd2[1]) {
+			snprintf(tracker_name, 40, "OpenMPT %d.%02x.%02x.%02x",
+				 (sfh.version & 0x0f00) >> 8, sfh.version & 0xff, sfh.rsvd2[1], sfh.rsvd2[0]);
+		} else {
+			snprintf(tracker_name, 40, "OpenMPT %d.%02x",
+				 (sfh.version & 0x0f00) >> 8, sfh.version & 0xff);
+		}
 		m->quirk |= QUIRK_ST3BUGS;
 		break;
 	case 4:


### PR DESCRIPTION
For a moment I thought about pulling the extended Schism Tracker version information into this PR as well (which is required for identifying Schism Tracker versions built after 2020-10-28), but then my brain froze looking at that code... Maybe later.