### PR TITLE
Add module size in struct xmp_module_info

### DIFF
--- a/include/xmp.h
+++ b/include/xmp.h
@@ -300,6 +300,7 @@ struct xmp_module_info {
 	char *comment;			/* Comment text, if any */
 	int num_sequences;		/* Number of valid sequences */
 	struct xmp_sequence *seq_data;	/* Pointer to sequence data */
+	int size;			/* Module size */
 };
 
 struct xmp_channel_info {

--- a/src/load.c
+++ b/src/load.c
@@ -394,6 +394,7 @@ int xmp_load_module(xmp_context opaque, const char *path)
 	ctx->m.filename = NULL;
 	ctx->m.dirname = NULL;
 	ctx->m.basename = NULL;
+	ctx->m.size = hio_size(h);
 #endif
 
 	ret = load_module(opaque, h);

--- a/src/player.c
+++ b/src/player.c
@@ -2200,6 +2200,7 @@ void xmp_get_module_info(xmp_context opaque, struct xmp_module_info *info)
 	info->num_sequences = m->num_sequences;
 	info->seq_data = m->seq_data;
 	info->vol_base = m->volbase;
+	info->size = m->size;
 }
 
 void xmp_get_frame_info(xmp_context opaque, struct xmp_frame_info *info)


### PR DESCRIPTION
Here's a patch I've been carrying locally a while, as the underlying changes for an xmp-cli change I'll create a PR for as well.

This is the kind of change which warrants both a version bump, so that libxmp clients can depend on the new version, and sadly, a recompilation of libxmp clients, at least on 32-bit platforms where the size of the struct changes. On 64-bit platforms, the new field could technically be stored in the padding bytes between integers and pointers in xmp_module_info.

I did think about using a `long` type for this new field, as `xmp_load_module_from_memory()` and `xmp_load_module_from_file()` take a `long` size (though the latter doesn't use its size argument). However, `src/common.h::module_data::size` has `int` type anyway.

IME on other projects, version bumps are usually a copy-paste-modify-check job, so I _can_ make a patch (attempting to check for locations which could have appeared since the previous version bump), but maintainers are usually the ones doing version bumps, so I'll let you do it, unless you want me to :)