### PR TITLE
Use asprintf when processing paths

### DIFF
--- a/cmake/libxmp-checks.cmake
+++ b/cmake/libxmp-checks.cmake
@@ -136,6 +136,7 @@ endif()
 xmp_check_function(powf "math.h" HAVE_POWF)
 cmake_pop_check_state()
 
+xmp_check_function(asprintf "stdio.h" HAVE_ASPRINTF)
 xmp_check_function(popen "stdio.h" HAVE_POPEN)
 xmp_check_function(fnmatch "fnmatch.h" HAVE_FNMATCH)
 xmp_check_function(umask "sys/stat.h" HAVE_UMASK)

--- a/configure.ac
+++ b/configure.ac
@@ -271,7 +271,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <dirent.h>]], [[
  [have_dirent=no])
 AC_MSG_RESULT($have_dirent)
 
-AC_CHECK_FUNCS(popen mkstemp fnmatch umask)
+AC_CHECK_FUNCS(asprintf popen mkstemp fnmatch umask)
 dnl fork, execv & co don't work with djgpp
 case "${host_os}" in
 *djgpp|mingw*|riscos*)

--- a/lite/configure.ac
+++ b/lite/configure.ac
@@ -235,6 +235,8 @@ dnl djgpp has all c89 math funcs in libc.a
 esac
 AC_CHECK_FUNCS(powf)
 
+AC_CHECK_FUNCS(asprintf)
+
 AC_SUBST([libxmplite_VERSION_MAJOR],libxmplite_VERSION_MAJOR_m4)
 AC_SUBST([libxmplite_VERSION_MINOR],libxmplite_VERSION_MINOR_m4)
 AC_SUBST([libxmplite_VERSION_PATCH],libxmplite_VERSION_PATCH_m4)

