### PR TITLE
use response files with msvc and watcom makefiles.

### DIFF
--- a/Makefile.os2
+++ b/Makefile.os2
@@ -24,7 +24,7 @@ USE_DEPACKERS	= 1
 
 CC = wcc386
 SYSTEM = os2v2
-SYSTEM_DLL = os2v2_dll
+TARGET_OS2=yes
 
 CFLAGS = -zq -bt=os2 -bm -fp5 -fpi87 -mf -oeatxh -w4 -ei -zp8
 # newer OpenWatcom versions enable W303 by default.
@@ -34,5 +34,27 @@ CFLAGS += -wcd=303
 CFLAGS += -5s
 CFLAGS += -I"$(%WATCOM)/h/os2" -I"$(%WATCOM)/h"
 
-TARGET_OS2=yes
 !include watcom.mif
+
+$(LNKFILE):
+	@echo Creating linker file: $@
+	@%create $@
+	@%append $@ SYSTEM os2v2_dll INITINSTANCE TERMINSTANCE
+	@%append $@ NAME $(DLLNAME)
+	@for %i in ($(ALL_OBJS)) do @%append $@ FILE %i
+	@%append $@ OPTION QUIET
+	@%append $@ OPTION MANYAUTODATA
+	@%append $@ OPTION IMPF=$(EXPNAME)
+	@%append $@ OPTION MAP=$(MAPNAME)
+	@%append $@ OPTION SHOWDEAD
+$(LNKLITE):
+	@echo Creating linker file: $@
+	@%create $@
+	@%append $@ SYSTEM os2v2_dll INITINSTANCE TERMINSTANCE
+	@%append $@ NAME $(DLLNAME_LITE)
+	@for %i in ($(LITE_OBJS)) do @%append $@ FILE %i
+	@%append $@ OPTION QUIET
+	@%append $@ OPTION MANYAUTODATA
+	@%append $@ OPTION IMPF=$(EXPNAME_LITE)
+	@%append $@ OPTION MAP=$(MAPNAME_LITE)
+	@%append $@ OPTION SHOWDEAD

--- a/Makefile.vc
+++ b/Makefile.vc
@@ -256,20 +256,26 @@ TEST	= src\md5.obj test\test.obj
 all: $(DLL)
 lite: $(DLL_LITE)
 
+# use a temporary response file
 $(DLL): $(ALL_OBJS)
-	$(LD) $(LDFLAGS) /OUT:$(DLL) $(ALL_OBJS)
-
+	$(LD) $(LDFLAGS) /OUT:$(DLL) @<<libxmp.rsp
+		$(ALL_OBJS)
+<<
 $(DLL_LITE): $(LITE_OBJS)
-	$(LD) $(LDFLAGS) /OUT:$(DLL_LITE) $(LITE_OBJS)
+	$(LD) $(LDFLAGS) /OUT:$(DLL_LITE) @<<libxmplt.rsp
+		$(LITE_OBJS)
+<<
 
 clean:
-	-del $(OBJS)
-	-del $(DEPACKER_OBJS)
-	-del $(PROWIZ_OBJS)
-	-del $(LITE_OBJS)
-	-del $(TEST)
+	-del src\*.obj
+	-del src\loaders\*.obj
+	-del src\loaders\prowizard\*.obj
+	-del src\depackers\*.obj
+	-del src\depackers\lhasa\*.obj
+	-del src\lite\*.obj
+	-del test\*.obj
 	-del test\*.dll test\*.exe
-	-del $(DLL) $(DLL_LITE) *.lib *.exp
+	-del *.dll *.lib *.exp
 
 check: $(TEST)
 	$(LD) /RELEASE /OUT:test\libxmp-test.exe $(TEST) libxmp.lib

--- a/Makefile.vc.in
+++ b/Makefile.vc.in
@@ -49,20 +49,26 @@ TEST	= src\md5.obj test\test.obj
 all: $(DLL)
 lite: $(DLL_LITE)
 
