### PR TITLE
fix ctest regression in test/test.c after PR/721 merge :

### DIFF
--- a/lite/test/CMakeLists.txt
+++ b/lite/test/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 if(POLICY CMP0079)
     cmake_policy(SET CMP0079 NEW)
 endif()
@@ -16,3 +15,4 @@ endif()
 target_link_libraries(libxmp-test XMP_IF)
 
 add_test(NAME libxmp-test COMMAND libxmp-test WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
+target_compile_definitions(libxmp-test PRIVATE LIBXMP_CORE_PLAYER)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 if(POLICY CMP0079)
     cmake_policy(SET CMP0079 NEW)
 endif()
@@ -21,3 +20,6 @@ endif()
 target_link_libraries(libxmp-test XMP_IF)
 
 add_test(NAME libxmp-test COMMAND libxmp-test WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
+if(LIBXMP_DISABLE_DEPACKERS)
+    target_compile_definitions(libxmp-test PRIVATE LIBXMP_NO_DEPACKERS)
+endif()


### PR DESCRIPTION
- ctest would fail in lite distribution,
- ctest would fail in full tree with depackers disabled.