--- a/src/bitrot/loaders/ssmt_load.c
+++ b/src/bitrot/loaders/ssmt_load.c
@@ -182,7 +182,7 @@ static int mtp_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	for (i = 0; i < mod->ins; i++) {
 		struct xmp_instrument *xxi = &mod->xxi[i];
 		HIO_HANDLE *s;
-		char filename[1024];
+		char *filename = NULL;
 		char tmpname[32];
 
 		if (!m->dirname) {
@@ -192,12 +192,15 @@ static int mtp_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		if (!xxi->name[0] || libxmp_copy_name_for_fopen(tmpname, xxi->name, 32))
 			continue;
 
-		snprintf(filename, 1024, "%s%s", m->dirname, tmpname);
+		if (asprintf(&filename, "%s%s", m->dirname, tmpname) < 0)
+			continue;
 
 		if ((s = hio_open(filename, "rb")) != NULL) {
 			asif_load(m, s, i);
 			hio_close(s);
 		}
+
+		free(filename);
 
 #if 0
 		mod->xxs[i].lps = 0;

--- a/src/common.h
+++ b/src/common.h
@@ -47,14 +47,6 @@
 #define LIBXMP_RESTRICT
 #endif
 
-#if defined(_MSC_VER) ||  defined(__WATCOMC__) || defined(__EMX__)
-#define XMP_MAXPATH _MAX_PATH
-#elif defined(PATH_MAX)
-#define XMP_MAXPATH  PATH_MAX
-#else
-#define XMP_MAXPATH  1024
-#endif
-
 #if defined(__MORPHOS__) || defined(__AROS__) || defined(__AMIGA__) \
  || defined(__amigaos__) || defined(__amigaos4__) || defined(AMIGA)
 #define LIBXMP_AMIGA	1
@@ -388,7 +380,6 @@ struct module_data {
 
 	char *dirname;			/* file dirname */
 	char *basename;			/* file basename */
-	const char *filename;		/* Module file name */
 	char *comment;			/* Comments, if any */
 	uint8 md5[16];			/* MD5 message digest */
 	int size;			/* File size */

--- a/src/load.c
+++ b/src/load.c
@@ -387,11 +387,8 @@ int xmp_load_module(xmp_context opaque, const char *path)
 		ret = -XMP_ERROR_SYSTEM;
 		goto err;
 	}
-
-	m->filename = path;	/* For ALM, SSMT, etc */
 	m->size = hio_size(h);
 #else
-	ctx->m.filename = NULL;
 	ctx->m.dirname = NULL;
 	ctx->m.basename = NULL;
 #endif
@@ -432,7 +429,6 @@ int xmp_load_module_from_memory(xmp_context opaque, const void *mem, long size)
 	if (ctx->state > XMP_STATE_UNLOADED)
 		xmp_release_module(opaque);
 
-	m->filename = NULL;
 	m->basename = NULL;
 	m->dirname = NULL;
 	m->size = size;
@@ -457,7 +453,6 @@ int xmp_load_module_from_file(xmp_context opaque, void *file, long size)
 	if (ctx->state > XMP_STATE_UNLOADED)
 		xmp_release_module(opaque);
 
-	m->filename = NULL;
 	m->basename = NULL;
 	m->dirname = NULL;
 	m->size = hio_size(h);
@@ -483,7 +478,6 @@ int xmp_load_module_from_callbacks(xmp_context opaque, void *priv,
 	if (ctx->state > XMP_STATE_UNLOADED)
 		xmp_release_module(opaque);
 
-	m->filename = NULL;
 	m->basename = NULL;
 	m->dirname = NULL;
 	m->size = hio_size(h);

--- a/src/loaders/flt_load.c
+++ b/src/loaders/flt_load.c
@@ -298,27 +298,28 @@ static int flt_load(struct module_data *m, HIO_HANDLE * f, const int start)
 	struct mod_header mh;
 	uint8 mod_event[4];
 	const char *tracker;
-	char filename[1024];
+	char *filename = NULL;
 	char buf[16];
-	HIO_HANDLE *nt;
+	HIO_HANDLE *nt = NULL;
 	int am_synth;
 
 	LOAD_INIT();
 
 	/* See if we have the synth parameters file */
 	am_synth = 0;
-	snprintf(filename, 1024, "%s%s.NT", m->dirname, m->basename);
-	if ((nt = hio_open(filename, "rb")) == NULL) {
-		snprintf(filename, 1024, "%s%s.nt", m->dirname, m->basename);
+	if (asprintf(&filename, "%s%s.NT", m->dirname, m->basename) >= 0) {
+		char *p = strrchr(filename, '.');
 		if ((nt = hio_open(filename, "rb")) == NULL) {
-			snprintf(filename, 1024, "%s%s.AS", m->dirname,
-				 m->basename);
+			strcpy(p, ".nt");
 			if ((nt = hio_open(filename, "rb")) == NULL) {
-				snprintf(filename, 1024, "%s%s.as", m->dirname,
-					 m->basename);
-				nt = hio_open(filename, "rb");
+				strcpy(p, ".AS");
+				if ((nt = hio_open(filename, "rb")) == NULL) {
+					strcpy(p, ".as");
+					nt = hio_open(filename, "rb");
+				}
 			}
 		}
+		free(filename);
 	}
 
 	tracker = "Startrekker";

--- a/src/loaders/loader.h
+++ b/src/loaders/loader.h
@@ -47,8 +47,8 @@ void	libxmp_set_xxh_defaults		(struct xmp_module *);
 void	libxmp_decode_protracker_event	(struct xmp_event *, const uint8 *);
 void	libxmp_decode_noisetracker_event(struct xmp_event *, const uint8 *);
 void	libxmp_disable_continue_fx	(struct xmp_event *);
-int	libxmp_check_filename_case	(const char *, const char *, char *, int);
-void	libxmp_get_instrument_path	(struct module_data *, char *, int);
+char    *libxmp_check_filename_case	(const char *, const char *);
+const char *libxmp_get_instrument_path	(struct module_data *);
 void	libxmp_set_type			(struct module_data *, const char *, ...);
 int	libxmp_load_sample		(struct module_data *, HIO_HANDLE *, int,
 					 struct xmp_sample *, const void *);

--- a/src/loaders/med2_load.c
+++ b/src/loaders/med2_load.c
@@ -184,26 +184,23 @@ static int med2_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	D_(D_INFO "Instruments    : %d ", mod->ins);
 
 	for (i = 0; i < 31; i++) {
-		char path[XMP_MAXPATH];
-		char ins_path[256];
+		char *path;
+		const char *ins_path;
 		char ins_name[32];
-		char name[256];
 		HIO_HANDLE *s = NULL;
 		int found = 0;
 
 		if (libxmp_copy_name_for_fopen(ins_name, mod->xxi[i].name, 32) != 0)
 			continue;
 
-		libxmp_get_instrument_path(m, ins_path, 256);
-		if (libxmp_check_filename_case(ins_path, ins_name, name, 256)) {
-			snprintf(path, XMP_MAXPATH, "%s/%s", ins_path, name);
+		ins_path = libxmp_get_instrument_path(m);
+		if ((path = libxmp_check_filename_case(ins_path, ins_name)) != NULL) {
 			found = 1;
 		}
 
 		/* Try the module dir if the instrument path didn't work. */
 		if (!found && m->dirname != NULL &&
-		    libxmp_check_filename_case(m->dirname, ins_name, name, 256)) {
-			snprintf(path, XMP_MAXPATH, "%s%s", m->dirname, name);
+		    (path = libxmp_check_filename_case(m->dirname, ins_name)) != NULL) {
 			found = 1;
 		}
 
@@ -212,6 +209,8 @@ static int med2_load(struct module_data *m, HIO_HANDLE *f, const int start)
 				mod->xxs[i].len = hio_size(s);
 			}
 		}
+
+		free(path);
 
 		if (mod->xxs[i].len > 0) {
 			mod->xxi[i].nsm = 1;

--- a/src/loaders/mod_load.c
+++ b/src/loaders/mod_load.c
@@ -943,7 +943,7 @@ skip_test:
 	#else
 	if (ptsong) {
 	    HIO_HANDLE *s;
-	    char sn[XMP_MAXPATH];
+	    char *sn = NULL;
 	    char tmpname[32];
 	    const char *instname = mod->xxi[i].name;
 
@@ -953,15 +953,19 @@ skip_test:
 	    if (libxmp_copy_name_for_fopen(tmpname, instname, 32))
 		continue;
 
-	    snprintf(sn, XMP_MAXPATH, "%s%s", m->dirname, tmpname);
+	    if (asprintf(&sn, "%s%s", m->dirname, tmpname) < 0)
+		return -1;
 
 	    if ((s = hio_open(sn, "rb")) != NULL) {
 	        if (libxmp_load_sample(m, s, flags, &mod->xxs[i], NULL) < 0) {
 		    hio_close(s);
+		    free(sn);
 		    return -1;
 		}
 		hio_close(s);
 	    }
+
+            free(sn);
 	} else {
 	    uint8 buf[5];
 	    long pos;

--- a/src/win32.c
+++ b/src/win32.c
@@ -3,6 +3,54 @@
 
 #include "common.h"
 
+#if defined(USE_LIBXMP_ASPRINTF)
+
+#undef asprintf
+
+int libxmp_asprintf(char **strp, const char *fmt, ...)
+{
+	int n;
+	int size = 100;     /* Guess we need no more than 100 bytes */
+	char *p, *np;
+	va_list ap;
+
+	*strp = NULL;
+
+	if ((p = malloc(size)) == NULL)
+		return -1;
+
+	while (1) {
+		/* Try to print in the allocated space */
+		va_start(ap, fmt);
+		n = vsnprintf(p, size, fmt, ap);
+		va_end(ap);
+
+		/* Check error code */
+		if (n < 0) {
+			free(p);
+			return -1;
+		}
+
+		/* If that worked, return the string */
+		if (n < size) {
+			*strp = p;
+			return n;
+		}
+
+		/* Else try again with more space */
+		size = n + 1; /* Precisely what is needed */
+
+		if ((np = realloc (p, size)) == NULL) {
+			free(p);
+			return -1;
+		} else {
+			p = np;
+		}
+	}
+}
+
+#endif
+
 #if defined(USE_LIBXMP_SNPRINTF)
 
 #undef snprintf


### PR DESCRIPTION
This should make it possible to handle paths with more than `XMP_MAXPATH` characters relatively easily. A fallback is also provided based on the code from [here](https://linux.die.net/man/3/asprintf).

I wasn't sure how to handle the `_GNU_SOURCE` requirement, so for now it produces additional warnings on platforms that have `asprintf`.
