### PR TITLE
Fixed the finetune in MultiTracker loader

### DIFF
--- a/src/loaders/mtm_load.c
+++ b/src/loaders/mtm_load.c
@@ -171,7 +171,7 @@ static int mtm_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		}
 
 		sub->vol = mih.volume;
-		sub->fin = mih.finetune;
+		sub->fin = (int8)(mih.finetune << 4);
 		sub->pan = 0x80;
 		sub->sid = i;
 


### PR DESCRIPTION
The finetune need to be shifted in the MultiTracker loader. If not, finetuned samples was played out of tune. This can especially be heard in module L'Esperanza.mtm from position 39 (the flute).

[L'Esperanza.zip](https://github.com/libxmp/libxmp/files/13539499/L.Esperanza.zip)
