### PR TITLE
cmake: tweak openbsd detection in BUILD_LITE case.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,7 @@ if(BUILD_SHARED)
             if(APPLE)
                 set_property(TARGET xmp_lite_shared APPEND_STRING PROPERTY
                              LINK_FLAGS " -Wl,-undefined,error")
-            elseif(NOT CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
+            elseif(NOT CMAKE_SYSTEM_NAME MATCHES "kOpenBSD.*|OpenBSD.*")
                 cmake_push_check_state()
                 set(CMAKE_REQUIRED_FLAGS "-Wl,--no-undefined")
                 check_c_compiler_flag("" HAVE_NO_UNDEFINED)


### PR DESCRIPTION
to match commit 1ff5c5a539e6497a27dfd998dfdebbcb708daff1 (was missed in PR/721)