### PR TITLE
Reformat mixer macros in preparation for stereo mixers.

### DIFF
--- a/src/mix_all.c
+++ b/src/mix_all.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2023 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -21,7 +21,6 @@
  */
 
 #include "common.h"
-#include "virtual.h"
 #include "mixer.h"
 #include "precomp_lut.h"
 
@@ -31,24 +30,24 @@
  * combination of the following parameters: interpolation, resolution
  * and number of channels.
  */
-#define NEAREST_NEIGHBOR() do { \
-    smp_in = ((int16)sptr[pos] << 8); \
+#define NEAREST_8BIT(smp_in, off) do { \
+    (smp_in) = ((int16)sptr[pos + (off)] << 8); \
 } while (0)
 
-#define NEAREST_NEIGHBOR_16BIT() do { \
-    smp_in = sptr[pos]; \
+#define NEAREST_16BIT(smp_in, off) do { \
+    (smp_in) = sptr[pos + (off)]; \
 } while (0)
 
-#define LINEAR_INTERP() do { \
-    smp_l1 = ((int16)sptr[pos] << 8); \
-    smp_dt = ((int16)sptr[pos + 1] << 8) - smp_l1; \
-    smp_in = smp_l1 + (((frac >> 1) * smp_dt) >> (SMIX_SHIFT - 1)); \
+#define LINEAR_8BIT(smp_in, off) do { \
+    smp_l1 = ((int16)sptr[pos + (off)] << 8); \
+    smp_dt = ((int16)sptr[pos + (off) + chn] << 8) - smp_l1; \
+    (smp_in) = smp_l1 + (((frac >> 1) * smp_dt) >> (SMIX_SHIFT - 1)); \
 } while (0)
 
