### PR TITLE
Add depacker test_hio function for more complex packed formats.

### DIFF
--- a/src/depackers/arc.c
+++ b/src/depackers/arc.c
@@ -374,5 +374,6 @@ static int arc_decrunch(HIO_HANDLE *in, void **out, long *outlen)
 const struct depacker libxmp_depacker_arc =
 {
   arc_test,
+  NULL,
   arc_decrunch
 };

--- a/src/depackers/arcfs.c
+++ b/src/depackers/arcfs.c
@@ -334,5 +334,6 @@ static int arcfs_decrunch(HIO_HANDLE *in, void **out, long *outlen)
 const struct depacker libxmp_depacker_arcfs =
 {
   arcfs_test,
+  NULL,
   arcfs_decrunch
 };

--- a/src/depackers/bunzip2.c
+++ b/src/depackers/bunzip2.c
@@ -740,5 +740,6 @@ static int decrunch_bzip2(HIO_HANDLE *in, void **out, long *outlen)
 
 const struct depacker libxmp_depacker_bzip2 = {
 	test_bzip2,
+	NULL,
 	decrunch_bzip2
 };

--- a/src/depackers/depacker.c
+++ b/src/depackers/depacker.c
@@ -280,8 +280,9 @@ int libxmp_decrunch(HIO_HANDLE *h, const char *filename, char **temp)
 
 	/* Check built-in depackers */
 	for (i = 0; depacker_list[i] != NULL; i++) {
-		if (depacker_list[i]->test(b)) {
-			depacker = depacker_list[i];
+		const struct depacker *d = depacker_list[i];
+		if ((d->test && d->test(b)) || (d->test_hio && d->test_hio(h))) {
+			depacker = d;
 			D_(D_INFO "Use depacker %d", i);
 			break;
 		}

--- a/src/depackers/depacker.h
+++ b/src/depackers/depacker.h
@@ -21,6 +21,7 @@ extern const struct depacker libxmp_depacker_xfd;
 
 struct depacker {
 	int (*test)(unsigned char *);
+	int (*test_hio)(HIO_HANDLE *);
 	int (*depack)(HIO_HANDLE *, void **, long *);
 };
 

--- a/src/depackers/gunzip.c
+++ b/src/depackers/gunzip.c
@@ -174,5 +174,6 @@ static int decrunch_gzip(HIO_HANDLE *in, void **out, long *outlen)
 
 const struct depacker libxmp_depacker_gzip = {
 	test_gzip,
+	NULL,
 	decrunch_gzip
 };

--- a/src/depackers/lzx.c
+++ b/src/depackers/lzx.c
@@ -440,5 +440,6 @@ static int decrunch_lzx(HIO_HANDLE *in, void **out, long *outlen)
 const struct depacker libxmp_depacker_lzx =
 {
   test_lzx,
+  NULL,
   decrunch_lzx
 };

--- a/src/depackers/mmcmp.c
+++ b/src/depackers/mmcmp.c
@@ -462,5 +462,6 @@ static int decrunch_mmcmp(HIO_HANDLE *in, void **out, long *outlen)
 
 const struct depacker libxmp_depacker_mmcmp = {
 	test_mmcmp,
+	NULL,
 	decrunch_mmcmp
 };

--- a/src/depackers/ppdepack.c
+++ b/src/depackers/ppdepack.c
@@ -234,5 +234,6 @@ err:
 
 const struct depacker libxmp_depacker_pp = {
 	test_pp,
+	NULL,
 	decrunch_pp
 };

--- a/src/depackers/s404_dec.c
+++ b/src/depackers/s404_dec.c
@@ -429,5 +429,6 @@ static int decrunch_s404(HIO_HANDLE *in, void **out, long *outlen)
 
 const struct depacker libxmp_depacker_s404 = {
 	test_s404,
+	NULL,
 	decrunch_s404
 };

--- a/src/depackers/uncompress.c
+++ b/src/depackers/uncompress.c
@@ -284,5 +284,6 @@ static int decrunch_compress(HIO_HANDLE * in, void ** out, long * outlen)
 
 const struct depacker libxmp_depacker_compress = {
 	test_compress,
+	NULL,
 	decrunch_compress
 };

--- a/src/depackers/unlha.c
+++ b/src/depackers/unlha.c
@@ -105,5 +105,6 @@ fail:
 
 const struct depacker libxmp_depacker_lha = {
     test_lha,
+    NULL,
     decrunch_lha
 };

--- a/src/depackers/unsqsh.c
+++ b/src/depackers/unsqsh.c
@@ -430,5 +430,6 @@ static int decrunch_sqsh(HIO_HANDLE * f, void ** outbuf, long * outlen)
 
 const struct depacker libxmp_depacker_sqsh = {
 	test_sqsh,
+	NULL,
 	decrunch_sqsh
 };

--- a/src/depackers/unxz.c
+++ b/src/depackers/unxz.c
@@ -102,5 +102,6 @@ static int decrunch_xz(HIO_HANDLE *in, void **out, long *outlen)
 
 const struct depacker libxmp_depacker_xz = {
 	test_xz,
+	NULL,
 	decrunch_xz
 };

--- a/src/depackers/unzip.c
+++ b/src/depackers/unzip.c
@@ -96,5 +96,6 @@ static int decrunch_zip(HIO_HANDLE *in, void **out, long *outlen)
 
 const struct depacker libxmp_depacker_zip = {
 	test_zip,
+	NULL,
 	decrunch_zip
 };

--- a/src/depackers/xfd.c
+++ b/src/depackers/xfd.c
@@ -113,6 +113,7 @@ static int decrunch_xfd(HIO_HANDLE *f, void **outbuf, long *outlen)
 
 const struct depacker libxmp_depacker_xfd = {
 	test_xfd,
+	NULL,
 	decrunch_xfd
 };
 


### PR DESCRIPTION
This allows depackers to test the input stream directly rather than the 1k buffer that libxmp currently provides them, which will be useful for formats that don't provide a magic string at the start.

Example 1: Pack-Ice—a packer format used on the Atari ST and Falcon (and occasionally the Amiga?)—in the 1.x variant of its format writes a footer with a 4 byte signature at the end of the file. It is impossible to detect this variant otherwise. I am currently finishing a depacker for the Pack-Ice format because Digital Tracker natively loads the 2.3/2.4 variant of it (allegedly; unpacking seems broken prior to Digital Home Studio) and the author regularly used Pack-Ice 2.3/2.4 on their modules.

Example 2: Zip does not reliably contain a magic string at the start (our Zip depacker currently assumes there is). A single volume Zip file can be more reliably detected by seeking to END - 22 and then searching backwards up to 65535 bytes for the Zip End of Central Directory record. This is because, due to the nature of the Zip format, it can be prefixed with an arbitrary-sized amount of data ("embedded stub"). Zip self-extractors may rely on this, but most Zip files don't, so I don't think there's any need to rush to implement this.

Nothing uses this yet; this branch just adds it to the depacker struct. If we'd rather not have this I can also just dummy out the Pack-Ice v1 depacker when I start [integrating things](https://github.com/AliceLR/megazeuxtests/blob/master/src/dimgutil/ice_unpack.c).

edit: to clarify why this patch exists at all or specifically right now, I have an unfinished Digital Tracker bugfix patch that was split off of the stereo samples support working branch because it grew into a tumor of mostly unrelated bugfixes. The DTM patch is unfinished in part because I've yet to finish effects testing but also because of a shortage of original test files due to half of the author's DTMs being packed with this format, which of course, turned into its own tangent because of how plain weird it is. So this is split off of a tangent of a tangent of the stereo samples work. (On top of this, Digital Tracker has *weird* stereo samples support I can't fully implement right now anyway, because of course it does.)