### PR TITLE
Replace rand() with a built-in reentrant alternative.

### DIFF
--- a/Makefile.vc
+++ b/Makefile.vc
@@ -48,6 +48,7 @@ OBJS	= \
  src\effects.obj \
  src\mixer.obj \
  src\mix_all.obj \
+ src\rng.obj \
  src\load_helpers.obj \
  src\load.obj \
  src\hio.obj \
@@ -236,6 +237,7 @@ LITE_OBJS	= \
  src\lite\lite-hio.obj \
  src\lite\lite-smix.obj \
  src\lite\lite-memio.obj \
+ src\lite\lite-rng.obj \
  src\lite\lite-win32.obj \
  src\lite\lite-common.obj \
  src\lite\lite-itsex.obj \

--- a/cmake/libxmp-sources.cmake
+++ b/cmake/libxmp-sources.cmake
@@ -17,6 +17,7 @@ set(LIBXMP_SRC_LIST
     src/effects.c
     src/mixer.c
     src/mix_all.c
+    src/rng.c
     src/load_helpers.c
     src/load.c
     src/hio.c
@@ -201,6 +202,7 @@ set(LIBXMP_SRC_LIST_LITE
     src/lite/lite-hio.c
     src/lite/lite-smix.c
     src/lite/lite-memio.c
+    src/lite/lite-rng.c
     src/lite/lite-win32.c
     src/lite/lite-common.c
     src/lite/lite-itsex.c

--- a/lite/src/Makefile
+++ b/lite/src/Makefile
@@ -2,11 +2,12 @@
 SRC_OBJS	= virtual.o format.o period.o player.o read_event.o \
 		  misc.o dataio.o lfo.o scan.o control.o filter.o \
 		  effects.o mixer.o mix_all.o load_helpers.o load.o \
-		  filetype.o hio.o smix.o memio.o win32.o
+		  filetype.o hio.o smix.o memio.o rng.o win32.o
 
 SRC_DFILES	= Makefile $(SRC_OBJS:.o=.c) md5.c md5.h common.h effects.h \
 		  format.h lfo.h list.h mixer.h period.h player.h virtual.h \
-		  precomp_lut.h hio.h callbackio.h memio.h mdataio.h tempfile.h
+		  precomp_lut.h hio.h callbackio.h memio.h mdataio.h tempfile.h \
+		  rng.h
 
 SRC_PATH	= src
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,13 +1,13 @@
 
 SRC_OBJS	= virtual.o format.o period.o player.o read_event.o dataio.o \
 		  misc.o mkstemp.o md5.o lfo.o scan.o control.o far_extras.o \
-		  med_extras.o filter.o effects.o mixer.o mix_all.o \
+		  med_extras.o filter.o effects.o mixer.o mix_all.o rng.o \
 		  load_helpers.o load.o hio.o hmn_extras.o extras.o smix.o \
 		  filetype.o memio.o tempfile.o mix_paula.o miniz_tinfl.o win32.o
 
 SRC_DFILES	= Makefile $(SRC_OBJS:.o=.c) common.h effects.h \
 		  format.h lfo.h list.h mixer.h period.h player.h virtual.h \
-		  md5.h precomp_lut.h tempfile.h med_extras.h hio.h \
+		  md5.h precomp_lut.h tempfile.h med_extras.h hio.h rng.h \
 		  hmn_extras.h extras.h callbackio.h memio.h mdataio.h \
 		  far_extras.h paula.h precomp_blep.h miniz.h
 

--- a/src/common.h
+++ b/src/common.h
@@ -523,11 +523,16 @@ struct mixer_data {
 	double pbase;		/* period base */
 };
 
+struct rng_state {
+	unsigned state;
+};
+
 struct context_data {
 	struct player_data p;
 	struct mixer_data s;
 	struct module_data m;
 	struct smix_data smix;
+	struct rng_state rng;
 	int state;
 };
 

--- a/src/control.c
+++ b/src/control.c
@@ -23,6 +23,7 @@
 #include "format.h"
 #include "virtual.h"
 #include "mixer.h"
+#include "rng.h"
 
 const char *xmp_version LIBXMP_EXPORT_VAR = XMP_VERSION;
 const unsigned int xmp_vercode LIBXMP_EXPORT_VAR = XMP_VERCODE;
@@ -39,6 +40,7 @@ xmp_context xmp_create_context(void)
 	ctx->state = XMP_STATE_UNLOADED;
 	ctx->m.defpan = 100;
 	ctx->s.numvoc = SMIX_NUMVOC;
+	libxmp_init_random(&ctx->rng);
 
 	return (xmp_context)ctx;
 }

--- a/src/lfo.c
+++ b/src/lfo.c
@@ -21,6 +21,7 @@
  */
 
 #include "lfo.h"
+#include "rng.h"
 
 #define WAVEFORM_SIZE 64
 
@@ -35,7 +36,7 @@ static const int sine_wave[WAVEFORM_SIZE] = {
 
 /* LFO */
 
-static int get_lfo_mod(struct lfo *lfo)
+static int get_lfo_mod(struct context_data *ctx, struct lfo *lfo)
 {
 	int val;
 
@@ -53,7 +54,7 @@ static int get_lfo_mod(struct lfo *lfo)
 		val = lfo->phase < WAVEFORM_SIZE / 2 ? 255 : -255;
 		break;
 	case 3: /* random */
-		val = ((rand() & 0x1ff) - 256);
+		val = libxmp_get_random(&ctx->rng, 512) - 256;
 		break;
 #ifndef LIBXMP_CORE_PLAYER
 	case 669: /* 669 vibrato */
@@ -67,7 +68,7 @@ static int get_lfo_mod(struct lfo *lfo)
 	return val * lfo->depth;
 }
 
-static int get_lfo_st3(struct lfo *lfo)
+static int get_lfo_st3(struct context_data *ctx, struct lfo *lfo)
 {
 	if (lfo->rate == 0) {
 		return 0;
@@ -79,14 +80,14 @@ static int get_lfo_st3(struct lfo *lfo)
 		return val * lfo->depth;
 	}
 
-	return get_lfo_mod(lfo);
+	return get_lfo_mod(ctx, lfo);
 }
 
 /* From OpenMPT VibratoWaveforms.xm:
  * "Generally the vibrato and tremolo tables are identical to those that
  *  ProTracker uses, but the vibrato’s “ramp down” table is upside down."
  */
-static int get_lfo_ft2(struct lfo *lfo)
+static int get_lfo_ft2(struct context_data *ctx, struct lfo *lfo)
 {
 	if (lfo->rate == 0)
 		return 0;
@@ -98,17 +99,17 @@ static int get_lfo_ft2(struct lfo *lfo)
 		return val * lfo->depth;
 	}
 
-	return get_lfo_mod(lfo);
+	return get_lfo_mod(ctx, lfo);
 }
 
 #ifndef LIBXMP_CORE_DISABLE_IT
 
-static int get_lfo_it(struct lfo *lfo)
+static int get_lfo_it(struct context_data *ctx, struct lfo *lfo)
 {
 	if (lfo->rate == 0)
 		return 0;
 
-	return get_lfo_st3(lfo);
+	return get_lfo_st3(ctx, lfo);
 }
 
 #endif
@@ -119,19 +120,19 @@ int libxmp_lfo_get(struct context_data *ctx, struct lfo *lfo, int is_vibrato)
 
 	switch (m->read_event_type) {
 	case READ_EVENT_ST3:
-		return get_lfo_st3(lfo);
+		return get_lfo_st3(ctx, lfo);
 	case READ_EVENT_FT2:
 		if (is_vibrato) {
-			return get_lfo_ft2(lfo);
+			return get_lfo_ft2(ctx, lfo);
 		} else {
-			return get_lfo_mod(lfo);
+			return get_lfo_mod(ctx, lfo);
 		}
 #ifndef LIBXMP_CORE_DISABLE_IT
 	case READ_EVENT_IT:
-		return get_lfo_it(lfo);
+		return get_lfo_it(ctx, lfo);
 #endif
 	default:
-		return get_lfo_mod(lfo);
+		return get_lfo_mod(ctx, lfo);
 	}
 }
 