-#define LINEAR_INTERP_16BIT() do { \
-    smp_l1 = sptr[pos]; \
-    smp_dt = sptr[pos + 1] - smp_l1; \
-    smp_in = smp_l1 + (((frac >> 1) * smp_dt) >> (SMIX_SHIFT - 1)); \
+#define LINEAR_16BIT(smp_in, off) do { \
+    smp_l1 = sptr[pos + (off)]; \
+    smp_dt = sptr[pos + (off) + chn] - smp_l1; \
+    (smp_in) = smp_l1 + (((frac >> 1) * smp_dt) >> (SMIX_SHIFT - 1)); \
 } while (0)
 
 /* The following lut settings are PRECOMPUTED. If you plan on changing these
@@ -65,20 +64,20 @@
 #define SPLINE_FRACSHIFT ((16 - SPLINE_FRACBITS) - 2)
 #define SPLINE_FRACMASK  (((1L << (16 - SPLINE_FRACSHIFT)) - 1) & ~3)
 
-#define SPLINE_INTERP() do { \
+#define SPLINE_8BIT(smp_in, off) do { \
     int f = frac >> 6; \
-    smp_in = (cubic_spline_lut0[f] * sptr[(int)pos - 1] + \
-              cubic_spline_lut1[f] * sptr[pos    ] + \
-              cubic_spline_lut3[f] * sptr[pos + 2] + \
-              cubic_spline_lut2[f] * sptr[pos + 1]) >> (SPLINE_SHIFT - 8); \
+    (smp_in) = (cubic_spline_lut0[f] * sptr[pos + (off) - chn] + \
+                cubic_spline_lut1[f] * sptr[pos + (off)   ] + \
+                cubic_spline_lut3[f] * sptr[pos + (off) + (chn << 1)] + \
+                cubic_spline_lut2[f] * sptr[pos + (off) + chn]) >> (SPLINE_SHIFT - 8); \
 } while (0)
 
-#define SPLINE_INTERP_16BIT() do { \
+#define SPLINE_16BIT(smp_in, off) do { \
     int f = frac >> 6; \
-    smp_in = (cubic_spline_lut0[f] * sptr[(int)pos - 1] + \
-              cubic_spline_lut1[f] * sptr[pos    ] + \
-              cubic_spline_lut3[f] * sptr[pos + 2] + \
-              cubic_spline_lut2[f] * sptr[pos + 1]) >> SPLINE_SHIFT; \
+    (smp_in) = (cubic_spline_lut0[f] * sptr[pos + (off) - chn] + \
+                cubic_spline_lut1[f] * sptr[pos + (off)   ] + \
+                cubic_spline_lut3[f] * sptr[pos + (off) + (chn << 1)] + \
+                cubic_spline_lut2[f] * sptr[pos + (off) + chn]) >> SPLINE_SHIFT; \
 } while (0)
 
 #define LOOP_AC for (; count > ramp; count--)
@@ -87,7 +86,7 @@
 
 #define UPDATE_POS() do { \
     frac += step; \
-    pos += frac >> SMIX_SHIFT; \
+    pos += (frac >> SMIX_SHIFT) * (chn); \
     frac &= SMIX_MASK; \
 } while (0)
 
@@ -102,55 +101,69 @@
 #define MIX_FILTER_CLAMP(a) \
  ((a) < FILTER_MIN ? FILTER_MIN : (a) > FILTER_MAX ? FILTER_MAX : (a))
 
-#define MIX_MONO() do { \
-    *(buffer++) += smp_in * vl; \
-} while (0)
-
-#define MIX_MONO_AC() do { \
-    *(buffer++) += smp_in * (old_vl >> 8); old_vl += delta_l; \
-} while (0)
-
-#define MIX_MONO_FILTER() do { \
-    sl64 = (a0 * (smp_in << PREAMP_BITS) + b0 * fl1 + b1 * fl2) >> FILTER_SHIFT; \
+#define FILTER_LEFT(smp_in_l) do { \
+    sl64 = (a0 * ((smp_in_l) << PREAMP_BITS) + b0 * fl1 + b1 * fl2) >> FILTER_SHIFT; \
     sl = MIX_FILTER_CLAMP(sl64); \
     fl2 = fl1; fl1 = sl; \
-    *(buffer++) += (sl >> PREAMP_BITS) * vl; \
+    (smp_in_l) = sl >> PREAMP_BITS; \
 } while (0)
 
-#define MIX_MONO_FILTER_AC() do { \
-    int vl = old_vl >> 8; \
-    MIX_MONO_FILTER(); \
+#if 0
+#define FILTER_RIGHT(smp_in_r) do { \
+    sr64 = (a0 * ((smp_in_r) << PREAMP_BITS) + b0 * fr1 + b1 * fr2) >> FILTER_SHIFT; \
+    sr = MIX_FILTER_CLAMP(sr64); \
+    fr2 = fr1; fr1 = sr; \
+    (smp_in_r) = sr >> PREAMP_BITS; \
+} while (0)
+#endif
+
+#define FILTER_MONO(smp_in_l) do { \
+    FILTER_LEFT((smp_in_l)); \
+} while(0)
+
+#if 0
+#define FILTER_STEREO(smp_in_l, smp_in_r) do { \
+    FILTER_LEFT((smp_in_l)); \
+    FILTER_RIGHT((smp_in_r)); \
+} while (0)
+#endif
+
+#define MIX_OUT(out_sample, out_level) do { \
+    *(buffer++) += (out_sample) * (out_level); \
+} while (0)
+
+#define MIX_MONO(smp_in) do { \
+    MIX_OUT((smp_in), vl); \
+} while (0)
+
+#define MIX_MONO_AC(smp_in) do { \
+    MIX_OUT((smp_in), old_vl >> 8); \
     old_vl += delta_l; \
 } while (0)
 
-#define MIX_STEREO() do { \
-    *(buffer++) += smp_in * vl; \
-    *(buffer++) += smp_in * vr; \
+#define MIX_STEREO(smp_in_l, smp_in_r) do { \
+    MIX_OUT((smp_in_l), vl); \
+    MIX_OUT((smp_in_r), vr); \
 } while (0)
 
-#define MIX_STEREO_AC() do { \
-    *(buffer++) += smp_in * (old_vl >> 8); old_vl += delta_l; \
-    *(buffer++) += smp_in * (old_vr >> 8); old_vr += delta_r; \
-} while (0)
-
-#define MIX_STEREO_FILTER() do { \
-    sr64 = (a0 * (smp_in << PREAMP_BITS) + b0 * fr1 + b1 * fr2) >> FILTER_SHIFT; \
-    sr = MIX_FILTER_CLAMP(sr64); \
-    fr2 = fr1; fr1 = sr; \
-    sl64 = (a0 * (smp_in << PREAMP_BITS) + b0 * fl1 + b1 * fl2) >> FILTER_SHIFT; \
-    sl = MIX_FILTER_CLAMP(sl64); \
-    fl2 = fl1; fl1 = sl; \
-    *(buffer++) += (sl >> PREAMP_BITS) * vl; \
-    *(buffer++) += (sr >> PREAMP_BITS) * vr; \
-} while (0)
-
-#define MIX_STEREO_FILTER_AC() do { \
-    int vl = old_vl >> 8; \
-    int vr = old_vr >> 8; \
-    MIX_STEREO_FILTER(); \
+#define MIX_STEREO_AC(smp_in_l, smp_in_r) do { \
+    MIX_OUT((smp_in_l), old_vl >> 8); \
+    MIX_OUT((smp_in_r), old_vr >> 8); \
     old_vl += delta_l; \
     old_vr += delta_r; \
 } while (0)
+
+#if 0
+#define AVERAGE(smp_in_l, smp_in_r) (((smp_in_l) + (smp_in_r)) >> 1)
+
+#define MIX_MONO_AVG(smp_in_l, smp_in_r) do { \
+    MIX_MONO(AVERAGE((smp_in_l), (smp_in_r))); \
+} while (0)
+
+#define MIX_MONO_AVG_AC(smp_in_l, smp_in_r) do { \
+    MIX_MONO_AC(AVERAGE((smp_in_l), (smp_in_r))); \
+} while (0)
+#endif
 
 /* For "nearest" to be nearest neighbor (instead of floor), the position needs
  * to be rounded. This only needs to be done once at the start of mixing, and
@@ -158,31 +171,53 @@
  */
 #define NEAREST_ROUND() do { \
     frac += (1 << (SMIX_SHIFT - 1)); \