+# use a temporary response file
 $(DLL): $(ALL_OBJS)
-	$(LD) $(LDFLAGS) /OUT:$(DLL) $(ALL_OBJS)
-
+	$(LD) $(LDFLAGS) /OUT:$(DLL) @<<libxmp.rsp
+		$(ALL_OBJS)
+<<
 $(DLL_LITE): $(LITE_OBJS)
-	$(LD) $(LDFLAGS) /OUT:$(DLL_LITE) $(LITE_OBJS)
+	$(LD) $(LDFLAGS) /OUT:$(DLL_LITE) @<<libxmplt.rsp
+		$(LITE_OBJS)
+<<
 
 clean:
-	-del $(OBJS)
-	-del $(DEPACKER_OBJS)
-	-del $(PROWIZ_OBJS)
-	-del $(LITE_OBJS)
-	-del $(TEST)
+	-del src\*.obj
+	-del src\loaders\*.obj
+	-del src\loaders\prowizard\*.obj
+	-del src\depackers\*.obj
+	-del src\depackers\lhasa\*.obj
+	-del src\lite\*.obj
+	-del test\*.obj
 	-del test\*.dll test\*.exe
-	-del $(DLL) $(DLL_LITE) *.lib *.exp
+	-del *.dll *.lib *.exp
 
 check: $(TEST)
 	$(LD) /RELEASE /OUT:test\libxmp-test.exe $(TEST) libxmp.lib

--- a/Makefile.w32
+++ b/Makefile.w32
@@ -24,7 +24,6 @@ USE_DEPACKERS	= 1
 
 CC = wcc386
 SYSTEM = nt
-SYSTEM_DLL = nt_dll
 
 CFLAGS = -zq -bt=nt -bm -fp5 -fpi87 -mf -oeatxh -w4 -ei -zp8
 # newer OpenWatcom versions enable W303 by default.
@@ -35,3 +34,24 @@ CFLAGS += -5s
 CFLAGS += -I"$(%WATCOM)/h/nt" -I"$(%WATCOM)/h"
 
 !include watcom.mif
+
+$(LNKFILE):
+	@echo * Creating linker file: $@
+	@%create $@
+	@%append $@ SYSTEM nt_dll INITINSTANCE TERMINSTANCE
+	@%append $@ NAME $(DLLNAME)
+	@for %i in ($(ALL_OBJS)) do @%append $@ FILE %i
+	@%append $@ OPTION QUIET
+	@%append $@ OPTION IMPF=$(EXPNAME)
+	@%append $@ OPTION MAP=$(MAPNAME)
+	@%append $@ OPTION SHOWDEAD
+$(LNKLITE):
+	@echo * Creating linker file: $@
+	@%create $@
+	@%append $@ SYSTEM nt_dll INITINSTANCE TERMINSTANCE
+	@%append $@ NAME $(DLLNAME_LITE)
+	@for %i in ($(LITE_OBJS)) do @%append $@ FILE %i
+	@%append $@ OPTION QUIET
+	@%append $@ OPTION IMPF=$(EXPNAME_LITE)
+	@%append $@ OPTION MAP=$(MAPNAME_LITE)
+	@%append $@ OPTION SHOWDEAD

--- a/lite/Makefile.os2
+++ b/lite/Makefile.os2
@@ -15,7 +15,7 @@ target = dll
 
 CC = wcc386
 SYSTEM = os2v2
-SYSTEM_DLL = os2v2_dll
+TARGET_OS2=yes
 
 CFLAGS = -zq -bt=os2 -bm -fp5 -fpi87 -mf -oeatxh -w4 -ei -zp8
 # newer OpenWatcom versions enable W303 by default.
@@ -25,5 +25,16 @@ CFLAGS += -wcd=303
 CFLAGS += -5s
 CFLAGS += -I"$(%WATCOM)/h/os2" -I"$(%WATCOM)/h"
 
