### PR TITLE
Fixing end-detection

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -1634,10 +1634,12 @@ static void next_order(struct context_data *ctx)
 			if (mod->rst > mod->len ||
 			    mod->xxo[mod->rst] >= mod->pat ||
 			    p->ord < m->seq_data[p->sequence].entry_point) {
-				p->ord = m->seq_data[p->sequence].entry_point;
 				/* Increment to loop count. This will make the player to quit like other modules when
 				   playing sequence 8 of "alien incident - leohou2.s3m" by Purple Motion */
-				p->loop_count++;
+				if (p->ord < m->seq_data[p->sequence].entry_point) {
+					p->loop_count++;
+				}
+				p->ord = m->seq_data[p->sequence].entry_point;
 			} else {
 				if (libxmp_get_sequence(ctx, mod->rst) == p->sequence) {
 					p->ord = mod->rst;

--- a/src/player.c
+++ b/src/player.c
@@ -1645,10 +1645,9 @@ static void next_order(struct context_data *ctx)
 					p->ord = mod->rst;
 				} else {
 					p->ord = m->seq_data[p->sequence].entry_point;
+					/* Increment loop count here too. This will fix e.g. "amazonas-dynomite mix.it" by Skaven */
+					p->loop_count++;
 				}
-
-				/* Increment loop count here too. This will fix e.g. "amazonas-dynomite mix.it" by Skaven */
-				p->loop_count++;
 			}
 			/* This might be a marker, so delay updating global
 			 * volume until an actual pattern is found */

--- a/src/player.c
+++ b/src/player.c
@@ -1635,6 +1635,9 @@ static void next_order(struct context_data *ctx)
 			    mod->xxo[mod->rst] >= mod->pat ||
 			    p->ord < m->seq_data[p->sequence].entry_point) {
 				p->ord = m->seq_data[p->sequence].entry_point;
+				/* Increment to loop count. This will make the player to quit like other modules when
+				   playing sequence 8 of "alien incident - leohou2.s3m" by Purple Motion */
+				p->loop_count++;
 			} else {
 				if (libxmp_get_sequence(ctx, mod->rst) == p->sequence) {
 					p->ord = mod->rst;

--- a/src/player.c
+++ b/src/player.c
@@ -1634,7 +1634,7 @@ static void next_order(struct context_data *ctx)
 			if (mod->rst > mod->len ||
 			    mod->xxo[mod->rst] >= mod->pat ||
 			    p->ord < m->seq_data[p->sequence].entry_point) {
-				/* Increment to loop count. This will make the player to quit like other modules when
+				/* Increment loop count. This will make the player to quit like other modules when
 				   playing sequence 8 of "alien incident - leohou2.s3m" by Purple Motion */
 				if (p->ord < m->seq_data[p->sequence].entry_point) {
 					p->loop_count++;
@@ -1646,6 +1646,9 @@ static void next_order(struct context_data *ctx)
 				} else {
 					p->ord = m->seq_data[p->sequence].entry_point;
 				}
+
+				/* Increment loop count here too. This will fix e.g. "amazonas-dynomite mix.it" by Skaven */
+				p->loop_count++;
 			}
 			/* This might be a marker, so delay updating global
 			 * volume until an actual pattern is found */


### PR DESCRIPTION
This little fix will make sure if a sequence jumps back to before it starting position, the loop count will be incremented. This will tell a player, that the module has ended.

An example of this, is sequence 8 of "alien incident - leohou2.s3m" by Purple Motion.