### PR TITLE
Fix config version variables.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
-m4_define([libxmp_VERSION_MAJOR_m4], 4)
-m4_define([libxmp_VERSION_MINOR_m4], 6)
-m4_define([libxmp_VERSION_PATCH_m4], 0)
+m4_define([libxmp_VERSION_MAJOR_m4], [4])
+m4_define([libxmp_VERSION_MINOR_m4], [6])
+m4_define([libxmp_VERSION_PATCH_m4], [0])
 m4_define([libxmp_VERSION_m4], libxmp_VERSION_MAJOR_m4[.]libxmp_VERSION_MINOR_m4[.]libxmp_VERSION_PATCH_m4)
 
 AC_PREREQ(2.60)

--- a/lite/configure.ac
+++ b/lite/configure.ac
@@ -1,6 +1,6 @@
-m4_define([libxmplite_VERSION_MAJOR_m4], 4)
-m4_define([libxmplite_VERSION_MINOR_m4], 6)
-m4_define([libxmplite_VERSION_PATCH_m4], 0)
+m4_define([libxmplite_VERSION_MAJOR_m4], [4])
+m4_define([libxmplite_VERSION_MINOR_m4], [6])
+m4_define([libxmplite_VERSION_PATCH_m4], [0])
 m4_define([libxmplite_VERSION_m4], libxmplite_VERSION_MAJOR_m4[.]libxmplite_VERSION_MINOR_m4[.]libxmplite_VERSION_PATCH_m4)
 
 AC_PREREQ(2.60)


### PR DESCRIPTION
I am by no means an autoconf/workingset master, but...

```config
VERSION_MAJOR	= @libxmp_VERSION_MAJOR@
VERSION_MINOR	= @libxmp_VERSION_MINOR@
VERSION_RELEASE	= @libxmp_VERSION_PATCH@

VERSION		= @libxmp_VERSION@
```

This was producing library links literally named like the following:

```
libxmp.so.@libxmp_VERSION_MAJOR@
libxmp.so.@libxmp_VERSION@
```

Now:

```
libxmp.so.4
libxmp.so.4.6.0
```

```sh
$ uname -srvmo
Linux 6.7.7-100.fc38.x86_64 #1 SMP PREEMPT_DYNAMIC Fri Mar  1 16:51:49 UTC 2024 x86_64 GNU/Linux
$ autoconf --version | head -n 1
autoconf (GNU Autoconf) 2.71
```

Am I missing something?

https://www.gnu.org/software/autoconf/manual/autoconf-2.64/html_node/Setting-Output-Variables.html