### PR TITLE
Fix loop detection edge cases broken by S3M/IT marker scan bugs.

### DIFF
--- a/docs/Changelog
+++ b/docs/Changelog
@@ -1,6 +1,10 @@
 Stable versions
 ---------------
 
+4.6.1 (?):
+	Changes by Alice Rowan:
+	- Fix loop detection edge cases broken by S3M/IT marker scan bugs.
+
 4.6.0 (20230615):
 	Changes by Alice Rowan:
 	- Add Astroidea XMF format loader.

--- a/src/scan.c
+++ b/src/scan.c
@@ -171,6 +171,14 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
 
 	/* Allow more complex order reuse only in main sequence */
 	if (ep != 0 && p->sequence_control[ord] != 0xff) {
+	    /* ...unless it's an end marker. Two sequences (7 and 8) in
+	     * "alien incident - leohou2.s3m" by Purple Motion share the
+	     * same S3M_END due to an off-by-one pattern jump.
+	     */
+	    if (has_marker && pat == S3M_END) {
+		ord = mod->len;
+		continue;
+	    }
 	    break;
 	}
 	p->sequence_control[ord] = chain;
@@ -576,6 +584,15 @@ end_module:
         if (pat >= mod->pat || row >= mod->xxp[pat]->rows) {
             row = 0;
         }
+
+	/* Currently to detect the end of the sequence, the player needs the
+	 * end to be a real position and row, so skip invalid and S3M_SKIP.
+	 * "amazonas-dynomite mix.it" by Skaven has a sequence (9) where an
+	 * S3M_END repeats into an S3M_SKIP.
+	 */
+	while (ord < mod->len && mod->xxo[ord] >= mod->pat) {
+	    ord++;
+	}
     }
 
     p->scan[chain].num = m->scan_cnt[ord][row];

--- a/test-dev/Makefile.in
+++ b/test-dev/Makefile.in
@@ -250,7 +250,7 @@ WRITE		= file_32bit_little_endian file_32bit_big_endian \
 		  file_16bit_little_endian file_16bit_big_endian \
 		  file_8bit
 
-PLAYER		= read_event scan period_amiga period_mod_range pan \
+PLAYER		= read_event scan loop period_amiga period_mod_range pan \
 		  med_extsample med_hold med_instruments med_ss2defpitch \
 		  med_synth med_synth_2 \
 		  hmn_extras \

--- a/test-dev/all_tests.txt
+++ b/test-dev/all_tests.txt
@@ -506,6 +506,7 @@ test_openmpt_mod_ptoffset
 test_openmpt_mod_vibratoreset
 test_player_read_event
 test_player_scan
+test_player_loop
 test_player_period_amiga
 test_player_period_mod_range
 test_player_pan

--- a/test-dev/test_player_loop.c
+++ b/test-dev/test_player_loop.c
@@ -1,0 +1,100 @@
+#include "test.h"
+#include "../src/effects.h"
+
+#define IT_SKIP 0xfe
+#define IT_END 0xff
+
+struct test_seq
+{
+	int entry;
+	int ticks;
+};
+
+TEST(test_player_loop)
+{
+	xmp_context opaque;
+	struct context_data *ctx;
+	struct xmp_frame_info info;
+	int ret, i, j, pat, pos, seq;
+	int remote_end;
+	struct test_seq test_seq[16];
+
+	opaque = xmp_create_context();
+	ctx = (struct context_data *)opaque;
+
+	create_simple_module(ctx, 1, 16);
+	libxmp_free_scan(ctx);
+	set_quirk(ctx, QUIRK_MARKER, READ_EVENT_IT);
+	pat = 0;
+	pos = 0;
+	seq = 0;
+
+	/* Main sequence */
+	new_event(ctx, pat, 0, 0, 0, 0, 0, FX_BREAK, 0, 0, 0);
+	test_seq[seq].entry = pos;
+	test_seq[seq].ticks = 6;
+	set_order(ctx, (pos++), (pat++));
+	remote_end = pos; /* for use by a later sequence */
+	set_order(ctx, (pos++), IT_END);
+	seq++;
+
+	/* Sequence: pattern, end */
+	new_event(ctx, pat, 0, 0, 0, 0, 0, FX_BREAK, 0, 0, 0);
+	test_seq[seq].entry = pos;
+	test_seq[seq].ticks = 6;
+	set_order(ctx, (pos++), (pat++));
+	set_order(ctx, (pos++), IT_END);
+	seq++;
+
+	/* Sequence: skip, pattern, end */
+	new_event(ctx, pat, 0, 0, 0, 0, 0, FX_BREAK, 0, 0, 0);
+	test_seq[seq].entry = pos + 1;
+	test_seq[seq].ticks = 6;
+	set_order(ctx, (pos++), IT_SKIP);
+	set_order(ctx, (pos++), (pat++));
+	set_order(ctx, (pos++), IT_END);
+	seq++;
+
+	/* Sequence: pattern jump into end marker */
+	new_event(ctx, pat, 0, 0, 0, 0, 0, FX_JUMP, remote_end, 0, 0);
+	test_seq[seq].entry = pos;
+	test_seq[seq].ticks = 6;
+	set_order(ctx, (pos++), (pat++));
+	set_order(ctx, (pos++), IT_END);
+	seq++;
+
+	ctx->m.mod.len = pos;
+	libxmp_prepare_scan(ctx);
+	libxmp_scan_sequences(ctx);
+
+	ret = xmp_start_player(opaque, XMP_MIN_SRATE, 0);
+	fail_unless(ret == 0, "failed to start player");
+
+	for (i = 0; i < seq; i++) {
+		xmp_restart_module(opaque);
+
+		ret = xmp_set_position(opaque, test_seq[i].entry);
+		if (i > 0) {
+			fail_unless(ret == test_seq[i].entry, "failed to set position");
+		} else {
+			fail_unless(ret == -1, "failed to set position");
+		}
+
+		xmp_get_frame_info(opaque, &info);
+		fail_unless(info.sequence == i, "entered wrong sequence");
+
+		ctx->p.loop_count = 0;
+
+		for (j = 0; j <= test_seq[i].ticks; j++) {
+			fail_unless(info.loop_count == 0, "loop occurred too early");
+
+			xmp_play_frame(opaque);
+
+			xmp_get_frame_info(opaque, &info);
+			fail_unless(info.sequence == i, "wrong sequence");
+		}
+		fail_unless(info.loop_count == 1, "failed to detect loop");
+	}
+	xmp_free_context(opaque);
+}
+END_TEST


### PR DESCRIPTION
* "alien incident - leohou2.s3m" by Purple Motion had broken loop detection in sequence 8 due to it using a pattern jump to an end marker associated with sequence 7. Fixed by handling end markers in the scan regardless of which sequence they are attached to.
* "amazonas-dynomite mix.it" by Skaven had broken loop detection in sequence 9 caused by the scan placing its loop point inside of a nonexistent marker "pattern". Fixed by placing the loop point at the start of the first real pattern in a sequence.