-    pos += frac >> SMIX_SHIFT; \
+    pos += (frac >> SMIX_SHIFT) * (chn); \
     frac &= SMIX_MASK; \
 } while (0)
 
 #define VAR_NORM(x) \
-    register int smp_in; \
+    register int smpl; \
     x *sptr = (x *)vi->sptr; \
-    unsigned int pos = vi->pos; \
+    int pos = ((int)vi->pos) * chn; \
     int frac = (1 << SMIX_SHIFT) * (vi->pos - (int)vi->pos)
 
-#define VAR_LINEAR_MONO(x) \
-    VAR_NORM(x); \
-    int old_vl = vi->old_vl; \
-    int smp_l1, smp_dt
-
-#define VAR_LINEAR_STEREO(x) \
-    VAR_LINEAR_MONO(x); \
-    int old_vr = vi->old_vr
-
-#define VAR_SPLINE_MONO(x) \
-    int old_vl = vi->old_vl; \
+#define VAR_MONO(x) \
+    const int chn = 1; \
     VAR_NORM(x)
 
+#if 0
+#define VAR_STEREO(x) \
+    const int chn = 2; \
+    register int smpr; \
+    VAR_NORM(x)
+#endif
+
+#define VAR_LINEAR() \
+    int smp_l1, smp_dt
+
+#define VAR_LINEAR_MONO(x) \
+    VAR_MONO(x); \
+    VAR_LINEAR()
+
+#if 0
+#define VAR_LINEAR_STEREO(x) \
+    VAR_STEREO(x); \
+    VAR_LINEAR()
+#endif
+
+#define VAR_SPLINE_MONO(x) \
+    VAR_MONO(x)
+
+#if 0
 #define VAR_SPLINE_STEREO(x) \