--- a/src/lite/Makefile
+++ b/src/lite/Makefile
@@ -3,7 +3,7 @@
 LITE		= lite-virtual.o lite-format.o lite-period.o lite-player.o lite-read_event.o \
 		  lite-misc.o lite-dataio.o lite-lfo.o lite-scan.o lite-control.o lite-filter.o \
 		  lite-effects.o lite-mixer.o lite-mix_all.o lite-load_helpers.o lite-load.o \
-		  lite-filetype.o lite-hio.o lite-smix.o lite-memio.o lite-win32.o \
+		  lite-filetype.o lite-hio.o lite-smix.o lite-memio.o lite-rng.o lite-win32.o \
 		  \
 		  lite-common.o lite-itsex.o lite-sample.o \
 		  lite-xm_load.o lite-mod_load.o lite-s3m_load.o lite-it_load.o

--- a/src/lite/lite-rng.c
+++ b/src/lite/lite-rng.c
@@ -1,0 +1,4 @@
+#ifndef LIBXMP_CORE_PLAYER
+#define LIBXMP_CORE_PLAYER
+#endif
+#include "../rng.c"

--- a/src/loaders/flt_load.c
+++ b/src/loaders/flt_load.c
@@ -23,6 +23,7 @@
 #include "loader.h"
 #include "mod.h"
 #include "../period.h"
