### PR TITLE
cmake: set maximum policy to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.2...3.5)
 project(libxmp VERSION 4.6.0 LANGUAGES C)
 
 set(LIBXMP_DEFINES)

--- a/lite/CMakeLists.txt
+++ b/lite/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.2...3.5)
 project(libxmplite VERSION 4.6.0 LANGUAGES C)
 
 set(LIBXMP_DEFINES)


### PR DESCRIPTION
This fixes the following warning when configuring with CMake 3.27+:
```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

@madebr: This was adapted from your SDL2 patch. OK?
