### PR TITLE
Update paramaters of xmp_channel_mute in libxmp.rst

### DIFF
--- a/docs/libxmp.rst
+++ b/docs/libxmp.rst
@@ -852,7 +852,7 @@ int xmp_channel_mute(xmp_context c, int chn, int status)
 
     :chn: the channel to mute or unmute.
 
-    :status: 0 to mute channel, 1 to unmute or -1 to query the
+    :status: 0 to mute channel, 1 to unmute, 2 the inverse of the current channel status, or -1 to query the
       current channel status.
 
   **Returns:**


### PR DESCRIPTION
`xmp_channel_mute` has another way of muting or unmuting that wasn't documented. 

Setting the status to 2 (or greater) will inverse the channel's current status. 