### PR TITLE
Fix crashes caused by xmp_set_tempo_factor.

### DIFF
--- a/docs/Changelog
+++ b/docs/Changelog
@@ -14,6 +14,10 @@ Stable versions
 	- Fix out-of-bounds reads in His Master's Noise Mupp instruments.
 	- Fix slow ProWizard testing.
 	- Replace rand() with a built-in reentrant alternative.
+	- xmp_set_tempo_factor now returns -XMP_ERROR_STATE when called prior
+	  to xmp_start_player (instead of causing crashes).
+	- Fix mixer crashes caused by previously valid tempo factors after
+	  sample rate or BPM changes.
 	Changes by Thomas Neumann:
 	- Fix XM envelope handling
 	- Bug fixes to DSMI loader

--- a/docs/libxmp.rst
+++ b/docs/libxmp.rst
@@ -801,7 +801,8 @@ int xmp_set_tempo_factor(xmp_context c, double val)
     :val: the new multiplier.
 
   **Returns:**
-    0 on success, or -1 if value is invalid.
+    0 on success, -1 if value is invalid, or ``-XMP_ERROR_STATE`` if
+    the player is not in the playing state.
 
 .. _xmp_stop_module():
 

--- a/lite/Changelog
+++ b/lite/Changelog
@@ -7,6 +7,10 @@ Stable versions
 	- Faster IT loading by buffering pattern, sample, and comment reads.
 	- Fix loop detection edge cases broken by S3M/IT marker scan bugs.
 	- Replace rand() with a built-in reentrant alternative.
+        - xmp_set_tempo_factor now returns -XMP_ERROR_STATE when called prior
+          to xmp_start_player (instead of causing crashes).
+        - Fix mixer crashes caused by previously valid tempo factors after
+          sample rate or BPM changes.
 	Changes by Thomas Neumann:
 	- Fix XM envelope handling
 	Changes by ds-sloth:

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -79,5 +79,6 @@ void	libxmp_mixer_setnote	(struct context_data *, int, int);
 void	libxmp_mixer_setperiod	(struct context_data *, int, double);
 void	libxmp_mixer_release	(struct context_data *, int, int);
 void	libxmp_mixer_reverse	(struct context_data *, int, int);
+int	libxmp_mixer_get_ticksize(int freq, double time_factor, double rrate, int bpm);
 
 #endif /* LIBXMP_MIXER_H */

--- a/test-dev/Makefile.in
+++ b/test-dev/Makefile.in
@@ -63,7 +63,8 @@ API		= get_format_list create_context free_context \
 		  start_player play_buffer \
 		  set_position prev_position set_position_midfx set_row \
 		  set_player stop_module restart_module seek_time \
-		  channel_mute channel_vol inject_event scan_module
+		  channel_mute channel_vol inject_event scan_module \
+		  set_tempo_factor
 
 API_SMIX	= smix_play_instrument smix_load_sample smix_play_sample \
 		  smix_channel_pan
@@ -707,7 +708,7 @@ gen_module_data: gen_module_data.o util.o ${SRC_PATH}/hio.o ${SRC_PATH}/dataio.o
 	if [ "$(V)" -gt 0 ]; then echo $$CMD; else echo LD $@ ; fi; \
 	eval $$CMD
 
-xmpchk: libxmp_fuzz.o ${SRC_PATH}/loaders/vorbis.o
+xmpchk: libxmp_fuzz.o ${SRC_PATH}/rng.o ${SRC_PATH}/loaders/vorbis.o
 	@CMD='$(LD) $(LDFLAGS) -o $@ $^ -L../lib -lxmp $(LIBS)'; \
 	if [ "$(V)" -gt 0 ]; then echo $$CMD; else echo LD $@ ; fi; \
 	eval $$CMD

--- a/test-dev/all_tests.txt
+++ b/test-dev/all_tests.txt
@@ -249,6 +249,7 @@ test_api_channel_mute
 test_api_channel_vol
 test_api_inject_event
 test_api_scan_module
+test_api_set_tempo_factor
 test_api_smix_play_instrument
 test_api_smix_load_sample
 test_api_smix_play_sample

