### PR TITLE
Atari Octalyser pattern loop fix

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -266,6 +266,7 @@ int libxmp_snprintf (char *, size_t, const char *, ...) LIBXMP_ATTRIB_PRINTF(3,4
 #define QUIRK_S3MLOOP	(1 << 0)	/* S3M loop mode */
 #define QUIRK_ENVFADE	(1 << 1)	/* Fade at end of envelope */
 #define QUIRK_PROTRACK	(1 << 2)	/* Use Protracker-specific quirks */
+#define QUIRK_OCTALYSERLOOP	(1 << 3)	/* Octalyser (Atari) loop mode */
 #define QUIRK_ST3BUGS	(1 << 4)	/* Scream Tracker 3 bug compatibility */
 #define QUIRK_FINEFX	(1 << 5)	/* Enable 0xf/0xe for fine effects */
 #define QUIRK_VSALL	(1 << 6)	/* Volume slides in all frames */
@@ -432,6 +433,7 @@ struct flow_control {
 	int loop_chn;
 #ifndef LIBXMP_CORE_PLAYER
 	int jump_in_pat;
+	int loop_set;
 #endif
 
 	struct pattern_loop *loop;

--- a/src/effects.c
+++ b/src/effects.c
@@ -106,6 +106,9 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 	struct flow_control *f = &p->flow;
 	uint8 note, fxp, fxt;
 	int h, l;
+#ifndef LIBXMP_CORE_PLAYER
+	int is_octalyser;
+#endif
 
 	/* key_porta is IT only */
 	if (m->read_event_type != READ_EVENT_IT) {
@@ -417,7 +420,7 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 			break;
 		case EX_PATTERN_LOOP:	/* Loop pattern */
 #ifndef LIBXMP_CORE_PLAYER
-			int is_octalyser = HAS_QUIRK(QUIRK_OCTALYSERLOOP);
+			is_octalyser = HAS_QUIRK(QUIRK_OCTALYSERLOOP);
 
 			/* Atari Octalyser seems to have the loop arguments as global instead
 			 * of channel separated. At least what I can see from 8er-mod.

--- a/src/loaders/mod_load.c
+++ b/src/loaders/mod_load.c
@@ -876,6 +876,7 @@ skip_test:
 	break;
     case TRACKER_OCTALYSER:
 	tracker = "Octalyser";
+	m->quirk |= QUIRK_OCTALYSERLOOP;
 	break;
     case TRACKER_DIGITALTRACKER:
 	tracker = "Digital Tracker";

--- a/src/player.c
+++ b/src/player.c
@@ -1999,6 +1999,10 @@ int xmp_play_frame(xmp_context opaque)
 		return -XMP_END;
 	}
 
+#ifndef LIBXMP_CORE_PLAYER
+	f->loop_set = 0;
+#endif
+
 	/* check reposition */
 	if (p->ord != p->pos) {
 		int start = m->seq_data[p->sequence].entry_point;

--- a/test-dev/Makefile.in
+++ b/test-dev/Makefile.in
@@ -53,7 +53,8 @@ EFFECTS		= 0_arpeggio 1_slide_up 2_slide_down \
 		  it_g00_nosuck it_l00_nosuck it_fine_vol_row_delay \
 		  far_slide far_toneporta far_retrig far_noteoffset \
 		  far_vibrato far_vibrato_per far_volslide far_tempo \
-		  ult_toneporta
+		  ult_toneporta \
+		  oct_pattern_loop1 oct_pattern_loop2
 
 API		= get_format_list create_context free_context \
 		  test_module load_module load_module_from_memory \

--- a/test-dev/all_tests.txt
+++ b/test-dev/all_tests.txt
@@ -350,6 +350,8 @@ test_effect_far_vibrato_per
 test_effect_far_volslide
 test_effect_far_tempo
 test_effect_ult_toneporta
+test_effect_oct_pattern_loop1
+test_effect_oct_pattern_loop2
 test_prev_order_start
 test_prev_order_skip
 test_prev_order_start_seq

--- a/test-dev/test_effect_oct_pattern_loop1.c
+++ b/test-dev/test_effect_oct_pattern_loop1.c
@@ -1,0 +1,55 @@
+#include "test.h"
+#include "../src/effects.h"
+
+static int patternloop_Vals1[] = {
+	0, 0, 0,
+	1, 1, 1,
+	1, 1, 1,
+	1, 1, 1,
+	1, 1, 1,
+	1, 1, 1,
+	2, 2, 2
+};
+
+/* Atari Octalyser seems to have the loop arguments as global
+ * instead of channel separated. At least what I can see from
+ * 8er-mod.
+ *
+ * The replay sources that I got my hands on, does not support E6x,
+ * so I can not verify it.
+ *
+ * This test simulate what 8er-mod module does by having both E60
+ * and E6x on the same row in different channels. The behaviour
+ * should loop the same row and then continue.
+ */
+
+TEST(test_effect_oct_pattern_loop1)
+{
+	xmp_context opaque;
+	struct context_data *ctx;
+	struct xmp_frame_info info;
+	int i;
+
+	opaque = xmp_create_context();
+	ctx = (struct context_data *)opaque;
+
+ 	create_simple_module(ctx, 2, 2);
+	set_quirk(ctx, QUIRK_OCTALYSERLOOP, READ_EVENT_MOD);
+
+	new_event(ctx, 0, 0, 0, 60, 1, 0, 0, 0, FX_SPEED, 3);
+	new_event(ctx, 0, 1, 0, 0, 0, 0, FX_EXTENDED, 0x60, 0, 0);
+	new_event(ctx, 0, 1, 1, 0, 0, 0, FX_EXTENDED, 0x64, 0, 0);
+	new_event(ctx, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0);
+
+	xmp_start_player(opaque, 44100, 0);
+
+	for (i = 0; i < 7 * 3; i++) {
+		xmp_play_frame(opaque);
+		xmp_get_frame_info(opaque, &info);
+		fail_unless(info.row == patternloop_Vals1[i], "row set error");
+	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
+}
+END_TEST

--- a/test-dev/test_effect_oct_pattern_loop2.c
+++ b/test-dev/test_effect_oct_pattern_loop2.c
@@ -1,0 +1,68 @@
+#include "test.h"
+#include "../src/effects.h"
+
+static int patternloop_Vals2[] = {
+	0, 0, 0,
+	1, 1, 1,
+	2, 2, 2,
+	3, 3, 3,
+	1, 1, 1,
+	2, 2, 2,
+	3, 3, 3,
+	1, 1, 1,
+	2, 2, 2,
+	3, 3, 3,
+	1, 1, 1,
+	2, 2, 2,
+	3, 3, 3,
+	1, 1, 1,
+	2, 2, 2,
+	3, 3, 3,
+	4, 4, 4
+};
+
+/* Atari Octalyser seems to have the loop arguments as global
+ * instead of channel separated. At least what I can see from
+ * 8er-mod.
+ *
+ * The replay sources that I got my hands on, does not support E6x,
+ * so I can not verify it.
+ *
+ * However, Dammed Illusion have the same E6x on multiple channels,
+ * so this test will check if the correct behavior still happens. It
+ * should just handle the effects as "one".
+ */
+
+TEST(test_effect_oct_pattern_loop2)
+{
+	xmp_context opaque;
+	struct context_data *ctx;
+	struct xmp_frame_info info;
+	int i;
+
+	opaque = xmp_create_context();
+	ctx = (struct context_data *)opaque;
+
+ 	create_simple_module(ctx, 2, 2);
+	set_quirk(ctx, QUIRK_OCTALYSERLOOP, READ_EVENT_MOD);
+
+	new_event(ctx, 0, 0, 0, 60, 1, 0, 0, 0, FX_SPEED, 3);
+	new_event(ctx, 0, 1, 0, 0, 0, 0, FX_EXTENDED, 0x60, 0, 0);
+	new_event(ctx, 0, 1, 1, 0, 0, 0, FX_EXTENDED, 0x60, 0, 0);
+	new_event(ctx, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0);
+	new_event(ctx, 0, 3, 0, 0, 0, 0, FX_EXTENDED, 0x64, 0, 0);
+	new_event(ctx, 0, 3, 1, 0, 0, 0, FX_EXTENDED, 0x64, 0, 0);
+	new_event(ctx, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0);
+
+	xmp_start_player(opaque, 44100, 0);
+
+	for (i = 0; i < 14 * 3; i++) {
+		xmp_play_frame(opaque);
+		xmp_get_frame_info(opaque, &info);
+		fail_unless(info.row == patternloop_Vals2[i], "row set error");
+	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
+}
+END_TEST


### PR DESCRIPTION
Atari Octalyser seems to have the pattern loop arguments as global instead of channel separated. This will fix that, so 8er-mod module will play correctly.

I have attached the modules mentioned in my comments.

[Octalyser.zip](https://github.com/libxmp/libxmp/files/13852599/Octalyser.zip)
