### PR TITLE
Extra optimizations for IT load

### DIFF
--- a/src/loaders/it_load.c
+++ b/src/loaders/it_load.c
@@ -1353,6 +1353,9 @@ static int it_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		}
 		pos = patbuf;
 
+		/* How do bits of mask[c] advance the file pointer? Bits 1, 2, and 4 advance 1 byte; bit 8 advances 2. */
+		static const uint8 adv[16] = {0, 1, 1, 2, 1, 2, 2, 3, 2, 3, 3, 4, 3, 4, 4, 5};
+
 		row = 0;
 		while (row < num_rows && --pat_len >= 0) {
 			int b = *(pos++);
@@ -1372,22 +1375,8 @@ static int it_load(struct module_data *m, HIO_HANDLE *f, const int start)
 				pat_len--;
 			}
 
-			if (mask[c] & 0x01) {
-				pos++;
-				pat_len--;
-			}
-			if (mask[c] & 0x02) {
-				pos++;
-				pat_len--;
-			}
-			if (mask[c] & 0x04) {
-				pos++;
-				pat_len--;
-			}
-			if (mask[c] & 0x08) {
-				pos += 2;
-				pat_len -= 2;
-			}
+			pos += adv[mask[c] & 0x0f];
+			pat_len -= adv[mask[c] & 0x0f];
 		}
 	}
 

--- a/src/loaders/it_load.c
+++ b/src/loaders/it_load.c
@@ -1003,17 +1003,21 @@ static int load_it_pattern(struct module_data *m, int i, int new_fx,
 			event = &(event_base[c][r]);
 		}
 
+		if ((mask[c] & 0x0f) == 0) {
+			goto second_nybble;
+		}
+
 		if (mask[c] & 0x01) {
 			if (pat_len < 1) break;
 			b = *(pos++);
 
-				/* From ittech.txt:
-				 * Note ranges from 0->119 (C-0 -> B-9)
-				 * 255 = note off, 254 = notecut
-				 * Others = note fade (already programmed into IT's player
-				 *                     but not available in the editor)
-				 */
-				switch (b) {
+			/* From ittech.txt:
+			 * Note ranges from 0->119 (C-0 -> B-9)
+			 * 255 = note off, 254 = notecut
+			 * Others = note fade (already programmed into IT's player
+			 *                     but not available in the editor)
+			 */
+			switch (b) {
 				case 0xff:	/* key off */
 					b = XMP_KEY_OFF;
 					break;
@@ -1059,6 +1063,11 @@ static int load_it_pattern(struct module_data *m, int i, int new_fx,
 				lastevent[c].fxp = event->fxp;
 			}
 			pat_len -= 2;
+		}
+
+second_nybble:
+		if ((mask[c] & 0xf0) == 0) {
+			continue;
 		}
 		if (mask[c] & 0x10) {
 			event->note = lastevent[c].note;


### PR DESCRIPTION
In discussion of @AliceLR's buffering for IT load I mentioned that I had noticed a few further possible optimizations. I'm sharing them here; there's no pressure to review them quickly (or at all).

On my own files, these seem to yield around a 7% total speedup when loading files and a 14% reduction in instructions spent in `it_load` (profiled with callgrind). I'm not certain what the Modland IT directory is but it would be nice to use that instead of (or in addition to) my own files for benchmarking.

A brief description of the optimizations in the commits I've shared here:
- cache channel event bases - at the top of a pattern load, get row 0's event mapping for each channel. Use this instead of the more expensive trinary `EVENT` macro.
- skip empty mask nybbles - when checking which bits are set in a mask, skip to the second nybble if the first is empty; continue to the next row if the second nybble is empty. On my files this was faster than checking and skipping over the entire byte, but this should be benchmarked with a bigger fileset.
- speed up first pass - the first pass over the IT is just checking which channels are active. It doesn't actually consume any of the information requested by masks, but it needs to advance the file pointer according to the less significant nybble of the mask. I index into a nybble-to-advancement mapping instead of using control flow to advance the file pointer. (This is less obviously interpretable to a casual reader.)

The performance improvement of each change for reduction in instructions spent in `it_load` (roughly half these for the total load time improvement):
- cache channel event bases - 4%
- skip empty mask nybbles - 7%
- speed up first pass - 3%