### PR TITLE
Fix compilation for UWP platform, disable external helpers

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -60,6 +60,21 @@
 #define LIBXMP_AMIGA	1
 #endif
 
+#if defined(_MSC_VER) && defined(__has_include)
+#if __has_include(<winapifamily.h>)
+#define HAVE_WINAPIFAMILY_H 1
+#else
+#define HAVE_WINAPIFAMILY_H 0
+#endif
+#endif
+
+#if HAVE_WINAPIFAMILY_H
+#include <winapifamily.h>
+#define LIBXMP_UWP (!WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP) && WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP))
+#else
+#define LIBXMP_UWP 0
+#endif
+
 #ifdef HAVE_EXTERNAL_VISIBILITY
 #define LIBXMP_EXPORT_VERSIONED __attribute__((visibility("default"),externally_visible))
 #else

--- a/src/depackers/depacker.c
+++ b/src/depackers/depacker.c
@@ -28,7 +28,7 @@
 #include "../tempfile.h"
 #include "xfnmatch.h"
 
-#ifdef _WIN32
+#if defined(_WIN32 ) && !LIBXMP_UWP
 /* Note: The _popen function returns an invalid file opaque, if
  * used in a Windows program, that will cause the program to hang
  * indefinitely. _popen works properly in a Console application.

--- a/src/depackers/ptpopen.c
+++ b/src/depackers/ptpopen.c
@@ -12,7 +12,9 @@
  * useful. -- Kurt Keller, Aug 2013
  */
 
-#ifdef _WIN32
+#include "../common.h"
+
+#if defined(_WIN32 ) && !LIBXMP_UWP
 
 #include "ptpopen.h"
 

--- a/src/mkstemp.c
+++ b/src/mkstemp.c
@@ -44,18 +44,21 @@
 #include <fcntl.h>
 #include <errno.h>
 
-#ifdef _MSC_VER
-#include <process.h>
-#define getpid _getpid
-#define open _open
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
 #endif
-
+#include <windows.h>
+#endif
 #if defined(_MSC_VER) || defined(__WATCOMC__)
 #include <io.h>
 #else
 #include <unistd.h>
 #endif
-
+#ifdef _MSC_VER
+#include <process.h>
+#define open _open
+#endif
 #ifndef O_BINARY
 #define O_BINARY 0
 #endif
@@ -64,12 +67,11 @@ int mkstemp(char *pattern)
 {
 	int start, i;
 #ifdef _WIN32
-	int   val;
+	int val = GetCurrentProcessId();
 #else
-	pid_t val;
+	pid_t val = getpid();
 #endif
 
-	val = getpid();
 	start = strlen(pattern) - 1;
 
 	while (pattern[start] == 'X') {


### PR DESCRIPTION
Fixes https://github.com/libxmp/libxmp/issues/642
This fix will work for all build systems.
CMake sets `-DWINAPI_FAMILY=WINAPI_FAMILY_APP` when building for UWP so there is a simpler fix but only if you don't care about other build systems.