-    VAR_SPLINE_MONO(x); \
+    VAR_STEREO(x)
+#endif
+
+#define VAR_MONOOUT \
+    int old_vl = vi->old_vl
+
+#define VAR_STEREOOUT \
+    VAR_MONOOUT; \
     int old_vr = vi->old_vr
 
 #ifndef LIBXMP_CORE_DISABLE_IT
@@ -193,27 +228,31 @@
     int64 sl64; \
     int sl
 
+#if 0
 #define VAR_FILTER_STEREO \
     VAR_FILTER_MONO; \
     int fr1 = vi->filter.r1, fr2 = vi->filter.r2; \
     int64 sr64; \
     int sr
+#endif
 
+/* Note: copying the left to the right here is for just in case these
+ * values don't get cleared between playing stereo/mono samples. */
 #define SAVE_FILTER_MONO() do { \
     vi->filter.l1 = fl1; \
     vi->filter.l2 = fl2; \
+    vi->filter.r1 = fl1; \
+    vi->filter.r2 = fl2; \
 } while (0)
 
+#if 0
 #define SAVE_FILTER_STEREO() do { \
     SAVE_FILTER_MONO(); \
     vi->filter.r1 = fr1; \
     vi->filter.r2 = fr2; \
 } while (0)
-
 #endif
 
-#ifdef _MSC_VER
-#pragma warning(disable:4457) /* shadowing */
 #endif
 
 
@@ -225,10 +264,10 @@
  */
 MIXER(monoout_mono_8bit_nearest)
 {
-    VAR_NORM(int8);
+    VAR_MONO(int8);
     NEAREST_ROUND();
 
-    LOOP { NEAREST_NEIGHBOR(); MIX_MONO(); UPDATE_POS(); }
+    LOOP { NEAREST_8BIT(smpl, 0); MIX_MONO(smpl); UPDATE_POS(); }
 }
 
 
@@ -236,30 +275,30 @@ MIXER(monoout_mono_8bit_nearest)
  */
 MIXER(monoout_mono_16bit_nearest)
 {
-    VAR_NORM(int16);
+    VAR_MONO(int16);
     NEAREST_ROUND();
 
-    LOOP { NEAREST_NEIGHBOR_16BIT(); MIX_MONO(); UPDATE_POS(); }
+    LOOP { NEAREST_16BIT(smpl, 0); MIX_MONO(smpl); UPDATE_POS(); }
 }
 
 /* Handler for 8-bit mono samples, nearest neighbor stereo output
  */
 MIXER(stereoout_mono_8bit_nearest)
 {
-    VAR_NORM(int8);
+    VAR_MONO(int8);
     NEAREST_ROUND();
 
-    LOOP { NEAREST_NEIGHBOR(); MIX_STEREO(); UPDATE_POS(); }
+    LOOP { NEAREST_8BIT(smpl, 0); MIX_STEREO(smpl, smpl); UPDATE_POS(); }
 }
 
 /* Handler for 16-bit mono samples, nearest neighbor stereo output
  */
 MIXER(stereoout_mono_16bit_nearest)
 {
-    VAR_NORM(int16);
+    VAR_MONO(int16);
     NEAREST_ROUND();
 
-    LOOP { NEAREST_NEIGHBOR_16BIT(); MIX_STEREO(); UPDATE_POS(); }
+    LOOP { NEAREST_16BIT(smpl, 0); MIX_STEREO(smpl, smpl); UPDATE_POS(); }
 }
 
 
