### PR TITLE
stb_vorbis CVE fixes

### DIFF
--- a/src/loaders/vorbis.c
+++ b/src/loaders/vorbis.c
@@ -3707,8 +3707,13 @@ static int start_decoder(vorb *f)
    f->comment_list = NULL;
    if (f->comment_list_length > 0)
    {
-      f->comment_list = (char**) setup_malloc(f, sizeof(char*) * (f->comment_list_length));
-      if (f->comment_list == NULL)                  return error(f, VORBIS_outofmem);
+      len = sizeof(char*) * f->comment_list_length;
+      f->comment_list = (char**) setup_malloc(f, len);
+      if (f->comment_list == NULL) {
+         f->comment_list_length = 0;
+         return error(f, VORBIS_outofmem);
+      }
+      memset(f->comment_list, 0, len);
    }
 
    for(i=0; i < f->comment_list_length; ++i) {

--- a/src/loaders/vorbis.c
+++ b/src/loaders/vorbis.c
@@ -3707,9 +3707,12 @@ static int start_decoder(vorb *f)
    f->comment_list = NULL;
    if (f->comment_list_length > 0)
    {
+      if (INT_MAX / sizeof(char*) < f->comment_list_length)
+          goto no_comment;
       len = sizeof(char*) * f->comment_list_length;
       f->comment_list = (char**) setup_malloc(f, len);
       if (f->comment_list == NULL) {
+         no_comment:
          f->comment_list_length = 0;
          return error(f, VORBIS_outofmem);
       }

--- a/src/loaders/vorbis.c
+++ b/src/loaders/vorbis.c
@@ -979,7 +979,7 @@ static void *make_block_array(void *mem, int count, int size)
 
 static void *setup_malloc(vorb *f, int sz)
 {
-   if (sz <= 0) return NULL; /* libxmp hack: https://github.com/nothings/stb/issues/1248 */
+   if (sz <= 0 || INT_MAX - 7 < sz) return NULL;
    sz = (sz+7) & ~7; // round up to nearest 8 for alignment of future allocs.
    f->setup_memory_required += sz;
    if (f->alloc.alloc_buffer) {

--- a/src/loaders/vorbis.c
+++ b/src/loaders/vorbis.c
@@ -967,6 +967,8 @@ static int error(vorb *f, enum STBVorbisError e)
 // given a sufficiently large block of memory, make an array of pointers to subblocks of it
 static void *make_block_array(void *mem, int count, int size)
 {
+  if (!mem) return NULL;
+  else {
    int i;
    void ** p = (void **) mem;
    char *q = (char *) (p + count);
@@ -975,6 +977,7 @@ static void *make_block_array(void *mem, int count, int size)
       q += size;
    }
    return p;
+  }
 }
 
 static void *setup_malloc(vorb *f, int sz)
@@ -999,7 +1002,7 @@ static void setup_free(vorb *f, void *p)
 
 static void *setup_temp_malloc(vorb *f, int sz)
 {
-   if (sz <= 0) return NULL; /* libxmp hack: https://github.com/nothings/stb/issues/1248 */
+   if (sz <= 0 || INT_MAX - 7 < sz) return NULL;
    sz = (sz+7) & ~7; // round up to nearest 8 for alignment of future allocs.
    if (f->alloc.alloc_buffer) {
       if (f->temp_offset - sz < f->setup_offset) return NULL;

--- a/src/loaders/vorbis.c
+++ b/src/loaders/vorbis.c
@@ -1798,7 +1798,7 @@ static int codebook_decode_scalar(vorb *f, Codebook *c)
 
 #define DECODE(var,f,c)                                       \
    DECODE_RAW(var,f,c)                                        \
-   if (c->sparse) var = c->sorted_values[var];
+   if (c->sparse && var >= 0) var = c->sorted_values[var];
 
 #ifndef STB_VORBIS_DIVIDES_IN_CODEBOOK
   #define DECODE_VQ(var,f,c)   DECODE_RAW(var,f,c)


### PR DESCRIPTION
The following 4 patches are based on PR submissions at mainstream.
I modified most of the patches and notified the patch author about
them.

(1) Fix CVE-2023-45679 and CVE-2023-45680:
Based on the patches by Jaroslav Lobačevski (@JarLob) submitted
to mainstream at: nothings/stb#1557 and nothings/stb#1558
GHSL-2023-169/CVE-2023-45679: Attempt to free an uninitialized memory pointer in vorbis_deinit()
GHSL-2023-170/CVE-2023-45680: Null pointer dereference in vorbis_deinit()

(2) Fix CVE-2023-45681 (integer overflow):
Based on patch by Jaroslav Lobačevski (@JarLob) submitted to
mainstream at nothings/stb#1559
GHSL-2023-171/CVE-2023-45681: Out of bounds heap buffer write

(3) Fix CVE-2023-45676 and CVE-2023-45677 (integer overflow in setup_malloc()):
Based on the patches by Jaroslav Lobačevski (@JarLob) submitted
to mainstream at: nothings/stb#1554 and nothings/stb#1555
GHSL-2023-166/CVE-2023-45676: Multi-byte write heap buffer overflow in start_decoder()
GHSL-2023-167/CVE-2023-45677: Heap buffer out of bounds write in start_decoder()

(4) Fix CVE-2023-45682:
Based on patch by Jaroslav Lobačevski (@JarLob) submitted to
mainstream at nothings/stb#1560
GHSL-2023-172/CVE-2023-45682: Wild address read in vorbis_decode_packet_rest()

(5) apply CVE-2023-45676/CVE-2023-45677 fix to setup_temp_malloc(), 
and fix make_block_array() for it along the way.

(The first two patches don't actually affect us because we disable the comments
support, but I included them here for completeness..)

@AliceLR: Please review.
