### PR TITLE
exclude_match: add HTML files

### DIFF
--- a/src/depackers/depacker.c
+++ b/src/depackers/depacker.c
@@ -357,6 +357,8 @@ int libxmp_exclude_match(const char *name)
 		"*.EXE", "*.exe",
 		"*.COM", "*.com",
 		"*.README", "*.readme", "*.Readme", "*.ReadMe",
+		"*.HTM", "*.htm",
+		"*.HTML", "*.html",
 		/* Found in Spark archives. */
 		"\\?From", "From\\?", "InfoText",
 		NULL


### PR DESCRIPTION
A few ZIPs I have from an artist include HTML READMEs alongside their .diz files, which is preventing libxmp from detecting them properly.