@@ -272,9 +311,10 @@ MIXER(stereoout_mono_16bit_nearest)
 MIXER(monoout_mono_8bit_linear)
 {
     VAR_LINEAR_MONO(int8);
+    VAR_MONOOUT;
 
-    LOOP_AC { LINEAR_INTERP(); MIX_MONO_AC(); UPDATE_POS(); }
-    LOOP    { LINEAR_INTERP(); MIX_MONO(); UPDATE_POS(); }
+    LOOP_AC { LINEAR_8BIT(smpl, 0); MIX_MONO_AC(smpl); UPDATE_POS(); }
+    LOOP    { LINEAR_8BIT(smpl, 0); MIX_MONO(smpl); UPDATE_POS(); }
 }
 
 /* Handler for 16-bit mono samples, linear interpolated mono output
@@ -282,29 +322,32 @@ MIXER(monoout_mono_8bit_linear)
 MIXER(monoout_mono_16bit_linear)
 {
     VAR_LINEAR_MONO(int16);
+    VAR_MONOOUT;
 
-    LOOP_AC { LINEAR_INTERP_16BIT(); MIX_MONO_AC(); UPDATE_POS(); }
-    LOOP    { LINEAR_INTERP_16BIT(); MIX_MONO(); UPDATE_POS(); }
+    LOOP_AC { LINEAR_16BIT(smpl, 0); MIX_MONO_AC(smpl); UPDATE_POS(); }
+    LOOP    { LINEAR_16BIT(smpl, 0); MIX_MONO(smpl); UPDATE_POS(); }
 }
 
 /* Handler for 8-bit mono samples, linear interpolated stereo output
  */
 MIXER(stereoout_mono_8bit_linear)
 {
-   VAR_LINEAR_STEREO(int8);
+    VAR_LINEAR_MONO(int8);
+    VAR_STEREOOUT;
 
-    LOOP_AC { LINEAR_INTERP(); MIX_STEREO_AC(); UPDATE_POS(); }
-    LOOP    { LINEAR_INTERP(); MIX_STEREO(); UPDATE_POS(); }
+    LOOP_AC { LINEAR_8BIT(smpl, 0); MIX_STEREO_AC(smpl, smpl); UPDATE_POS(); }
+    LOOP    { LINEAR_8BIT(smpl, 0); MIX_STEREO(smpl, smpl); UPDATE_POS(); }
 }
 
 /* Handler for 16-bit mono samples, linear interpolated stereo output
  */
 MIXER(stereoout_mono_16bit_linear)
 {
-    VAR_LINEAR_STEREO(int16);
+    VAR_LINEAR_MONO(int16);
+    VAR_STEREOOUT;
 
-    LOOP_AC { LINEAR_INTERP_16BIT(); MIX_STEREO_AC(); UPDATE_POS(); }
-    LOOP    { LINEAR_INTERP_16BIT(); MIX_STEREO(); UPDATE_POS(); }
+    LOOP_AC { LINEAR_16BIT(smpl, 0); MIX_STEREO_AC(smpl, smpl); UPDATE_POS(); }
+    LOOP    { LINEAR_16BIT(smpl, 0); MIX_STEREO(smpl, smpl); UPDATE_POS(); }
 }
 
 
@@ -316,9 +359,12 @@ MIXER(monoout_mono_8bit_linear_filter)
 {
     VAR_LINEAR_MONO(int8);
     VAR_FILTER_MONO;
+    VAR_MONOOUT;
 
-    LOOP_AC { LINEAR_INTERP(); MIX_MONO_FILTER_AC(); UPDATE_POS(); }
-    LOOP    { LINEAR_INTERP(); MIX_MONO_FILTER(); UPDATE_POS(); }
+    LOOP_AC {   LINEAR_8BIT(smpl, 0); FILTER_MONO(smpl);
+                MIX_MONO_AC(smpl); UPDATE_POS(); }
+    LOOP    {   LINEAR_8BIT(smpl, 0); FILTER_MONO(smpl);
+                MIX_MONO(smpl); UPDATE_POS(); }
 
     SAVE_FILTER_MONO();
 }