-TARGET_OS2=yes
 !include watcom.mif
+
+$(LNKFILE):
+	@echo Creating linker file: $@
+	@%create $@
+	@%append $@ SYSTEM os2v2_dll INITINSTANCE TERMINSTANCE
+	@%append $@ NAME $(DLLNAME)
+	@for %i in ($(OBJS)) do @%append $@ FILE %i
+	@%append $@ OPTION QUIET
+	@%append $@ OPTION MANYAUTODATA
+	@%append $@ OPTION IMPF=$(EXPNAME)
+	@%append $@ OPTION MAP=$(MAPNAME)
+	@%append $@ OPTION SHOWDEAD

--- a/lite/Makefile.vc.in
+++ b/lite/Makefile.vc.in
@@ -26,13 +26,18 @@ TEST	= src\md5.obj test\test.obj
 
 all: $(DLL)
 
+# use a temporary response file
 $(DLL): $(OBJS)
-	$(LD) $(LDFLAGS) $(OBJS)
+	$(LD) $(LDFLAGS) @<<libxmp-lite.rsp
+		$(OBJS)
+<<
 
 clean:
-	-del $(OBJS) $(DLL) *.lib *.exp
-	-del $(TEST)
+	-del src\*.obj
+	-del src\loaders\*.obj
+	-del test\*.obj
 	-del test\*.dll test\*.exe
+	-del *.dll *.lib *.exp
 
 check: $(TEST)
 	$(LD) /RELEASE /OUT:test\libxmp-lite-test.exe $(TEST) libxmp-lite.lib

--- a/lite/Makefile.w32
+++ b/lite/Makefile.w32
@@ -15,7 +15,6 @@ target = dll
 
 CC = wcc386
 SYSTEM = nt
-SYSTEM_DLL = nt_dll
 
 CFLAGS = -zq -bt=nt -bm -fp5 -fpi87 -mf -oeatxh -w4 -ei -zp8
 # newer OpenWatcom versions enable W303 by default.
@@ -26,3 +25,14 @@ CFLAGS += -5s
 CFLAGS += -I"$(%WATCOM)/h/nt" -I"$(%WATCOM)/h"
 
 !include watcom.mif
+
+$(LNKFILE):
+	@echo Creating linker file: $@
+	@%create $@
+	@%append $@ SYSTEM nt_dll INITINSTANCE TERMINSTANCE
+	@%append $@ NAME $(DLLNAME)
+	@for %i in ($(OBJS)) do @%append $@ FILE %i
+	@%append $@ OPTION QUIET
+	@%append $@ OPTION IMPF=$(EXPNAME)
+	@%append $@ OPTION MAP=$(MAPNAME)
+	@%append $@ OPTION SHOWDEAD

--- a/lite/watcom.mif.in
+++ b/lite/watcom.mif.in
@@ -15,10 +15,13 @@ LIBNAME=libxmplt.lib
 DLLNAME=libxmp-lite.dll
 LIBNAME=libxmp-lite.lib
 !endif
+LNKFILE=libxmplt.lnk
 EXPNAME=xmp-lite.exp
 # Note: not libxmp.map...
 MAPNAME=xmp-lite.map
 LIBSTATIC=xmplite_static.lib
+LBCFILE=libxmplt.lbc
+
 TESTNAME=libxmp-test.exe
 
 !ifeq target static
@@ -50,12 +53,12 @@ test/test.obj: test/test.c
 	$(CC) $(CFLAGS) -fo=$^@ $<
 
 # rely on symbol name, not ordinal: -irn switch of wlib is default, but -inn is not.
