### PR TITLE
replace unnecessary use of %z in format-strings in D_().

### DIFF
--- a/src/depackers/gunzip.c
+++ b/src/depackers/gunzip.c
@@ -152,8 +152,8 @@ static int decrunch_gzip(HIO_HANDLE *in, void **out, long *outlen)
 	crc_in = hio_read32l(in);
 	crc = libxmp_crc32_A((uint8 *)pOut_buf, pOut_len, 0UL);
 	if (crc_in != crc) {
-		D_(D_CRIT "CRC-32 mismatch: expected %08zx, got %08zx",
-		   (size_t)crc_in, (size_t)crc);
+		D_(D_CRIT "CRC-32 mismatch: expected %08lx, got %08lx",
+		   (unsigned long)crc_in, (unsigned long)crc);
 		free(pOut_buf);
 		return -1;
 	}

--- a/src/loaders/xmf_load.c
+++ b/src/loaders/xmf_load.c
@@ -136,8 +136,8 @@ static int xmf_test(HIO_HANDLE *f, char *t, const int start)
 	samples_start = 0x1103 + num_channels + num_patterns * num_channels * 64 * 6;
 	length = hio_size(f);
 	if (length < samples_start || (size_t)length - samples_start < samples_length) {
-		D_(D_WARN "not XMF: file length %ld is shorter than required %zu",
-		 length, (size_t)samples_start + samples_length);
+		D_(D_WARN "not XMF: file length %ld is shorter than required %lu",
+		 length, (unsigned long)samples_start + samples_length);
 		return -1;
 	}
 


### PR DESCRIPTION
Their use lead to warnings in mingw debug builds:

```
D:/a/libxmp/libxmp/src/depackers/gunzip.c: In function 'decrunch_gzip':
D:/a/libxmp/libxmp/src/common.h:198:16: warning: unknown conversion type character 'z' in format [-Wformat=]
  198 | #define D_CRIT "\x1b[31m"
      |                ^~~~~~~~~~
D:/a/libxmp/libxmp/src/common.h:202:46: note: in definition of macro 'D_'
  202 |                 __FILE__, __LINE__); printf (__VA_ARGS__); printf ("\x1b[0m\n"); \
      |                                              ^~~~~~~~~~~
D:/a/libxmp/libxmp/src/depackers/gunzip.c:155:20: note: in expansion of macro 'D_CRIT'
  155 |                 D_(D_CRIT "CRC-32 mismatch: expected %08zx, got %08zx",
      |                    ^~~~~~
D:/a/libxmp/libxmp/src/common.h:198:16: warning: unknown conversion type character 'z' in format [-Wformat=]
  198 | #define D_CRIT "\x1b[31m"
      |                ^~~~~~~~~~
D:/a/libxmp/libxmp/src/common.h:202:46: note: in definition of macro 'D_'
  202 |                 __FILE__, __LINE__); printf (__VA_ARGS__); printf ("\x1b[0m\n"); \
      |                                              ^~~~~~~~~~~
D:/a/libxmp/libxmp/src/depackers/gunzip.c:155:20: note: in expansion of macro 'D_CRIT'
  155 |                 D_(D_CRIT "CRC-32 mismatch: expected %08zx, got %08zx",
      |                    ^~~~~~
D:/a/libxmp/libxmp/src/common.h:198:16: warning: too many arguments for format [-Wformat-extra-args]
  198 | #define D_CRIT "\x1b[31m"
      |                ^~~~~~~~~~
D:/a/libxmp/libxmp/src/common.h:202:46: note: in definition of macro 'D_'
  202 |                 __FILE__, __LINE__); printf (__VA_ARGS__); printf ("\x1b[0m\n"); \
      |                                              ^~~~~~~~~~~
D:/a/libxmp/libxmp/src/depackers/gunzip.c:155:20: note: in expansion of macro 'D_CRIT'
  155 |                 D_(D_CRIT "CRC-32 mismatch: expected %08zx, got %08zx",
      |                    ^~~~~~
```

```
In file included from D:/a/libxmp/libxmp/src/loaders/loader.h:4,
                 from D:/a/libxmp/libxmp/src/loaders/xmf_load.c:27:
D:/a/libxmp/libxmp/src/loaders/xmf_load.c: In function 'xmf_test':
D:/a/libxmp/libxmp/src/common.h:199:16: warning: unknown conversion type character 'z' in format [-Wformat=]
  199 | #define D_WARN "\x1b[36m"
      |                ^~~~~~~~~~
D:/a/libxmp/libxmp/src/common.h:202:46: note: in definition of macro 'D_'
  202 |                 __FILE__, __LINE__); printf (__VA_ARGS__); printf ("\x1b[0m\n"); \
      |                                              ^~~~~~~~~~~
D:/a/libxmp/libxmp/src/loaders/xmf_load.c:139:20: note: in expansion of macro 'D_WARN'
  139 |                 D_(D_WARN "not XMF: file length %ld is shorter than required %zu",
      |                    ^~~~~~
D:/a/libxmp/libxmp/src/common.h:199:16: warning: too many arguments for format [-Wformat-extra-args]
  199 | #define D_WARN "\x1b[36m"
      |                ^~~~~~~~~~
D:/a/libxmp/libxmp/src/common.h:202:46: note: in definition of macro 'D_'
  202 |                 __FILE__, __LINE__); printf (__VA_ARGS__); printf ("\x1b[0m\n"); \
      |                                              ^~~~~~~~~~~
D:/a/libxmp/libxmp/src/loaders/xmf_load.c:139:20: note: in expansion of macro 'D_WARN'
  139 |                 D_(D_WARN "not XMF: file length %ld is shorter than required %zu",
      |                    ^~~~~~
```