@@ -329,9 +375,12 @@ MIXER(monoout_mono_16bit_linear_filter)
 {
     VAR_LINEAR_MONO(int16);
     VAR_FILTER_MONO;
+    VAR_MONOOUT;
 
-    LOOP_AC { LINEAR_INTERP_16BIT(); MIX_MONO_FILTER_AC(); UPDATE_POS(); }
-    LOOP    { LINEAR_INTERP_16BIT(); MIX_MONO_FILTER(); UPDATE_POS(); }
+    LOOP_AC {   LINEAR_16BIT(smpl, 0); FILTER_MONO(smpl);
+                MIX_MONO_AC(smpl); UPDATE_POS(); }
+    LOOP    {   LINEAR_16BIT(smpl, 0); FILTER_MONO(smpl);
+                MIX_MONO(smpl); UPDATE_POS(); }
 
     SAVE_FILTER_MONO();
 }
@@ -340,26 +389,32 @@ MIXER(monoout_mono_16bit_linear_filter)
  */
 MIXER(stereoout_mono_8bit_linear_filter)
 {
-    VAR_LINEAR_STEREO(int8);
-    VAR_FILTER_STEREO;
+    VAR_LINEAR_MONO(int8);
+    VAR_FILTER_MONO;
+    VAR_STEREOOUT;
 
-    LOOP_AC { LINEAR_INTERP(); MIX_STEREO_FILTER_AC(); UPDATE_POS(); }
-    LOOP    { LINEAR_INTERP(); MIX_STEREO_FILTER(); UPDATE_POS(); }
+    LOOP_AC {   LINEAR_8BIT(smpl, 0); FILTER_MONO(smpl);
+                MIX_STEREO_AC(smpl, smpl); UPDATE_POS(); }
+    LOOP    {   LINEAR_8BIT(smpl, 0); FILTER_MONO(smpl);
+                MIX_STEREO(smpl, smpl); UPDATE_POS(); }
 
-    SAVE_FILTER_STEREO();
+    SAVE_FILTER_MONO();
 }
 
 /* Handler for 16-bit mono samples, filtered linear interpolated stereo output
  */
 MIXER(stereoout_mono_16bit_linear_filter)
 {
-    VAR_LINEAR_STEREO(int16);
-    VAR_FILTER_STEREO;
+    VAR_LINEAR_MONO(int16);
+    VAR_FILTER_MONO;
+    VAR_STEREOOUT;
 
-    LOOP_AC { LINEAR_INTERP_16BIT(); MIX_STEREO_FILTER_AC(); UPDATE_POS(); }
-    LOOP    { LINEAR_INTERP_16BIT(); MIX_STEREO_FILTER(); UPDATE_POS(); }
+    LOOP_AC {   LINEAR_16BIT(smpl, 0); FILTER_MONO(smpl);
+                MIX_STEREO_AC(smpl, smpl); UPDATE_POS(); }
+    LOOP    {   LINEAR_16BIT(smpl, 0); FILTER_MONO(smpl);
+                MIX_STEREO(smpl, smpl); UPDATE_POS(); }
 
-    SAVE_FILTER_STEREO();
+    SAVE_FILTER_MONO();
 }
 
 #endif