-$(DLLNAME) $(LIBNAME) $(EXPNAME): $(OBJS)
-	wlink NAM $(DLLNAME) SYSTEM $(SYSTEM_DLL) INITINSTANCE TERMINSTANCE OP QUIET FIL {$(OBJS)} OP IMPF=$(EXPNAME) OP MAP=$(MAPNAME)
+$(DLLNAME) $(LIBNAME) $(EXPNAME): $(OBJS) $(LNKFILE)
+	wlink @$(LNKFILE)
 	wlib -q -b -n -c -pa -s -t -zld -ii -io -inn $(LIBNAME) +$(DLLNAME)
 
-$(LIBSTATIC): $(OBJS)
-	wlib -q -b -n -c -pa -s -t -zld -ii -io $@ $(OBJS)
+$(LIBSTATIC): $(OBJS) $(LBCFILE)
+	wlib -q -b -n -c -pa -s -t -zld -ii -io $@ @$(LBCFILE)
 
 test/$(TESTNAME): $(BLD_LIB) $(TEST_OBJS)
 	wlink NAM test/$(TESTNAME) SYSTEM $(SYSTEM) OP QUIET LIBR {$(BLD_LIB)} FIL {$(TEST_OBJS)}
@@ -73,7 +76,7 @@ clean: .symbolic
 	rm -f $(TEST_OBJS)
 
 distclean: clean .symbolic
-	rm -f *.err
+	rm -f *.err *.lnk *.lbc
 	rm -f $(DLLNAME) $(EXPNAME) $(MAPNAME) $(LIBNAME) $(LIBSTATIC) test/$(DLLNAME) test/$(TESTNAME)
 
 !ifdef __UNIX__
@@ -81,3 +84,9 @@ CMD_CP=cp
 !else
 CMD_CP=copy
 !endif
+
+$(LBCFILE):
+	@echo Creating wlib commands file: $@
+	@%create $@
+	@for %i in ($(OBJS)) do @%append $@ +%i
+

--- a/watcom.mif
+++ b/watcom.mif
@@ -15,8 +15,11 @@ DLLNAME=libxmp.dll
 EXPNAME=libxmp.exp
 # Note: not libxmp.map...
 MAPNAME=xmp.map
+LNKFILE=libxmp.lnk
 LIBNAME=libxmp.lib
 LIBSTATIC=xmp_static.lib
+LBCFILE=libxmp.lbc
+
 TESTNAME=libxmp-test.exe
 
 # the lite version:
@@ -27,10 +30,12 @@ LIBNAME_LITE=libxmplt.lib
 DLLNAME_LITE=libxmp-lite.dll
 LIBNAME_LITE=libxmp-lite.lib
 !endif
+LNKLITE=libxmplt.lnk
 EXPNAME_LITE=xmp-lite.exp
 # Note: not libxmp.map...
 MAPNAME_LITE=xmp-lite.map
 LIBSTATIC_LITE=xmplite_static.lib
+LBCLITE=libxmplt.lbc
 
 !ifeq target static
 CFLAGS += $(STATICFLAGS)
@@ -285,17 +290,17 @@ test/test.obj: test/test.c
 	$(CC) $(CFLAGS) -fo=$^@ $<
 
 # rely on symbol name, not ordinal: -irn switch of wlib is default, but -inn is not.
-$(DLLNAME) $(LIBNAME) $(EXPNAME): $(ALL_OBJS)
-	wlink NAM $(DLLNAME) SYSTEM $(SYSTEM_DLL) INITINSTANCE TERMINSTANCE OP QUIET FIL {$(ALL_OBJS)} OP IMPF=$(EXPNAME) OP MAP=$(MAPNAME)
+$(DLLNAME) $(LIBNAME) $(EXPNAME): $(ALL_OBJS) $(LNKFILE)
+	wlink @$(LNKFILE)
 	wlib -q -b -n -c -pa -s -t -zld -ii -io -inn $(LIBNAME) +$(DLLNAME)
