### PR TITLE
Fix restart position for >64k sample and Digital Tracker MODs.

### DIFF
--- a/src/loaders/mod_load.c
+++ b/src/loaders/mod_load.c
@@ -542,11 +542,13 @@ static int mod_load(struct module_data *m, HIO_HANDLE *f, const int start)
     strncpy(mod->name, (char *) mh.name, 20);
 
     mod->len = mh.len;
-    /* mod->rst = mh.restart; */
-
-    if (mod->rst >= mod->len)
-	mod->rst = 0;
     memcpy(mod->xxo, mh.order, 128);
+
+    if (mh.restart < 0x7f && mh.restart != 0x78 && (int)mh.restart < mod->len) {
+	/* TODO: an older version of this code was commented out 23+ years ago
+	 * and adding this may have rebroke something. */
+	mod->rst = mh.restart;
+    }
 
     for (i = 0; i < 128; i++) {
 	/* This fixes dragnet.mod (garbage in the order list) */

--- a/test-dev/data/format_mod_dt.data
+++ b/test-dev/data/format_mod_dt.data
@@ -1,6 +1,6 @@
 8 voices mods
 Digital Tracker FA08
-9 72 8 31 31 6 125 10 0 64
+9 72 8 31 31 6 125 10 4 64
 0 1 2 3 4 6 5 5 7 8
 64 1 0 By MC JEE/KAMIKAZES
 0 0 0 0 0 0 0


### PR DESCRIPTION
Workaround for a bug caused by a change prior to version tracking. I should note that libxmp-lite is not setting the restart position for MOD anywhere whatsoever as far as I can tell.

Ideally it'd be nice to know why that line was commented out so it can be uncommented.

Fixes #763 for libxmp and  libxmp-lite.