@@ -373,9 +428,10 @@ MIXER(stereoout_mono_16bit_linear_filter)
 MIXER(monoout_mono_8bit_spline)
 {
     VAR_SPLINE_MONO(int8);
+    VAR_MONOOUT;
 
-    LOOP_AC { SPLINE_INTERP(); MIX_MONO_AC(); UPDATE_POS(); }
-    LOOP    { SPLINE_INTERP(); MIX_MONO(); UPDATE_POS(); }
+    LOOP_AC { SPLINE_8BIT(smpl, 0); MIX_MONO_AC(smpl); UPDATE_POS(); }
+    LOOP    { SPLINE_8BIT(smpl, 0); MIX_MONO(smpl); UPDATE_POS(); }
 }
 
 /* Handler for 16-bit mono samples, spline interpolated mono output
@@ -383,29 +439,32 @@ MIXER(monoout_mono_8bit_spline)
 MIXER(monoout_mono_16bit_spline)
 {
     VAR_SPLINE_MONO(int16);
+    VAR_MONOOUT;
 
-    LOOP_AC { SPLINE_INTERP_16BIT(); MIX_MONO_AC(); UPDATE_POS(); }
-    LOOP    { SPLINE_INTERP_16BIT(); MIX_MONO(); UPDATE_POS(); }
+    LOOP_AC { SPLINE_16BIT(smpl, 0); MIX_MONO_AC(smpl); UPDATE_POS(); }
+    LOOP    { SPLINE_16BIT(smpl, 0); MIX_MONO(smpl); UPDATE_POS(); }
 }
 
 /* Handler for 8-bit mono samples, spline interpolated stereo output
  */
 MIXER(stereoout_mono_8bit_spline)
 {
-    VAR_SPLINE_STEREO(int8);
+    VAR_SPLINE_MONO(int8);
+    VAR_STEREOOUT;
 
-    LOOP_AC { SPLINE_INTERP(); MIX_STEREO_AC(); UPDATE_POS(); }
-    LOOP    { SPLINE_INTERP(); MIX_STEREO(); UPDATE_POS(); }
+    LOOP_AC { SPLINE_8BIT(smpl, 0); MIX_STEREO_AC(smpl, smpl); UPDATE_POS(); }
+    LOOP    { SPLINE_8BIT(smpl, 0); MIX_STEREO(smpl, smpl); UPDATE_POS(); }
 }
 
 /* Handler for 16-bit mono samples, spline interpolated stereo output
  */
 MIXER(stereoout_mono_16bit_spline)
 {
-    VAR_SPLINE_STEREO(int16);
+    VAR_SPLINE_MONO(int16);
+    VAR_STEREOOUT;
 
-    LOOP_AC { SPLINE_INTERP_16BIT(); MIX_STEREO_AC(); UPDATE_POS(); }
-    LOOP    { SPLINE_INTERP_16BIT(); MIX_STEREO(); UPDATE_POS(); }
+    LOOP_AC { SPLINE_16BIT(smpl, 0); MIX_STEREO_AC(smpl, smpl); UPDATE_POS(); }
+    LOOP    { SPLINE_16BIT(smpl, 0); MIX_STEREO(smpl, smpl); UPDATE_POS(); }
 }
 
 #ifndef LIBXMP_CORE_DISABLE_IT
@@ -416,9 +475,12 @@ MIXER(monoout_mono_8bit_spline_filter)
 {
     VAR_SPLINE_MONO(int8);
     VAR_FILTER_MONO;
+    VAR_MONOOUT;
 
-    LOOP_AC { SPLINE_INTERP(); MIX_MONO_FILTER_AC(); UPDATE_POS(); }
-    LOOP    { SPLINE_INTERP(); MIX_MONO_FILTER(); UPDATE_POS(); }
+    LOOP_AC {   SPLINE_8BIT(smpl, 0); FILTER_MONO(smpl);
+                MIX_MONO_AC(smpl); UPDATE_POS(); }
+    LOOP    {   SPLINE_8BIT(smpl, 0); FILTER_MONO(smpl);
+                MIX_MONO(smpl); UPDATE_POS(); }
 
     SAVE_FILTER_MONO();
 }
@@ -429,9 +491,12 @@ MIXER(monoout_mono_16bit_spline_filter)
 {
     VAR_SPLINE_MONO(int16);
     VAR_FILTER_MONO;
+    VAR_MONOOUT;
 
-    LOOP_AC { SPLINE_INTERP_16BIT(); MIX_MONO_FILTER_AC(); UPDATE_POS(); }
-    LOOP    { SPLINE_INTERP_16BIT(); MIX_MONO_FILTER(); UPDATE_POS(); }
+    LOOP_AC {   SPLINE_16BIT(smpl, 0); FILTER_MONO(smpl);
+                MIX_MONO_AC(smpl); UPDATE_POS(); }
+    LOOP    {   SPLINE_16BIT(smpl, 0); FILTER_MONO(smpl);
+                MIX_MONO(smpl); UPDATE_POS(); }
 
     SAVE_FILTER_MONO();
 }