+#include "../rng.h"
 
 static int flt_test(HIO_HANDLE *, char *, const int);
 static int flt_load(struct module_data *, HIO_HANDLE *, const int);
@@ -118,6 +119,7 @@ static int read_am_instrument(struct module_data *m, HIO_HANDLE *nt, int i)
 	struct xmp_envelope *vol_env = &xxi->aei;
 	struct xmp_envelope *freq_env = &xxi->fei;
 	struct am_instrument am;
+	struct rng_state rng;
 	char *wave;
 	int a, b;
 	int8 am_noise[1024];
@@ -162,8 +164,9 @@ static int read_am_instrument(struct module_data *m, HIO_HANDLE *nt, int i)
 		xxs->lps = 0;
 		xxs->lpe = 1024;
 
+		libxmp_init_random(&rng);
 		for (j = 0; j < 1024; j++)
-			am_noise[j] = rand() % 256;
+			am_noise[j] = libxmp_get_random(&rng, 256);
 
 		wave = (char *)&am_noise[0];
 	}

--- a/src/read_event.c
+++ b/src/read_event.c
@@ -25,6 +25,7 @@
 #include "effects.h"
 #include "virtual.h"
 #include "period.h"
+#include "rng.h"
 
 #ifndef LIBXMP_CORE_PLAYER
 #include "med_extras.h"
@@ -1234,7 +1235,7 @@ static int read_event_it(struct context_data *ctx, struct xmp_event *e, int chn)
 			rvv = sub->rvv & 0xff;
 			if (rvv) {
 				CLAMP(rvv, 0, 100);
-				xc->rvv = rand() % (rvv + 1);
+				xc->rvv = libxmp_get_random(&ctx->rng, rvv + 1);
 			} else {
 				xc->rvv = 0;
 			}
@@ -1243,7 +1244,7 @@ static int read_event_it(struct context_data *ctx, struct xmp_event *e, int chn)
 			rvv = (sub->rvv & 0xff00) >> 8;
 			if (rvv) {
 				CLAMP(rvv, 0, 64);
-				xc->rpv = rand() % (rvv + 1) - (rvv / 2);
+				xc->rpv = libxmp_get_random(&ctx->rng, rvv + 1) - (rvv / 2);
 			} else {
 				xc->rpv = 0;
 			}

--- a/src/rng.c
+++ b/src/rng.c
@@ -1,0 +1,55 @@
+/* Extended Module Player
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "common.h"
+#include "rng.h"
+
+#include <time.h>
+
+static unsigned libxmp_random_step_xorshift32(unsigned state)
+{
+	if (state == 0) state = 1;
+	state ^= state << 13u;
+	state ^= state >> 17u;
+	return   state <<  5u;
+}
+
+unsigned libxmp_get_random(struct rng_state *rng, unsigned range)
+{
+	unsigned state = libxmp_random_step_xorshift32(rng->state);
+	rng->state = state;
+
+	return (uint64)range * state >> 32u;
+}
+
+void libxmp_set_random(struct rng_state *rng, unsigned state)
+{
+	rng->state = state;
+}
+
+void libxmp_init_random(struct rng_state *rng)
+{
+	rng->state = (unsigned) time(NULL);
+	libxmp_get_random(rng, 0);
+	libxmp_get_random(rng, 0);
+	libxmp_get_random(rng, 0);
+}

--- a/src/rng.h
+++ b/src/rng.h
@@ -1,0 +1,38 @@
+/* Extended Module Player
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef LIBXMP_RNG_H
+#define LIBXMP_RNG_H
+
+#include "common.h"
+
+LIBXMP_BEGIN_DECLS
+
+/* Returns a pseudo-random unsigned integer between 0 and (range - 1) and
+ * steps the player's internal random state. If range = 0, returns 0. */
+unsigned libxmp_get_random	(struct rng_state *, unsigned range);
+void	 libxmp_set_random	(struct rng_state *, unsigned seed);
+void	 libxmp_init_random	(struct rng_state *);
+
+LIBXMP_END_DECLS
+
+#endif /* LIBXMP_RNG_H */

