### PR TITLE
Fix an extra scan edge case related to scan edge case fix #688.

### DIFF
--- a/src/scan.c
+++ b/src/scan.c
@@ -171,12 +171,19 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
 
 	/* Allow more complex order reuse only in main sequence */
 	if (ep != 0 && p->sequence_control[ord] != 0xff) {
-	    /* ...unless it's an end marker. Two sequences (7 and 8) in
-	     * "alien incident - leohou2.s3m" by Purple Motion share the
-	     * same S3M_END due to an off-by-one pattern jump.
+	    /* Currently to detect the end of the sequence, the player needs the
+	     * end to be a real position and row, so skip invalid and S3M_SKIP.
+	     * "amazonas-dynomite mix.it" by Skaven has a sequence (9) where an
+	     * S3M_END repeats into an S3M_SKIP.
+	     *
+	     * Two sequences (7 and 8) in "alien incident - leohou2.s3m" by
+	     * Purple Motion share the same S3M_END due to an off-by-one jump,
+	     * so check S3M_END here too.
 	     */
-	    if (has_marker && pat == S3M_END) {
-		ord = mod->len;
+	    if (pat >= mod->pat) {
+		if (has_marker && pat == S3M_END) {
+			ord = mod->len;
+		}
 		continue;
 	    }
 	    break;
@@ -584,15 +591,6 @@ end_module:
         if (pat >= mod->pat || row >= mod->xxp[pat]->rows) {
             row = 0;
         }
-
-	/* Currently to detect the end of the sequence, the player needs the
-	 * end to be a real position and row, so skip invalid and S3M_SKIP.
-	 * "amazonas-dynomite mix.it" by Skaven has a sequence (9) where an
-	 * S3M_END repeats into an S3M_SKIP.
-	 */
-	while (ord < mod->len && mod->xxo[ord] >= mod->pat) {
-	    ord++;
-	}
     }
 
     p->scan[chain].num = m->scan_cnt[ord][row];

--- a/test-dev/test_player_loop.c
+++ b/test-dev/test_player_loop.c
@@ -16,7 +16,7 @@ TEST(test_player_loop)
 	struct context_data *ctx;
 	struct xmp_frame_info info;
 	int ret, i, j, pat, pos, seq;
-	int remote_end;
+	int remote_end, jump_skip_end;
 	struct test_seq test_seq[16];
 
 	opaque = xmp_create_context();
@@ -62,6 +62,22 @@ TEST(test_player_loop)
 	set_order(ctx, (pos++), (pat++));
 	set_order(ctx, (pos++), IT_END);
 	seq++;
+
+	/* Sequence: jump into skip into end. This should be last. */
+	jump_skip_end = pat;
+	test_seq[seq].entry = pos;
+	test_seq[seq].ticks = 6;
+	set_order(ctx, (pos++), (pat++));
+	seq++;
+	/* Sequence: do it again, because the reuse is what caused a bug. */
+	test_seq[seq].entry = pos;
+	test_seq[seq].ticks = 6;
+	set_order(ctx, (pos++), jump_skip_end);
+	seq++;
+	/* Target */
+	new_event(ctx, jump_skip_end, 0, 0, 0, 0, 0, FX_JUMP, pos, 0, 0);
+	set_order(ctx, (pos++), IT_SKIP);
+	/* intentionally no terminating IT_END. */
 
 	ctx->m.mod.len = pos;
 	libxmp_prepare_scan(ctx);


### PR DESCRIPTION
If two sequences jump to the same invalid/skip pattern immediately prior to the end of the module, the previous scan fix patch would attempt to read the order list out-of-bounds. I've fixed this by just making the invalid/skip pattern handling part of the same branch as the S3M_END handling in the fix, which I should have done anyway.

Found by libFuzzer.