@@ -440,26 +505,32 @@ MIXER(monoout_mono_16bit_spline_filter)
  */
 MIXER(stereoout_mono_8bit_spline_filter)
 {
-    VAR_SPLINE_STEREO(int8);
-    VAR_FILTER_STEREO;
+    VAR_SPLINE_MONO(int8);
+    VAR_FILTER_MONO;
+    VAR_STEREOOUT;
 
-    LOOP_AC { SPLINE_INTERP(); MIX_STEREO_FILTER_AC(); UPDATE_POS(); }
-    LOOP    { SPLINE_INTERP(); MIX_STEREO_FILTER(); UPDATE_POS(); }
+    LOOP_AC {   SPLINE_8BIT(smpl, 0); FILTER_MONO(smpl);
+                MIX_STEREO_AC(smpl, smpl); UPDATE_POS(); }
+    LOOP    {   SPLINE_8BIT(smpl, 0); FILTER_MONO(smpl);
+                MIX_STEREO(smpl, smpl); UPDATE_POS(); }
 
-    SAVE_FILTER_STEREO();
+    SAVE_FILTER_MONO();
 }
 
 /* Handler for 16-bit mono samples, filtered spline interpolated stereo output
  */
 MIXER(stereoout_mono_16bit_spline_filter)
 {
-    VAR_SPLINE_STEREO(int16);
-    VAR_FILTER_STEREO;
+    VAR_SPLINE_MONO(int16);
+    VAR_FILTER_MONO;
+    VAR_STEREOOUT;
 
-    LOOP_AC { SPLINE_INTERP_16BIT(); MIX_STEREO_FILTER_AC(); UPDATE_POS(); }
-    LOOP    { SPLINE_INTERP_16BIT(); MIX_STEREO_FILTER(); UPDATE_POS(); }
+    LOOP_AC {   SPLINE_16BIT(smpl, 0); FILTER_MONO(smpl);
+                MIX_STEREO_AC(smpl, smpl); UPDATE_POS(); }
+    LOOP    {   SPLINE_16BIT(smpl, 0); FILTER_MONO(smpl);
+                MIX_STEREO(smpl, smpl); UPDATE_POS(); }
 
-    SAVE_FILTER_STEREO();
+    SAVE_FILTER_MONO();
 }
 
 #endif

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -59,7 +59,8 @@ struct loop_data
 	uint32 epilogue[LOOP_EPILOGUE];
 };
 
-#define MIX_FN(x) void libxmp_mix_##x(struct mixer_voice *, int32 *, int, int, int, int, int, int, int)
+#define MIX_FN(x) void libxmp_mix_##x(struct mixer_voice * LIBXMP_RESTRICT, \
+	int32 * LIBXMP_RESTRICT, int, int, int, int, int, int, int)
 
 #define ANTICLICK_FPSHIFT	24
 

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -14,8 +14,9 @@
 #include "paula.h"
 #endif
 
-#define MIXER(f) void libxmp_mix_##f(struct mixer_voice *vi, int *buffer, \
-	int count, int vl, int vr, int step, int ramp, int delta_l, int delta_r)
+#define MIXER(f) void libxmp_mix_##f(struct mixer_voice * LIBXMP_RESTRICT vi, \
+	int * LIBXMP_RESTRICT buffer, int count, int vl, int vr, int step, int ramp, \
+	int delta_l, int delta_r)
 
 struct mixer_voice {
 	int chn;		/* channel number */


### PR DESCRIPTION
* The interpolation macros now take an output sample and a sample number (required for stereo mixers for obvious reasons). The channel count is provided via a `const int` for lack of a better way of doing this (should not harm most builds). The alternative was yet another macro parameter to the interpolators and UPDATE_POS.
* Renamed the interpolation macros for consistency.
* I've separated the filter macros from the output macros since the filter macros are supposed to operate on the INPUT according to sagamusix. These macros take one or two input+output variables.
* The output macros have been greatly simplified, and now take one or two output variables.
* Similarly, the variable declarations needed an overhaul.
* Reverted 69653c24 as the underlying cause seems to have been fixed during fuzzing and reverting it tidied up the macros.

Marking as a draft until I've had some time to verify this is complete. Stereo mixers will be a separate patch.