### PR TITLE
fix / silence MSVC warnings.

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -96,6 +96,10 @@ typedef unsigned long long uint64;
 typedef signed long long int64;
 #endif
 
+#ifdef _MSC_VER
+#pragma warning(disable:4100) /* unreferenced formal parameter */
+#endif
+
 #ifndef LIBXMP_CORE_PLAYER
 #define LIBXMP_PAULA_SIMULATOR
 #endif

--- a/src/depackers/bunzip2.c
+++ b/src/depackers/bunzip2.c
@@ -223,7 +223,8 @@ static int read_block_header(struct bunzip_data *bd, struct bwdata *bw)
   // Read in the group selector array, which is stored as MTF encoded
   // bit runs.  (MTF = Move To Front.  Every time a symbol occurs it's moved
   // to the front of the table, so it has a shorter encoding next time.)
-  if (!(bd->nSelectors = get_bits(bd, 15))) return RETVAL_DATA_ERROR;
+  bd->nSelectors = get_bits(bd, 15);
+  if (!bd->nSelectors) return RETVAL_DATA_ERROR;
   for (ii=0; ii<bd->groupCount; ii++) bd->mtfSymbol[ii] = ii;
   for (ii=0; ii<bd->nSelectors; ii++) {
 
@@ -704,7 +705,8 @@ static int decrunch_bzip2(HIO_HANDLE *in, void **out, long *outlen)
   output.buf_size = 0;
   output.buf_alloc = 0;
 
-  if (!(i = start_bunzip(&bd, in, 0, 0))) {
+  i = start_bunzip(&bd, in, 0, 0);
+  if (!i) {
     i = write_bunzip_data(bd, bd->bwdata, &output, 0, 0);
     if (i==RETVAL_LAST_BLOCK) {
       if (bd->bwdata[0].headerCRC==bd->totalCRC) i = 0;

--- a/src/depackers/unlha.c
+++ b/src/depackers/unlha.c
@@ -337,7 +337,8 @@ static int read_pt_len(struct LhADecrData *dat, int16 nn, int16 nbit, int16 i_sp
 {
   int16 i, c, n;
 
-  if(!(n = getbits(dat, nbit)))
+  n = getbits(dat, nbit);
+  if(!n)
   {
     c = getbits(dat, nbit);
     for(i = 0; i < nn; i++)
@@ -384,7 +385,8 @@ static int read_c_len(struct LhADecrData *dat)
 {
   int16 i, c, n;
 
-  if(!(n = getbits(dat, CBIT)))
+  n = getbits(dat, CBIT);
+  if(!n)
   {
     c = getbits(dat, CBIT);
     for(i = 0; i < NC; i++)

--- a/src/depackers/xfnmatch.c
+++ b/src/depackers/xfnmatch.c
@@ -186,7 +186,8 @@ rangematch(const char *pattern, char test, int flags, char **newp)
 	 * consistency with the regular expression syntax.
 	 * J.T. Conklin (conklin@ngai.kaleida.com)
 	 */
-	if ((negate = (*pattern == '!' || *pattern == '^')))
+	negate = (*pattern == '!' || *pattern == '^');
+	if (negate)
 		++pattern;
 
 	if (flags & FNM_CASEFOLD)

--- a/src/loaders/lzw.c
+++ b/src/loaders/lzw.c
@@ -350,13 +350,13 @@ int libxmp_read_lzw(void *dest, size_t dest_len, size_t max_read_len,
 
 	if (flags & LZW_FLAG_SYMQUIRKS) {
 		/* Digital Symphony LZW compressed stream size is 4 aligned. */
-		size_t pos = bs.num_read;
-		while (pos & 3) {
+		size_t num_read = bs.num_read;
+		while (num_read & 3) {
 			#ifdef LZW_DEBUG
 			printf("A: align byte\n");
 			#endif
 			hio_read8(f);
-			pos++;
+			num_read++;
 		}
 	}
 	#ifdef LZW_DEBUG

--- a/src/loaders/stm_load.c
+++ b/src/loaders/stm_load.c
@@ -394,8 +394,8 @@ static int stm_load(struct module_data *m, HIO_HANDLE * f, const int start)
 				continue;
 
 			snprintf(sn, XMP_MAXPATH, "%s%s", m->dirname, tmpname);
-
-			if ((s = hio_open(sn, "rb"))) {
+			s = hio_open(sn, "rb");
+			if (s != NULL) {
 				if (libxmp_load_sample(m, s, SAMPLE_FLAG_UNS, &mod->xxs[i], NULL) < 0) {
 					hio_close(s);
 					return -1;

--- a/src/loaders/vorbis.c
+++ b/src/loaders/vorbis.c
@@ -70,6 +70,9 @@
 #define STB_VORBIS_C
 #include "vorbis.h"
 
+#ifdef _MSC_VER
+#pragma warning(disable:4457) /* shadowing */
+#endif
 
 //////////////////////////////////////////////////////////////////////////////
 //

--- a/src/loaders/vorbis.c
+++ b/src/loaders/vorbis.c
@@ -71,7 +71,8 @@
 #include "vorbis.h"
 
 #ifdef _MSC_VER
-#pragma warning(disable:4457) /* shadowing */
+#pragma warning(disable:4456) /* shadowing (hides previous local decl) */
+#pragma warning(disable:4457) /* shadowing (hides function parameter.) */
 #endif
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/mix_all.c
+++ b/src/mix_all.c
@@ -203,6 +203,10 @@
 
 #endif
 
+#ifdef _MSC_VER
+#pragma warning(disable:4457) /* shadowing */
+#endif
+
 
 /*
  * Nearest neighbor mixers

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -384,8 +384,9 @@ static int has_active_sustain_loop(struct context_data *ctx, struct mixer_voice 
 #ifndef LIBXMP_CORE_DISABLE_IT
 	struct module_data *m = &ctx->m;
 	return vi->smp < m->mod.smp && (xxs->flg & XMP_SAMPLE_SLOOP) && (~vi->flags & VOICE_RELEASE);
-#endif
+#else
 	return 0;
+#endif
 }
 
 static int has_active_loop(struct context_data *ctx, struct mixer_voice *vi,

--- a/test-dev/test_effect_set_nna_cut.c
+++ b/test-dev/test_effect_set_nna_cut.c
@@ -16,7 +16,7 @@ TEST(test_effect_set_nna_cut)
 	ctx = (struct context_data *)opaque;
 	p = &ctx->p;
 
- 	create_simple_module(ctx, 2, 2);
+	create_simple_module(ctx, 2, 2);
 	set_instrument_volume(ctx, 0, 0, 22);
 	set_instrument_volume(ctx, 1, 0, 33);
 	new_event(ctx, 0, 0, 0, 60, 1, 44, 0x0f, 2, FX_IT_INSTFUNC, 0x03);
@@ -47,7 +47,7 @@ TEST(test_effect_set_nna_cut)
 	fail_unless(vi->pos0 ==  0, "sample didn't reset");
 
 	for (i = 0; i < p->virt.maxvoc; i++) {
-		struct mixer_voice *vi = &p->virt.voice_array[i];
+		vi = &p->virt.voice_array[i];
 		if (i != 0 && vi->root == 0) {
 			break;
 		}

--- a/test-dev/test_fuzzer_asy_invalid_samples.c
+++ b/test-dev/test_fuzzer_asy_invalid_samples.c
@@ -1,6 +1,5 @@
 #include "test.h"
 
-
 TEST(test_fuzzer_asy_invalid_samples)
 {
 	xmp_context opaque;
@@ -18,7 +17,7 @@ TEST(test_fuzzer_asy_invalid_samples)
 	 * (All of the original ASYLUM module samples seem to be <64k.)
 	 */
 	ret = xmp_load_module(opaque, "data/f/load_asy_invalid_samples2.amf");
-	fail_unless(ret = -XMP_ERROR_LOAD, "module load (2)");
+	fail_unless(ret == -XMP_ERROR_LOAD, "module load (2)");
 
 	xmp_free_context(opaque);
 }

--- a/test-dev/test_player_nna_cut.c
+++ b/test-dev/test_player_nna_cut.c
@@ -15,7 +15,7 @@ TEST(test_player_nna_cut)
 	ctx = (struct context_data *)opaque;
 	p = &ctx->p;
 
- 	create_simple_module(ctx, 2, 2);
+	create_simple_module(ctx, 2, 2);
 	set_instrument_volume(ctx, 0, 0, 22);
 	set_instrument_volume(ctx, 1, 0, 33);
 	set_instrument_nna(ctx, 1, 0, XMP_INST_NNA_CUT, XMP_INST_DCT_OFF,
@@ -48,7 +48,7 @@ TEST(test_player_nna_cut)
 	fail_unless(vi->pos0 ==  0, "sample didn't reset");
 
 	for (i = 0; i < p->virt.maxvoc; i++) {
-		struct mixer_voice *vi = &p->virt.voice_array[i];
+		vi = &p->virt.voice_array[i];
 		if (i != 0 && vi->root == 0) {
 			break;
 		}


### PR DESCRIPTION
This patchset fixes/silences multiple MSVC warnings plaguing the build logs.
Individual commit messages should be self-explanatory. One of the commits to
test-dev is an actual fix.

Feel free to push to my branch for any more fixes.

The remaining notable warnings are the following:
```
src\player.c(517): warning C4701: potentially uninitialized local variable 'lps' used
src\loaders\sample.c(75,13): warning C4245: '*=': conversion from 'int' to 'uint8', signed/unsigned mismatch
src\loaders\sample.c(127,16): warning C4245: '+=': conversion from 'int' to 'uint8', signed/unsigned mismatch
src\loaders\sample.c(127,16): warning C4310: cast truncates constant value
src\depackers\arc_unpack.c(139,29): warning C4310: cast truncates constant value
test-dev\test_string_adjustment.c(6,9): warning C4310: cast truncates constant value
src\depackers\xz_dec_stream.c(424,7): warning C4125: decimal digit terminates octal escape sequence
```

There are also the following sign mismatch warnings: don't know whether they
are worth fixing.
```
src\loaders\sample.c(270,42): warning C4389: '!=': signed/unsigned mismatch
src\smix.c(286,38): warning C4389: '!=': signed/unsigned mismatch
src\loaders\xm_load.c(412,57): warning C4389: '!=': signed/unsigned mismatch
src\loaders\s3m_load.c(337,42): warning C4389: '!=': signed/unsigned mismatch
src\loaders\s3m_load.c(342,42): warning C4389: '!=': signed/unsigned mismatch
src\loaders\okt_load.c(241,41): warning C4389: '!=': signed/unsigned mismatch
src\loaders\mdl_load.c(411,44): warning C4389: '!=': signed/unsigned mismatch
src\loaders\mdl_load.c(985,35): warning C4389: '!=': signed/unsigned mismatch
src\loaders\mdl_load.c(1007,35): warning C4389: '!=': signed/unsigned mismatch
src\loaders\liq_load.c(426,30): warning C4389: '!=': signed/unsigned mismatch
src\loaders\sym_load.c(407,42): warning C4389: '!=': signed/unsigned mismatch
src\loaders\sym_load.c(457,42): warning C4389: '!=': signed/unsigned mismatch
src\loaders\muse_load.c(79,32): warning C4389: '!=': signed/unsigned mismatch
src\depackers\ppdepack.c(189,39): warning C4389: '!=': signed/unsigned mismatch
src\depackers\s404_dec.c(380,35): warning C4389: '!=': signed/unsigned mismatch
src\depackers\gunzip.c(163,10): warning C4389: '!=': signed/unsigned mismatch
src\depackers\bunzip2.c(678,39): warning C4389: '!=': signed/unsigned mismatch
src\depackers\unlha.c(1779,43): warning C4389: '!=': signed/unsigned mismatch
src\depackers\unlha.c(1801,43): warning C4389: '!=': signed/unsigned mismatch
src\depackers\unlha.c(1851,39): warning C4389: '!=': signed/unsigned mismatch
src\loaders\prowizard\pp21.c(217,44): warning C4389: '!=': signed/unsigned mismatch
test-dev\util.c(31,35): warning C4389: '!=': signed/unsigned mismatch
test-dev\test_effect_it_break_to_row.c(43,4): warning C4389: '==': signed/unsigned mismatch
test-dev\test_storlek_09_sample_change_no_note.c(43,4): warning C4389: '==': signed/unsigned mismatch
test-dev\test_storlek_14_pingpong_loop_and_sample_number.c(35,4): warning C4389: '==': signed/unsigned mismatch
test-dev\test_storlek_19_random_waveform.c(85,18): warning C4389: '==': signed/unsigned mismatch
test-dev\test_storlek_19_random_waveform.c(85,43): warning C4389: '==': signed/unsigned mismatch
test-dev\test_player_period_amiga.c(32,3): warning C4389: '==': signed/unsigned mismatch
test-dev\test_player_period_amiga.c(33,3): warning C4389: '==': signed/unsigned mismatch
```
