### PR TITLE
minor Makefile.lite and autotools updates

### DIFF
--- a/Makefile.lite
+++ b/Makefile.lite
@@ -1,9 +1,8 @@
 
 DIST		= libxmp-lite-stagedir
-DFILES		= lite/README INSTALL install-sh configure configure.ac \
-		  config.sub config.guess Makefile.in lite/libxmp-lite.pc.in \
-		  libxmp.map lite/Makefile.vc.in lite/Makefile.os2 lite/Makefile.w32 \
-		  lite/watcom.mif.in aclocal.m4 autogen.sh
+DFILES		= INSTALL install-sh config.sub config.guess aclocal.m4 autogen.sh libxmp.map \
+		  lite/README lite/configure.ac lite/Makefile.in lite/libxmp-lite.pc.in \
+		  lite/Makefile.vc.in lite/Makefile.os2 lite/Makefile.w32 lite/watcom.mif.in
 DDIRS		= src loaders test cmake m4
 
 all: dist

--- a/Makefile.lite
+++ b/Makefile.lite
@@ -1,4 +1,4 @@
-
+AUTOCONF	= autoconf
 DIST		= libxmp-lite-stagedir
 DFILES		= INSTALL install-sh config.sub config.guess aclocal.m4 autogen.sh libxmp.map \
 		  lite/README lite/configure.ac lite/Makefile.in lite/libxmp-lite.pc.in \
@@ -44,10 +44,10 @@ dist-subdirs: $(addprefix dist-,$(DDIRS))
 	cp lite/CMakeLists.txt $(DIST)/CMakeLists.txt
 
 dist-dist:
-	(cd  $(DIST); autoconf; ./configure)
+	(cd  $(DIST); $(AUTOCONF); ./configure)
 	$(MAKE) -C $(DIST) dist distcheck || false
 
 check-no-it:
-	(cd  $(DIST); autoconf; ./configure --disable-it)
+	(cd  $(DIST); $(AUTOCONF); ./configure --disable-it)
 	$(MAKE) -C $(DIST) || false
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-autoconf
+"${AUTOCONF:-autoconf}"

--- a/test-dev/Makefile.in
+++ b/test-dev/Makefile.in
@@ -1,3 +1,4 @@
+AUTOCONF	= autoconf
 CC		= @CC@
 CFLAGS		= -c @CFLAGS@ @DEFS@ -I../include -I../src
 LD		= @CC@
@@ -787,7 +788,7 @@ $(FUZZLIB_PATH):
 
 $(FUZZLIB_PATH)/libxmp-asan.a: $(FUZZLIB_PATH)
 	(cd $(FUZZLIB_PATH) && \
-		autoconf && \
+		$(AUTOCONF) && \
 		CC="$(FUZZ_CC)" CFLAGS="$(FUZZLIB_ASAN_FLAGS)" LDFLAGS="$(FUZZLIB_ASAN_FLAGS)" ./configure && \
 		$(MAKE) static && \
 		cp lib/libxmp.a libxmp-asan.a && \
@@ -795,7 +796,7 @@ $(FUZZLIB_PATH)/libxmp-asan.a: $(FUZZLIB_PATH)
 
 $(FUZZLIB_PATH)/libxmp-msan.a: $(FUZZLIB_PATH) | $(FUZZLIB_PATH)/libxmp-asan.a
 	(cd $(FUZZLIB_PATH) && \
-		autoconf && \
+		$(AUTOCONF) && \
 		CC="$(FUZZ_CC)" CFLAGS="$(FUZZLIB_MSAN_FLAGS)" LDFLAGS="$(FUZZLIB_MSAN_FLAGS)" ./configure && \
 		$(MAKE) static && \
 		cp lib/libxmp.a libxmp-msan.a && \


### PR DESCRIPTION
- Makefile.lite: tweak DFILES:
  Copy configure.ac and Makefile.in from the lite directory, not from
  top-level. And remove configure script from DFILES: The rest of the
  rules already run autoconf in the staging directory i.e. it will be
  generated already.  No need to generate the configure script before
  running Makefile.lite, anymore.

- autotools: allow specifying the autoconf command in AUTOCONF env. var.
  (on the make command line in case of Makefile.lite.)
