### PR TITLE
Fix loading edge case STMs with an EOF byte of 2.

### DIFF
--- a/docs/Changelog
+++ b/docs/Changelog
@@ -3,6 +3,7 @@ Stable versions
 
 4.6.1 (?):
 	Changes by Alice Rowan:
+	- Fix loading edge case STMs with an EOF byte of 2.
 	- Fix loading Imago Orpheus modules with null instrument magic
 	  strings, bidirectional samples, and disabled default panning.
 	- Faster IT loading by buffering pattern, sample, and comment reads.

--- a/src/loaders/stm_load.c
+++ b/src/loaders/stm_load.c
@@ -95,7 +95,9 @@ static int stm_test(HIO_HANDLE * f, char *t, const int start)
 	if (libxmp_test_name(buf, 8, 0))	/* Tracker name should be ASCII */
 		return -1;
 
-	if (hio_read8(f) != 0x1a)
+	/* EOF should be 0x1a. putup10.stm and putup11.stm have 2 instead. */
+	buf[0] = hio_read8(f);
+	if (buf[0] != 0x1a && buf[0] != 0x02)
 		return -1;
 
 	if (hio_read8(f) > STM_TYPE_MODULE)


### PR DESCRIPTION
All STMs should have 0x1a as their EOF byte, but two broken STM modules "putup10.stm" and "putup11.stm" have a value of 2 here instead. This patch allows those modules to load.

Fixes #700.