--- a/test-dev/CMakeLists.txt
+++ b/test-dev/CMakeLists.txt
@@ -24,6 +24,7 @@ set(DEVTEST_SRC
     ../src/period.c
     ../src/memio.c
     ../src/dataio.c
+    ../src/rng.c
     ../src/scan.c
     ../src/loaders/itsex.c
     ../src/loaders/sample.c

--- a/test-dev/Makefile.in
+++ b/test-dev/Makefile.in
@@ -662,7 +662,7 @@ SRC_PATH	= ../src
 
 TEST_INTERNAL	= md5.o win32.o hio.o load_helpers.o loaders/itsex.o dataio.o scan.o \
 		  loaders/sample.o loaders/common.o filetype.o period.o memio.o \
-		  depackers/xfnmatch.o far_extras.o lfo.o
+		  depackers/xfnmatch.o far_extras.o lfo.o rng.o
 
 T_OBJS 		= $(addprefix $(TEST_PATH)/,$(TEST_OBJS)) \
 		  $(addprefix $(SRC_PATH)/,$(TEST_INTERNAL))
@@ -769,8 +769,8 @@ $(addprefix $(SRC_PATH)/,$(TEST_INTERNAL)): $(SRC_PATH)/player.h
 #
 
 FUZZLIB_PATH		= .fuzzer
-FUZZ_ASAN_FLAGS		= -O3 -fsanitize=fuzzer,address,undefined -fno-sanitize-recover=all -fno-sanitize=shift-base -fno-omit-frame-pointer -g -DLIBXMP_LIBFUZZER
-FUZZ_MSAN_FLAGS		= -O3 -fsanitize=fuzzer,memory -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer -g -DLIBXMP_LIBFUZZER
+FUZZ_ASAN_FLAGS		= -O3 -fsanitize=fuzzer,address,undefined -fno-sanitize-recover=all -fno-sanitize=shift-base -fno-omit-frame-pointer -g -DLIBXMP_LIBFUZZER -I../include -I../src
+FUZZ_MSAN_FLAGS		= -O3 -fsanitize=fuzzer,memory -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer -g -DLIBXMP_LIBFUZZER -I../include -I../src
 FUZZLIB_ASAN_FLAGS	= $(subst fuzzer,fuzzer-no-link,$(FUZZ_ASAN_FLAGS))
 FUZZLIB_MSAN_FLAGS	= $(subst fuzzer,fuzzer-no-link,$(FUZZ_MSAN_FLAGS))
 FUZZ_CC			?= clang

--- a/test-dev/Makefile.vc
+++ b/test-dev/Makefile.vc
@@ -26,6 +26,7 @@ XMP_SOURCES	= \
  ..\src\depackers\xfnmatch.c \
  ..\src\far_extras.c \
  ..\src\lfo.c \
+ ..\src\rng.c \
 
 ALL_SOURCES	= $(SOURCES) $(TEST_SOURCES) $(XMP_SOURCES)
 

--- a/test-dev/libxmp_fuzz.c
+++ b/test-dev/libxmp_fuzz.c
@@ -28,7 +28,10 @@
 #include <sys/stat.h>
 
 #include "../include/xmp.h"
+#include "../src/common.h"
+#include "../src/rng.h"
 
+#define FIXED_SEED		0xbaadcafeUL
 #define DEFAULT_FRAMES_TO_PLAY	64
 
 #ifndef LIBXMP_LIBFUZZER
@@ -63,6 +66,8 @@ static inline int libxmp_test_function(xmp_context opaque, const uint8_t *data,
 	int test_error = 0;
 	int test_print = 0;
 	int load_error;
+
+	libxmp_set_random(&((struct context_data *)opaque)->rng, FIXED_SEED);
 
 	/* Fuzz loaders. */
 	load_error = xmp_load_module_from_memory(opaque, data, size);

--- a/watcom.mif
+++ b/watcom.mif
@@ -64,6 +64,7 @@ OBJS= &
  src/effects.obj &
  src/mixer.obj &
  src/mix_all.obj &
+ src/rng.obj &
  src/load_helpers.obj &
  src/load.obj &
  src/hio.obj &
@@ -245,6 +246,7 @@ LITE_OBJS= &
  src/lite/lite-hio.obj &
  src/lite/lite-smix.obj &
  src/lite/lite-memio.obj &
+ src/lite/lite-rng.obj &
  src/lite/lite-win32.obj &
  src/lite/lite-common.obj &
  src/lite/lite-itsex.obj &


### PR DESCRIPTION
This patch replaces all rand() usage with a built-in implementation of xorshift32. This is not an especially cryptographically good PRNG but it is fast (4 bitshifts, 3 XORs, 1 multiply for output) and produces reasonably "random" output.

Unlike rand(), this implementation is reentrant i.e. it easily supports multiple different concurrent states and doesn't cause any race conditions with caller code outside of libxmp.

This implementation will also behave exactly the same on all platforms given a fixed seed, which allows the fuzzer/xmpchk and the storlek_20.it test to use fixed seeds. (Lack of doing this has caused failures of this test on NetBSD and in neumatho's C# port.)

Fixes #685 and #723.