### PR TITLE
Added an extra check on the restart value for XM modules

### DIFF
--- a/src/loaders/xm_load.c
+++ b/src/loaders/xm_load.c
@@ -814,10 +814,6 @@ static int xm_load(struct module_data *m, HIO_HANDLE * f, const int start)
 		return -1;
 	}
 
-	if (xfh.restart > 255 && xfh.restart != 0xffff) {
-		D_(D_CRIT "bad restart position: %d", xfh.restart);
-		return -1;
-	}
 	if (xfh.channels > XMP_MAX_CHANNELS) {
 		D_(D_CRIT "bad channel count: %d", xfh.channels);
 		return -1;
@@ -850,7 +846,7 @@ static int xm_load(struct module_data *m, HIO_HANDLE * f, const int start)
 	mod->chn = xfh.channels;
 	mod->pat = xfh.patterns;
 	mod->ins = xfh.instruments;
-	mod->rst = xfh.restart > 255 ? 0 : xfh.restart;
+	mod->rst = xfh.restart > xfh.songlen ? 0 : xfh.restart;
 	mod->spd = xfh.tempo;
 	mod->bpm = xfh.bpm;
 	mod->trk = mod->chn * mod->pat + 1;

--- a/src/loaders/xm_load.c
+++ b/src/loaders/xm_load.c
@@ -814,7 +814,7 @@ static int xm_load(struct module_data *m, HIO_HANDLE * f, const int start)
 		return -1;
 	}
 
-	if (xfh.restart > 255) {
+	if (xfh.restart > 255 && xfh.restart != 0xffff) {
 		D_(D_CRIT "bad restart position: %d", xfh.restart);
 		return -1;
 	}
@@ -850,7 +850,7 @@ static int xm_load(struct module_data *m, HIO_HANDLE * f, const int start)
 	mod->chn = xfh.channels;
 	mod->pat = xfh.patterns;
 	mod->ins = xfh.instruments;
-	mod->rst = xfh.restart;
+	mod->rst = xfh.restart > 255 ? 0 : xfh.restart;
 	mod->spd = xfh.tempo;
 	mod->bpm = xfh.bpm;
 	mod->trk = mod->chn * mod->pat + 1;

--- a/src/loaders/xm_load.c
+++ b/src/loaders/xm_load.c
@@ -846,7 +846,7 @@ static int xm_load(struct module_data *m, HIO_HANDLE * f, const int start)
 	mod->chn = xfh.channels;
 	mod->pat = xfh.patterns;
 	mod->ins = xfh.instruments;
-	mod->rst = xfh.restart > xfh.songlen ? 0 : xfh.restart;
+	mod->rst = xfh.restart >= xfh.songlen ? 0 : xfh.restart;
 	mod->spd = xfh.tempo;
 	mod->bpm = xfh.bpm;
 	mod->trk = mod->chn * mod->pat + 1;


### PR DESCRIPTION
Added an extra check on the restart value for XM modules, so it is possible to play "10 Days Of Abstinence.xm".

This module has a value of 0xffff as the restart and before this change, the loader failed. Now it can load this module and play it.

You can find the module here:

https://modland.com/pub/modules/Fasttracker%202/Andy%20(DE)/10%20days%20of%20abstinence.xm