### PR TITLE
Increase libxmp maximum sample rate to 384kHz (ignore API).

### DIFF
--- a/docs/libxmp.rst
+++ b/docs/libxmp.rst
@@ -115,7 +115,7 @@ error. Error codes are::
 If a system error occurs, the specific error is set in ``errno``.
 
 Parameters to `xmp_start_player()`_ are the sampling
-rate (up to 48kHz) and a bitmapped integer holding one or more of the
+rate (up to 384kHz) and a bitmapped integer holding one or more of the
 following mixer flags::
 
   XMP_MIX_8BIT          /* Mix to 8-bit instead of 16 */
@@ -599,7 +599,7 @@ int xmp_start_player(xmp_context c, int rate, int format)
     :c: the player context handle.
 
     :rate: the sampling rate to use, in Hz (typically 44100). Valid values
-       range from 8kHz to 48kHz.
+       range from 8kHz to 384kHz.
 
     :flags: bitmapped configurable player flags, one or more of the
       following::
@@ -709,7 +709,8 @@ void xmp_get_frame_info(xmp_context c, struct xmp_frame_info \*info)
       This function should be used to retrieve sound buffer data after
       `xmp_play_frame()`_ is called. Fields ``buffer`` and ``buffer_size``
       contain the pointer to the sound buffer PCM data and its size. The
-      buffer size will be no larger than ``XMP_MAX_FRAMESIZE``.
+      buffer size will be no larger than ``XMP_MAX_FRAMESIZE`` if the player
+      is initialized with a rate equal to or less than ``XMP_MAX_SRATE``.
 
 .. _xmp_end_player():
 

--- a/src/common.h
+++ b/src/common.h
@@ -125,6 +125,7 @@ typedef int tst_uint64[2 * (8 == sizeof(uint64)) - 1];
 #endif
 
 /* Constants */
+#define REAL_MAX_SRATE	384000		/* actual maximum sample rate */
 #define PAL_RATE	250.0		/* 1 / (50Hz * 80us)		  */
 #define NTSC_RATE	208.0		/* 1 / (60Hz * 80us)		  */
 #define C4_PAL_RATE	8287		/* 7093789.2 / period (C4) * 2	  */