--- a/test-dev/test_api_set_tempo_factor.c
+++ b/test-dev/test_api_set_tempo_factor.c
@@ -1,0 +1,89 @@
+#include "test.h"
+#include "../src/effects.h"
+
+#include <math.h>
+
+TEST(test_api_set_tempo_factor)
+{
+	xmp_context opaque;
+	struct context_data *ctx;
+	struct player_data *p;
+	struct module_data *m;
+	int state, ret;
+	double factor;
+
+	opaque = xmp_create_context();
+	ctx = (struct context_data *)opaque;
+	p = &ctx->p;
+	m = &ctx->m;
+
+	state = xmp_get_player(opaque, XMP_PLAYER_STATE);
+	fail_unless(state == XMP_STATE_UNLOADED, "state error");
+
+	create_simple_module(ctx, 1, 1);
+	libxmp_free_scan(ctx);
+	set_order(ctx, 0, 0);
+
+	new_event(ctx, 0, 0, 0, 0, 0, 0, FX_S3M_BPM, 0x21, FX_SPEED, 1);
+	new_event(ctx, 0, 1, 0, 0, 0, 0, FX_S3M_BPM, 0xff, FX_BREAK, 0);
+	m->mod.bpm = 255; /* Initial BPM */
+
+	libxmp_prepare_scan(ctx);
+	libxmp_scan_sequences(ctx);
+
+	/* This function relies on values initialized by xmp_start_player. */
+	ret = xmp_set_tempo_factor(opaque, 1.0);
+	fail_unless(ret == -XMP_ERROR_STATE, "should fail if not already playing");
+
+	xmp_start_player(opaque, 44100, 0);
+	fail_unless(p->ord == 0, "didn't start at pattern 0");
+
+	ret = xmp_set_tempo_factor(opaque, 0.0);
+	fail_unless(ret == -1, "didn't fail to set tempo factor to 0.0");
+	ret = xmp_set_tempo_factor(opaque, 1000.0);
+	fail_unless(ret == -1, "didn't fail to set tempo factor to extreme value");
+	ret = xmp_set_tempo_factor(opaque, -10.0);
+	fail_unless(ret == -1, "didn't fail to set tempo factor to negative value");
+#ifdef INFINITY
+	ret = xmp_set_tempo_factor(opaque, INFINITY);
+	fail_unless(ret == -1, "didn't fail to set tempo factor to infinity");
+	ret = xmp_set_tempo_factor(opaque, -INFINITY);
+	fail_unless(ret == -1, "didn't fail to set tempo factor to negative infinity");
+#endif
+#ifdef NAN
+	ret = xmp_set_tempo_factor(opaque, NAN);
+	fail_unless(ret == -1, "didn't fail to set tempo factor to NaN");
+	ret = xmp_set_tempo_factor(opaque, -NAN);
+	fail_unless(ret == -1, "didn't fail to set tempo factor to -NaN");
+#endif
+
+	/* It should always work with reasonable tempo factors. */
+	for (factor = 0.1; factor <= 2.0; factor += 0.1) {
+		/* bpm = 255 */
+		ret = xmp_set_tempo_factor(opaque, factor);
+		fail_unless(ret == 0, "failed to set tempo factor (0)");
+		xmp_play_frame(opaque);
+		fail_unless(p->row == 0, "didn't play frame (0)");
+		/* bpm = 33 */
+		ret = xmp_set_tempo_factor(opaque, factor);
+		fail_unless(ret == 0, "failed to set tempo factor (1)");
+		xmp_play_frame(opaque);
+		fail_unless(p->row == 1, "didn't play frame (1)");
+	}
+
+	/* Anything is fine here, as long as the mixer doesn't crash. */
+	for (; factor <= 128.0; factor *= 2.0) {
+		/* bpm = 255 */
+		xmp_set_tempo_factor(opaque, factor);
+		xmp_play_frame(opaque);
+		fail_unless(p->row == 0, "didn't play frame (0)");
+		/* bpm = 33 */
+		xmp_set_tempo_factor(opaque, factor);
+		xmp_play_frame(opaque);
+		fail_unless(p->row == 1, "didn't play frame (1)");
+	}
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
+}
+END_TEST


### PR DESCRIPTION
* `xmp_set_tempo_factor` now returns `-XMP_ERROR_STATE` when called prior to `xmp_start_player` (instead of causing crashes).
* Fix mixer crashes caused by previously valid tempo factors after sample rate or BPM changes.

If the new return value is too much of a problem for 4.6.1 I can change it to -1.

The crash is easily reproduceable by setting the time factor to some nonsense prior to calling `xmp_start_player` (`xmp_set_tempo_factor` will also generate an UndefinedBehaviorSanitizer error):
```C
int main(void)
{
  xmp_context ctx = xmp_create_context();
  xmp_load_module(ctx, "test-dev/data/test.it");
  xmp_set_tempo_factor(ctx, 10000.0);
  xmp_start_player(ctx, 44100, 0);
  xmp_play_frame(ctx); // crash
  xmp_free_context(ctx);
  return 0;
}
```