### PR TITLE
Fix GCC 14 -Wcalloc-transposed-args warnings.

### DIFF
--- a/src/med_extras.c
+++ b/src/med_extras.c
@@ -385,10 +385,10 @@ int libxmp_med_new_module_extras(struct module_data *m)
 
 	me = (struct med_module_extras *)m->extra;
 
-	me->vol_table = (uint8 **) calloc(sizeof(uint8 *), mod->ins);
+	me->vol_table = (uint8 **) calloc(mod->ins, sizeof(uint8 *));
 	if (me->vol_table == NULL)
 		return -1;
-	me->wav_table = (uint8 **) calloc(sizeof(uint8 *), mod->ins);
+	me->wav_table = (uint8 **) calloc(mod->ins, sizeof(uint8 *));
 	if (me->wav_table == NULL)
 		return -1;
 

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -989,11 +989,11 @@ int libxmp_mixer_on(struct context_data *ctx, int rate, int format, int c4rate)
 {
 	struct mixer_data *s = &ctx->s;
 
-	s->buffer = (char *) calloc(2, XMP_MAX_FRAMESIZE);
+	s->buffer = (char *) calloc(XMP_MAX_FRAMESIZE, sizeof(int16));
 	if (s->buffer == NULL)
 		goto err;
 
-	s->buf32 = (int32 *) calloc(sizeof(int32), XMP_MAX_FRAMESIZE);
+	s->buf32 = (int32 *) calloc(XMP_MAX_FRAMESIZE, sizeof(int32));
 	if (s->buf32 == NULL)
 		goto err1;
 


### PR DESCRIPTION
Fixes GCC's latest contribution to compiler warnings :) found while testing Fedora 40.
Note `XMP_MAX_FRAMESIZE` is the number of frames in the buffer, not the size of an individual frame in the buffer (hence I reversed both instances in mixer.c instead of just the one that triggered the warning).

```
CC src/med_extras.lo
src/med_extras.c: In function ‘libxmp_med_new_module_extras’:
src/med_extras.c:388:50: warning: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
  388 |         me->vol_table = (uint8 **) calloc(sizeof(uint8 *), mod->ins);
      |                                                  ^~~~~
src/med_extras.c:388:50: note: earlier argument should specify number of elements, later size of each element
src/med_extras.c:391:50: warning: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
  391 |         me->wav_table = (uint8 **) calloc(sizeof(uint8 *), mod->ins);
      |                                                  ^~~~~
src/med_extras.c:391:50: note: earlier argument should specify number of elements, later size of each element
```
```
CC src/mixer.lo
src/mixer.c: In function ‘libxmp_mixer_on’:
src/mixer.c:996:44: warning: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
  996 |         s->buf32 = (int32 *) calloc(sizeof(int32), XMP_MAX_FRAMESIZE);
      |                                            ^~~~~
src/mixer.c:996:44: note: earlier argument should specify number of elements, later size of each element
```

edit: commit push CI failure is bogus ("autoconf: command not found").