### PR TITLE
Update ChangeLog for 4.6.1 changes so far

### DIFF
--- a/docs/Changelog
+++ b/docs/Changelog
@@ -19,6 +19,8 @@ Stable versions
 	- Bug fixes to DSMI loader
 	- Fix 16-bit sample check in MultiTracker loader
 	- Fix finetune in MultiTracker loader
+	Changes by Saga Musix:
+	- S3M: Detect PlayerPRO, Velvet Studio and old MPT versions
 	Changes by ds-sloth:
 	- Optimize scan code for common case of no effects
 	Changes by Misty De Méo:

--- a/lite/Changelog
+++ b/lite/Changelog
@@ -7,10 +7,10 @@ Stable versions
 	- Faster IT loading by buffering pattern, sample, and comment reads.
 	- Fix loop detection edge cases broken by S3M/IT marker scan bugs.
 	- Replace rand() with a built-in reentrant alternative.
-	Changes by ds-sloth:
-	- Optimize scan code for common case of no effects
 	Changes by Thomas Neumann:
 	- Fix XM envelope handling
+	Changes by ds-sloth:
+	- Optimize scan code for common case of no effects
 	Changes by Ozkan Sezer:
 	- Build system fixes and clean-ups. Misc code clean-ups.
 
@@ -35,9 +35,9 @@ Stable versions
 	- Fix >1MB S3M modules relying on the sample segment high byte.
 	- Move interpolation wraparound handling out of sample loader.
 	- Don't increment voice position by step value at loop/tick end.
-	- Allow xmp_smix_play functions to play key off, cut and fade events.
 	- Several loading performance improvements.
 	- Allow up to 255 sequences to be scanned.
+	- Allow xmp_smix_play functions to play key off, cut and fade events.
 	- Fixed numerous defects found by fuzzing.
 	Changes by Vitaly Novichkov:
 	- Cmake build system support.
@@ -62,7 +62,7 @@ Stable versions
 	  (no ABI change)
 	- xmp_load_module_from_memory() now accepts a const void* memory
 	  param (no ABI change)
-	- xmp_load_module_from_memory no longer accepts sizes <= 0.
+	- xmp_load_module_from_memory() no longer accepts sizes <= 0.
 	- explicitly document that callers of xmp_load_module_from_file()
 	  are responsible for closing their own file.
 	- remove nonportable use of fdopen in xmp_load_module_from_file()
@@ -166,7 +166,7 @@ Stable versions
 	- fix S3M set pan effect (reported by Hai Shalom and Johannes Schultz)
 	- code refactoring and cleanup
 
-4.3.12 (20150305):
+4.3.12 (20160305):
 	Fix bugs caught in the OpenMPT test cases:
 	- fix IT note off with instrument
 	- fix IT note recover after cut
@@ -213,8 +213,8 @@ Stable versions
 	- prevent division by zero in memory I/O
 	Other changes:
 	- fix IT envelope release + fadeout (reported by NoSuck)
-	- fix IT autovibrato depth (reported by Travis Evans)
 	- fix tone portamento target setting (reported by Georgy Lomsadze)
+	- fix IT autovibrato depth (reported by Travis Evans)
 	- disable ST3 sample size limit (reported by Jochen Goernitz)
 
 4.3.9 (20150623):
@@ -340,7 +340,7 @@ Stable versions
 	- fix module titles and instrument names in Mac OS X
 	- fix row delay initialization on new module
 
-4.3.0 (20140927):
+4.3.0 (20140926):
 	- rebranded as libxmp-lite
 	- build from the same source tree as the full libxmp
 	- fix fine volume slide memory

--- a/src/loaders/s3m_load.c
+++ b/src/loaders/s3m_load.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2023 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
Also minor rearrangement in lite ChangeLog so that it diffs cleaner
against the full version.

Also update copyright years of s3m_load.c

P.S.: The lite <-> full changelog diff isn't clean in 4.5.0 section
I gave up immediately when I hit that part, better to leave as is..