@@ -515,6 +516,7 @@ struct mixer_data {
 	int dsp;		/* dsp effect flags */
 	char *buffer;		/* output buffer */
 	int32 *buf32;		/* temporary buffer for 32 bit samples */
+	int total_size;		/* allocated samples (not frames) in buffers */
 	int numvoc;		/* default softmixer voices number */
 	int ticksize;
 	int dtright;		/* anticlick control, right channel */

--- a/src/control.c
+++ b/src/control.c
@@ -583,7 +583,7 @@ int xmp_set_tempo_factor(xmp_context opaque, double val)
 
 	val *= 10;
 	ticksize = s->freq * val * m->rrate / p->bpm / 1000 * sizeof(int);
-	if (ticksize > XMP_MAX_FRAMESIZE) {
+	if (ticksize > s->total_size) {
 		return -1;
 	}
 	m->time_factor = val;

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -988,15 +988,20 @@ int libxmp_mixer_numvoices(struct context_data *ctx, int num)
 int libxmp_mixer_on(struct context_data *ctx, int rate, int format, int c4rate)
 {
 	struct mixer_data *s = &ctx->s;
+	int total_size = 5 * rate * 2 / XMP_MIN_BPM; /* See xmp.h */
 
-	s->buffer = (char *) calloc(XMP_MAX_FRAMESIZE, sizeof(int16));
+	if(total_size < XMP_MAX_FRAMESIZE)
+		total_size = XMP_MAX_FRAMESIZE;
+
+	s->buffer = (char *) calloc(total_size, sizeof(int16));
 	if (s->buffer == NULL)
 		goto err;
 
-	s->buf32 = (int32 *) calloc(XMP_MAX_FRAMESIZE, sizeof(int32));
+	s->buf32 = (int32 *) calloc(total_size, sizeof(int32));
 	if (s->buf32 == NULL)
 		goto err1;
 
+	s->total_size = total_size;
 	s->freq = rate;
 	s->format = format;
 	s->amplify = DEFAULT_AMPLIFY;

--- a/src/player.c
+++ b/src/player.c
@@ -1859,7 +1859,7 @@ int xmp_start_player(xmp_context opaque, int rate, int format)
 	int i;
 	int ret = 0;
 
-	if (rate < XMP_MIN_SRATE || rate > XMP_MAX_SRATE)
+	if (rate < XMP_MIN_SRATE || rate > REAL_MAX_SRATE)
 		return -XMP_ERROR_INVALID;
 
 	if (ctx->state < XMP_STATE_LOADED)
@@ -2244,7 +2244,7 @@ void xmp_get_frame_info(xmp_context opaque, struct xmp_frame_info *info)
 	info->time = p->current_time;
 	info->buffer = s->buffer;
 
-	info->total_size = XMP_MAX_FRAMESIZE;
+	info->total_size = s->total_size;
 	info->buffer_size = s->ticksize;
 	if (~s->format & XMP_FORMAT_MONO) {
 		info->buffer_size *= 2;

--- a/test-dev/test_api_start_player.c
+++ b/test-dev/test_api_start_player.c
@@ -33,7 +33,7 @@ TEST(test_api_start_player)
 	state = xmp_get_player(ctx, XMP_PLAYER_STATE);
 	fail_unless(state == XMP_STATE_LOADED, "state error");
 
-	ret = xmp_start_player(ctx, XMP_MAX_SRATE, 0);
+	ret = xmp_start_player(ctx, REAL_MAX_SRATE, 0);
 	fail_unless(ret == 0, "max sample rate failed");
 
 	state = xmp_get_player(ctx, XMP_PLAYER_STATE);
@@ -53,7 +53,7 @@ TEST(test_api_start_player)
 
 	xmp_end_player(ctx);
 
-	ret = xmp_start_player(ctx, XMP_MAX_SRATE + 1, 0);
+	ret = xmp_start_player(ctx, REAL_MAX_SRATE + 1, 0);
 	fail_unless(ret == -XMP_ERROR_INVALID, "max sample rate limit failed");
 
 	state = xmp_get_player(ctx, XMP_PLAYER_STATE);


### PR DESCRIPTION
This makes the mixer initialization allow high rates that previously would have been rejected by `xmp_start_player` calls. This means the API values `XMP_MAX_SRATE` and `XMP_MAX_FRAMESIZE`, while unmodified, are effectively suggestions that will be ignored if someone requests a rate above 48kHz.

Since the mixer will never allocate less than `XMP_MAX_FRAMESIZE` samples for the buffers, and since `xmp_start_player` previously rejected these high rates, this shouldn't break any users *unless* someone was both:

1) relying on `xmp_start_player` rejecting these rates, and *also*
2) doing something very weird with the buffer pointer returned by `xmp_get_frame_info` that almost certainly would have broke before anyway.

More on `xmp_get_frame_info`, the only reason `XMP_MAX_FRAMESIZE` is in the API at all: it returns a pointer to the downmixed buffer in the field `xmp_frame_info::buffer`, and then provides two fields to bound it. The first is `xmp_frame_info::buffer_size`, which is in bytes, and the second is `xmp_frame_info::total_size`, which is in samples (frames × channels) and is *always* `XMP_MAX_FRAMESIZE`. If someone is using these fields as intended (not as documented; they barely are!) to bound accesses to this pointer, nothing should break, and if someone is relying on `XMP_MAX_FRAMESIZE` directly, at worst they won't read the whole buffer. So, I don't think this point of "compatibility" really matters.

Regardless, carefully consider before merging this, and if we need to wait for a minor version or something, that's okay. This theoretically changes the API, but the API was stupid here anyway. Fixes #171. Doesn't fix the crash bugs caused by `xmp_set_tempo_factor`, but I'm working on another patch for that.