### PR TITLE
scan.c: optimize for common case of no effects

### DIFF
--- a/src/scan.c
+++ b/src/scan.c
@@ -277,13 +277,19 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
 		if (row >= tracks[chn]->rows)
 		    continue;
 
-		//event = &EVENT(mod->xxo[ord], chn, row);
+		/* event = &EVENT(mod->xxo[ord], chn, row); */
 		event = &tracks[chn]->event[row];
 
 		f1 = event->fxt;
 		p1 = event->fxp;
 		f2 = event->f2t;
 		p2 = event->f2p;
+
+		if (f1 == 0 && f2 == 0) {
+			continue;
+		}
+
+		/* note: could use #include hackery to duplicate the below block based on whether f2 is zero (likely) */
 
 		if (f1 == FX_GLOBALVOL || f2 == FX_GLOBALVOL) {
 		    gvl = (f1 == FX_GLOBALVOL) ? p1 : p2;

--- a/src/scan.c
+++ b/src/scan.c
@@ -289,8 +289,6 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
 			continue;
 		}
 
-		/* note: could use #include hackery to duplicate the below block based on whether f2 is zero (likely) */
-
 		if (f1 == FX_GLOBALVOL || f2 == FX_GLOBALVOL) {
 		    gvl = (f1 == FX_GLOBALVOL) ? p1 : p2;
 		    gvl = gvl > m->gvolbase ? m->gvolbase : gvl < 0 ? 0 : gvl;


### PR DESCRIPTION
This is a very simple PR. While profiling `scan_module`, I noticed that the effects slots for all events were compared to all possible FX, even though the vast majority of effects slots are empty.

The only change in the PR is to skip these checks if both effects slots for an event are empty.

In my benchmarking, this yields about a 10% load time improvement *in general*.