### PR TITLE
conditionalize use of __forceinline

### DIFF
--- a/src/depackers/miniz_zip.h
+++ b/src/depackers/miniz_zip.h
@@ -203,9 +203,8 @@ MINIZ_EXPORT mz_bool mz_zip_reader_end(mz_zip_archive *pZip);
 
 /* -------- ZIP reading or writing */
 
-#ifdef DEBUG /* libxmp uses this only in debug mode */
+/* libxmp uses this only in debug mode in _D(...) calls. */
 MINIZ_EXPORT const char *mz_zip_get_error_string(mz_zip_error mz_err);
-#endif
 
 /* MZ_TRUE if the archive file entry is a directory entry. */
 MINIZ_EXPORT mz_bool mz_zip_reader_is_file_a_directory(mz_zip_archive *pZip, mz_uint file_index);

--- a/src/loaders/vorbis.c
+++ b/src/loaders/vorbis.c
@@ -613,8 +613,10 @@ enum STBVorbisError
 #include <limits.h>
 
 #ifndef STB_FORCEINLINE
-    #if defined(_MSC_VER)
+    #if defined(_MSC_VER) && (_MSC_VER >= 1200)
         #define STB_FORCEINLINE __forceinline
+    #elif defined(_MSC_VER)
+        #define STB_FORCEINLINE static __inline
     #elif (defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 2))) || defined(__clang__)
         #define STB_FORCEINLINE static __inline __attribute__((always_inline))
     #else

--- a/src/miniz.h
+++ b/src/miniz.h
@@ -337,8 +337,10 @@ typedef int mz_bool;
 
 #define MZ_READ_LE64(p) (((mz_uint64)MZ_READ_LE32(p)) | (((mz_uint64)MZ_READ_LE32((const mz_uint8 *)(p) + sizeof(mz_uint32))) << 32U))
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
 #define MZ_FORCEINLINE __forceinline
+#elif defined(_MSC_VER)
+#define MZ_FORCEINLINE __inline
 #elif (defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 2))) || defined(__clang__)
 #define MZ_FORCEINLINE __inline__ __attribute__((__always_inline__))
 #else


### PR DESCRIPTION
Was feeling more retro than usual: With this patch applied, I was able
to build libxmp using msvc 4.0 and 4.2, if you can believe it...
