### PR TITLE
CI, macOS: run 'brew install autoconf'

### DIFF
--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -156,6 +156,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Install dependencies
+        run: brew install autoconf
       - name: CMake configure for Intel
         run: |
           cmake . -DCMAKE_BUILD_TYPE=Debug -DWITH_UNIT_TESTS=ON -B build


### PR DESCRIPTION
To fix `autoconf: command not found` errors.

From CI logs:
```
Run brew install autoconf cmake
Warning: Treating cmake as a formula. For the cask, use homebrew/cask/cmake or specify the `--cask` flag.
Warning: cmake 3.29.2 is already installed and up-to-date.
To reinstall 3.29.2, run:
  brew reinstall cmake
==> Downloading https://ghcr.io/v2/homebrew/core/autoconf/manifests/2.72
==> Fetching dependencies for autoconf: m4
==> Downloading https://ghcr.io/v2/homebrew/core/m4/manifests/1.4.19
==> Fetching m4
==> Downloading https://ghcr.io/v2/homebrew/core/m4/blobs/sha256:f42d89db519a07d67bcaead6c8dfb2da45e8266bebb996dd8b3f19b1ca13b8a0
==> Fetching autoconf
==> Downloading https://ghcr.io/v2/homebrew/core/autoconf/blobs/sha256:bb39057e87dd9cb940bee15ff5b5172952a0350e59b14a6f55b8006a07813186
==> Installing dependencies for autoconf: m4
==> Installing autoconf dependency: m4
==> Downloading https://ghcr.io/v2/homebrew/core/m4/manifests/1.4.19
Already downloaded: /Users/runner/Library/Caches/Homebrew/downloads/5b2a7f715487b7377e409e8ca58569040cd89f33859f691210c58d94410fd33b--m4-1.4.19.bottle_manifest.json
==> Pouring m4--1.4.19.arm64_sonoma.bottle.tar.gz
🍺  /opt/homebrew/Cellar/m4/1.4.19: 13 files, 726.2KB
==> Installing autoconf
==> Pouring autoconf--2.72.arm64_sonoma.bottle.tar.gz
🍺  /opt/homebrew/Cellar/autoconf/2.72: 71 files, 3.6MB
```