-$(DLLNAME_LITE) $(LIBNAME_LITE) $(EXPNAME_LITE): $(LITE_OBJS)
-	wlink NAM $(DLLNAME_LITE) SYSTEM $(SYSTEM_DLL) INITINSTANCE TERMINSTANCE OP QUIET FIL {$(LITE_OBJS)} OP IMPF=$(EXPNAME_LITE) OP MAP=$(MAPNAME_LITE)
+$(DLLNAME_LITE) $(LIBNAME_LITE) $(EXPNAME_LITE): $(LITE_OBJS) $(LNKLITE)
+	wlink @$(LNKLITE)
 	wlib -q -b -n -c -pa -s -t -zld -ii -io -inn $(LIBNAME_LITE) +$(DLLNAME_LITE)
 
-$(LIBSTATIC): $(ALL_OBJS)
-	wlib -q -b -n -c -pa -s -t -zld -ii -io $@ $(ALL_OBJS)
-$(LIBSTATIC_LITE): $(LITE_OBJS)
-	wlib -q -b -n -c -pa -s -t -zld -ii -io $@ $(LITE_OBJS)
+$(LIBSTATIC): $(ALL_OBJS) $(LBCFILE)
+	wlib -q -b -n -c -pa -s -t -zld -ii -io $@ @$(LBCFILE)
+$(LIBSTATIC_LITE): $(LITE_OBJS) $(LBCLITE)
+	wlib -q -b -n -c -pa -s -t -zld -ii -io $@ @$(LBCLITE)
 
 test/$(TESTNAME): $(BLD_LIB) $(TEST_OBJS)
 	wlink NAM test/$(TESTNAME) SYSTEM $(SYSTEM) OP QUIET LIBR {$(BLD_LIB)} FIL {$(TEST_OBJS)}
