### PR TITLE
Add tracker detection for ModPlug Tracker XMs, pre-alpha ITs.

### DIFF
--- a/test-dev/data/format_xm_instsamples.data
+++ b/test-dev/data/format_xm_instsamples.data
@@ -1,5 +1,5 @@
 grass near the house
-FastTracker v2.00 XM 1.04
+ModPlug Tracker 1.16 XM 1.04
 14 209 16 7 29 3 125 14 0 64
 0 1 2 3 4 5 6 7 8 9 10 11 5 12
 64 23 512 Drums


### PR DESCRIPTION
Adds a small handful of MPT module detection improvements:

* ModPlug Tracker XMs are now detected in many (but not all) cases. This is currently used only to apply MPT preamp to XMs that expect it. Example: `test-dev/data/m/xyce-dans_la_rue.xm`.
* ModPlug Tracker XM comments are now loaded.
* IT modules *probably* saved using early ModPlug Tracker pre-alpha releases are now detected. These have tracker version `0202h`, format version `0200h`, an a non-zero first pattern parapointer that is less than the first sample parapointer. There are only a very small number of these on Modland, and this fingerprinting was only recently discovered by Saga Musix.