### PR TITLE
Fix typo in CMake config

### DIFF
--- a/libxmp-config.cmake
+++ b/libxmp-config.cmake
@@ -1,11 +1,11 @@
 set(libxmp_FOUND OFF)
 
-if(EXISTS "${CMAKE_CURRENT_LISTDIR}/libxmp-shared-targets.cmake")
-    include("${CMAKE_CURRENT_LISTDIR}/libxmp-shared-targets.cmake")
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/libxmp-shared-targets.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/libxmp-shared-targets.cmake")
     set(libxmp_FOUND ON)
 endif()
 
-if(EXISTS "${CMAKE_CURRENT_LISTDIR}/libxmp-static-targets.cmake")
-    include("${CMAKE_CURRENT_LISTDIR}/libxmp-static-targets.cmake")
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/libxmp-static-targets.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/libxmp-static-targets.cmake")
     set(libxmp_FOUND ON)
 endif()


### PR DESCRIPTION
CMAKE_CURRENT_LIST_DIR is the proper name, reference: https://cmake.org/cmake/help/latest/variable/CMAKE_CURRENT_LIST_DIR.html