@@ -316,7 +321,7 @@ clean: .symbolic
 	rm -f test/*.obj
 
 distclean: clean .symbolic
-	rm -f *.err
+	rm -f *.err *.lnk *.lbc
 	rm -f $(DLLNAME) $(EXPNAME) $(MAPNAME) $(LIBNAME) $(LIBSTATIC) test/$(DLLNAME) test/$(TESTNAME)
 	rm -f $(DLLNAME_LITE) $(EXPNAME_LITE) $(MAPNAME_LITE) $(LIBNAME_LITE) $(LIBSTATIC_LITE)
 
@@ -325,3 +330,14 @@ CMD_CP=cp
 !else
 CMD_CP=copy
 !endif
+
+$(LBCFILE):
+	@echo Creating wlib commands file: $@
+	@%create $@
+	@for %i in ($(ALL_OBJS)) do @%append $@ +%i
+
+$(LBCLITE):
+	@echo Creating wlib commands file: $@
+	@%create $@
+	@for %i in ($(LITE_OBJS)) do @%append $@ +%i
+

--- a/watcom.mif.in
+++ b/watcom.mif.in
@@ -15,8 +15,11 @@ DLLNAME=libxmp.dll
 EXPNAME=libxmp.exp
 # Note: not libxmp.map...
 MAPNAME=xmp.map
+LNKFILE=libxmp.lnk
 LIBNAME=libxmp.lib
 LIBSTATIC=xmp_static.lib
+LBCFILE=libxmp.lbc
+
 TESTNAME=libxmp-test.exe
 
 # the lite version:
@@ -27,10 +30,12 @@ LIBNAME_LITE=libxmplt.lib
 DLLNAME_LITE=libxmp-lite.dll
 LIBNAME_LITE=libxmp-lite.lib
 !endif
+LNKLITE=libxmplt.lnk
 EXPNAME_LITE=xmp-lite.exp
 # Note: not libxmp.map...
 MAPNAME_LITE=xmp-lite.map
 LIBSTATIC_LITE=xmplite_static.lib
+LBCLITE=libxmplt.lbc
 
 !ifeq target static
 CFLAGS += $(STATICFLAGS)
@@ -78,17 +83,17 @@ test/test.obj: test/test.c
 	$(CC) $(CFLAGS) -fo=$^@ $<
 
 # rely on symbol name, not ordinal: -irn switch of wlib is default, but -inn is not.
-$(DLLNAME) $(LIBNAME) $(EXPNAME): $(ALL_OBJS)
-	wlink NAM $(DLLNAME) SYSTEM $(SYSTEM_DLL) INITINSTANCE TERMINSTANCE OP QUIET FIL {$(ALL_OBJS)} OP IMPF=$(EXPNAME) OP MAP=$(MAPNAME)
+$(DLLNAME) $(LIBNAME) $(EXPNAME): $(ALL_OBJS) $(LNKFILE)
+	wlink @$(LNKFILE)
 	wlib -q -b -n -c -pa -s -t -zld -ii -io -inn $(LIBNAME) +$(DLLNAME)
-$(DLLNAME_LITE) $(LIBNAME_LITE) $(EXPNAME_LITE): $(LITE_OBJS)
-	wlink NAM $(DLLNAME_LITE) SYSTEM $(SYSTEM_DLL) INITINSTANCE TERMINSTANCE OP QUIET FIL {$(LITE_OBJS)} OP IMPF=$(EXPNAME_LITE) OP MAP=$(MAPNAME_LITE)
+$(DLLNAME_LITE) $(LIBNAME_LITE) $(EXPNAME_LITE): $(LITE_OBJS) $(LNKLITE)
+	wlink @$(LNKLITE)
 	wlib -q -b -n -c -pa -s -t -zld -ii -io -inn $(LIBNAME_LITE) +$(DLLNAME_LITE)
 
-$(LIBSTATIC): $(ALL_OBJS)
-	wlib -q -b -n -c -pa -s -t -zld -ii -io $@ $(ALL_OBJS)
-$(LIBSTATIC_LITE): $(LITE_OBJS)
-	wlib -q -b -n -c -pa -s -t -zld -ii -io $@ $(LITE_OBJS)
+$(LIBSTATIC): $(ALL_OBJS) $(LBCFILE)
+	wlib -q -b -n -c -pa -s -t -zld -ii -io $@ @$(LBCFILE)
+$(LIBSTATIC_LITE): $(LITE_OBJS) $(LBCLITE)
+	wlib -q -b -n -c -pa -s -t -zld -ii -io $@ @$(LBCLITE)
 
 test/$(TESTNAME): $(BLD_LIB) $(TEST_OBJS)
 	wlink NAM test/$(TESTNAME) SYSTEM $(SYSTEM) OP QUIET LIBR {$(BLD_LIB)} FIL {$(TEST_OBJS)}
@@ -109,7 +114,7 @@ clean: .symbolic
 	rm -f test/*.obj
 
 distclean: clean .symbolic
-	rm -f *.err
+	rm -f *.err *.lnk *.lbc
 	rm -f $(DLLNAME) $(EXPNAME) $(MAPNAME) $(LIBNAME) $(LIBSTATIC) test/$(DLLNAME) test/$(TESTNAME)
 	rm -f $(DLLNAME_LITE) $(EXPNAME_LITE) $(MAPNAME_LITE) $(LIBNAME_LITE) $(LIBSTATIC_LITE)
 
@@ -118,3 +123,14 @@ CMD_CP=cp
 !else
 CMD_CP=copy
 !endif
+
+$(LBCFILE):
+	@echo Creating wlib commands file: $@
+	@%create $@
+	@for %i in ($(ALL_OBJS)) do @%append $@ +%i
+
+$(LBCLITE):
+	@echo Creating wlib commands file: $@
+	@%create $@
+	@for %i in ($(LITE_OBJS)) do @%append $@ +%i
+


### PR DESCRIPTION
avoids 'too long' errors on old operating systems.

P.S.: msvc makefile in test-dev is weird, I didn't touch it. If you want
I'll try and mess with it, or I can keep it as is because it works where
it matters.
