### PR TITLE
Fix XM envelope sustain points that exist on a zero-length loop.

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -137,6 +137,9 @@ static int update_envelope_generic(struct xmp_envelope *env, int x, int release)
 	 * envelope loop end and the key is released, FT2 escapes the loop
 	 * while IT runs another iteration. (See EnvLoops.xm in the OpenMPT
 	 * test cases.)
+	 * TODO: this is a bit suspicious, has little relation to the above
+	 * description, and had to be removed from the XM handler because it
+	 * broke a module (fade_2_grey_visage.xm). Retesting is required.
 	 */
 	if (has_loop && has_sus && sus == lpe) {
 		if (!release)
@@ -168,6 +171,12 @@ static int update_envelope_generic(struct xmp_envelope *env, int x, int release)
 	 * Real Tracker 2.
 	 */
 	if (has_loop && x >= data[lpe]) {
+		/* FT2 and IT envelopes behave in a different way regarding
+		 * loops, sustain and release. When the sustain point is at the
+		 * end of the envelope loop end and the key is released, FT2
+		 * escapes the loop while IT runs another iteration.
+		 * (See OpenMPT EnvLoops.xm)
+		 */
 		if (!(release && has_sus && sus == lpe))
 			x = data[lps];
 	}
@@ -190,17 +199,6 @@ static int update_envelope_xm(struct xmp_envelope *env, int x, int release)
 	lpe = env->lpe << 1;
 	sus = env->sus << 1;
 
-	/* FT2 and IT envelopes behave in a different way regarding loops,
-	 * sustain and release. When the sustain point is at the end of the
-	 * envelope loop end and the key is released, FT2 escapes the loop
-	 * while IT runs another iteration. (See EnvLoops.xm in the OpenMPT
-	 * test cases.)
-	 */
-	if (has_loop && has_sus && sus == lpe) {
-		if (!release)
-			has_sus = 0;
-	}
-
 	/* If the envelope point is set to somewhere after the sustain point
 	 * or sustain loop, enable release to prevent the envelope point from
 	 * returning to the sustain point or loop start. (See Filip Skutela's
@@ -221,10 +219,16 @@ static int update_envelope_xm(struct xmp_envelope *env, int x, int release)
 	 *
 	 * If the envelope point is set to somewhere after the sustain point
 	 * or sustain loop, the loop point is ignored to prevent the envelope
-	 * point to return to the sustain point or loop start. (See Filip Skutela's
-	 * farewell_tear.xm or Ebony Owl Netsuke.xm.)
+	 * point from returning to the sustain point or loop start.
+	 * (See Filip Skutela's farewell_tear.xm or Ebony Owl Netsuke.xm.)
 	*/
 	if (has_loop && x == data[lpe]) {
+		/* FT2 and IT envelopes behave in a different way regarding
+		 * loops, sustain and release. When the sustain point is at the
+		 * end of the envelope loop end and the key is released, FT2
+		 * escapes the loop while IT runs another iteration.
+		 * (See OpenMPT EnvLoops.xm)
+		 */
 		if (!(release && has_sus && sus == lpe))
 			x = data[lps];
 	}

--- a/test-dev/test_player_xm_envelope_zero_loop.c
+++ b/test-dev/test_player_xm_envelope_zero_loop.c
@@ -4,6 +4,11 @@
  * the end of the envelope loop, and only loops if the envelope position
  * is exactly at the envelope end. This causes it to entirely skip loops
  * where the start and end points are the same.
+ *
+ * However, if the sustain point is on the same position and has NOT
+ * been released, it will be held at this position (this was previously
+ * broken by an old incorrect bugfix). See fade_2_grey_visage.xm
+ * instrument 3, orders 3-4, channels 8-9.
  */
 TEST(test_player_xm_envelope_zero_loop)
 {
@@ -21,7 +26,13 @@ TEST(test_player_xm_envelope_zero_loop)
 	set_instrument_envelope(ctx, 0, 1, 16, 0);
 	set_instrument_envelope_loop(ctx, 0, 0, 0);
 
+	set_instrument_envelope(ctx, 1, 0, 0, 64);
+	set_instrument_envelope(ctx, 1, 1, 16, 0);
+	set_instrument_envelope_loop(ctx, 1, 0, 0);
+	set_instrument_envelope_sus(ctx, 1, 0);
+
 	new_event(ctx, 0, 0, 0, 60, 1, 0, 0, 0, 0, 0);
+	new_event(ctx, 0, 0, 1, 60, 2, 0, 0, 0, 0, 0);
 	set_quirk(ctx, QUIRKS_FT2 | QUIRK_FT2ENV, READ_EVENT_FT2);
 
 	xmp_start_player(opaque, 44100, 0);
@@ -31,6 +42,7 @@ TEST(test_player_xm_envelope_zero_loop)
 		xmp_get_frame_info(opaque, &fi);
 
 		fail_unless(fi.channel_info[0].volume == 64 - (i * 4), "wrong volume");
+		fail_unless(fi.channel_info[1].volume == 64, "wrong volume (sus)");
 	}
 
 	for (i = 0; i < 16; i++) {
@@ -38,6 +50,7 @@ TEST(test_player_xm_envelope_zero_loop)
 		xmp_get_frame_info(opaque, &fi);
 
 		fail_unless(fi.channel_info[0].volume == 0, "volume not zero");
+		fail_unless(fi.channel_info[1].volume == 64, "volume not 64 (sus)");
 	}
 
 	xmp_release_module(opaque);


### PR DESCRIPTION
An old bugfix(?) in the XM and generic envelope handlers was disabling the sustain point when it exists on the end of the envelope loop. This doesn't really line up with reality and, in the case of XM, was definitely wrong.

[fade_2_grey_visage.xm](https://modarchive.org/index.php?request=view_by_moduleid&query=134790) contains an instrument (3) with a sustain point on the same envelope point as the loop start and loop end. In XM, loops where the start and end are on the same point are ignored, but the sustain point in this case is supposed to work. The module relies on the sustain loop working in this situation in positions 3 and 4 (channels 8 and 9).

This bug was previously masked because XM loops with the start and the end on the same point were NOT being ignored (fixed in #678).

See issue #710.