### PR TITLE
windows C4996 warning fixes and include tidy-ups :

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -159,6 +159,7 @@ typedef int tst_uint64[2 * (8 == sizeof(uint64)) - 1];
 #define EVENT(a,c,r)	m->mod.xxt[TRACK_NUM((a),(c))]->event[r]
 
 #ifdef _MSC_VER
+
 #define D_CRIT "  Error: "
 #define D_WARN "Warning: "
 #define D_INFO "   Info: "
@@ -212,16 +213,6 @@ static void __inline D_(const char *text, ...) {
 
 #endif	/* !_MSC_VER */
 
-#ifdef _MSC_VER
-#define dup _dup
-#define fileno _fileno
-#define strnicmp _strnicmp
-#define fdopen _fdopen
-#define open _open
-#define close _close
-#define unlink _unlink
-#define S_ISDIR(x) (((x)&_S_IFDIR) != 0)
-#endif
 #if defined(_WIN32) || defined(__WATCOMC__) /* in win32.c */
 #define USE_LIBXMP_SNPRINTF
 /* MSVC 2015+ has C99 compliant snprintf and vsnprintf implementations.
@@ -230,6 +221,9 @@ static void __inline D_(const char *text, ...) {
  * functions. Additionally, GCC may optimize some calls to those functions. */
 #if defined(_MSC_VER) && _MSC_VER >= 1900
 #undef USE_LIBXMP_SNPRINTF
+#endif
+#if defined(__MINGW32__) && !defined(__MINGW_FEATURES__)
+#define __MINGW_FEATURES__ 0 /* to avoid -Wundef from old mingw.org headers */
 #endif
 #if defined(__MINGW32__) && defined(__USE_MINGW_ANSI_STDIO) && (__USE_MINGW_ANSI_STDIO != 0)
 #undef USE_LIBXMP_SNPRINTF

--- a/src/mkstemp.c
+++ b/src/mkstemp.c
@@ -41,22 +41,23 @@
  * SUCH DAMAGE.
  */
 
-#include <fcntl.h>
-#include <errno.h>
-
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
-#endif
-#if defined(_MSC_VER) || defined(__WATCOMC__)
+#include <io.h>
+#include <process.h>
+#elif defined(__WATCOMC__)
 #include <io.h>
 #else
 #include <unistd.h>
 #endif
-#ifdef _MSC_VER
-#include <process.h>
+
+#include <fcntl.h>
+#include <errno.h>
+
+#ifdef _WIN32
 #define open _open
 #endif
 #ifndef O_BINARY

--- a/src/tempfile.c
+++ b/src/tempfile.c
@@ -28,7 +28,7 @@
 
 #if !(defined(LIBXMP_NO_PROWIZARD) && defined(LIBXMP_NO_DEPACKERS))
 
-#if defined(_MSC_VER) || defined(__WATCOMC__)
+#if defined(_WIN32) || defined(__WATCOMC__)
 #include <io.h>
 #else
 #include <unistd.h>
@@ -42,6 +42,10 @@
 
 #ifdef _WIN32
 
+#define fdopen _fdopen
+#define close _close
+#define unlink _unlink
+#define umask _umask
 int mkstemp(char *);
 
 static int get_temp_dir(char *buf, size_t size)

--- a/test-dev/test.h
+++ b/test-dev/test.h
@@ -1,7 +1,7 @@
 #include <xmp.h>
 #include <math.h>
 
-#if defined(_MSC_VER) || defined(__WATCOMC__)
+#if defined(_WIN32) || defined(__WATCOMC__)
 #include <io.h>
 #else
 #include <unistd.h>
@@ -9,6 +9,10 @@
 
 #include "../src/common.h"
 #include "../src/md5.h"
+
+#ifdef _WIN32
+#define unlink _unlink
+#endif
 
 #define TMP_FILE ".test"
 


### PR DESCRIPTION
Defines in common.h to avoid MSVC C4996 warnings were defunct, because:
(i) dup, fileno, strnicmp, and S_ISDIR() aren't used anywhere, at least
not for windows, and:
(ii) the rest requires including io.h, and common.h used to be included
before it resulting in a mess.

Therefore, remove those defines from common.h, and define the necessary
ones only where they are needed, namely mkstemp.c and tempfile.c.

Also define `__MINGW_FEATURES__` as 0 if not already defined, in order to
avoid loud -Wundef warnings from old mingw.org headers.
