### PR TITLE
Add HWAddressSanitizer fuzzer (AArch64 only).

### DIFF
--- a/test-dev/Makefile.in
+++ b/test-dev/Makefile.in
@@ -774,46 +774,80 @@ $(addprefix $(SRC_PATH)/,$(TEST_INTERNAL)): $(SRC_PATH)/player.h
 #
 
 FUZZLIB_PATH		= .fuzzer
-FUZZ_ASAN_FLAGS		= -O3 -fsanitize=fuzzer,address,undefined -fno-sanitize-recover=all -fno-sanitize=shift-base -fno-omit-frame-pointer -g -DLIBXMP_LIBFUZZER -I../include -I../src
-FUZZ_MSAN_FLAGS		= -O3 -fsanitize=fuzzer,memory -fsanitize-memory-track-origins=2 -fno-omit-frame-pointer -g -DLIBXMP_LIBFUZZER -I../include -I../src
-FUZZLIB_ASAN_FLAGS	= $(subst fuzzer,fuzzer-no-link,$(FUZZ_ASAN_FLAGS))
-FUZZLIB_MSAN_FLAGS	= $(subst fuzzer,fuzzer-no-link,$(FUZZ_MSAN_FLAGS))
+FUZZ_CFLAGS		+= -fno-omit-frame-pointer -g -DLIBXMP_LIBFUZZER -I../include -I../src
+FUZZ_LDFLAGS		+= -fuse-ld=lld -L$(FUZZLIB_PATH)
 FUZZ_CC			?= clang
+
+FUZZ_ASAN_FLAGS		= -O3 -fsanitize=fuzzer,address,undefined \
+			  -fno-sanitize-recover=all -fno-sanitize=shift-base
+FUZZ_HWASAN_FLAGS	= -O3 -fsanitize=fuzzer,hwaddress,undefined \
+			  -fno-sanitize-recover=all -fno-sanitize=shift-base
+FUZZ_MSAN_FLAGS		= -O3 -fsanitize=fuzzer,memory -fsanitize-memory-track-origins=2
+
+FUZZ_ASAN_FLAGS		+= $(FUZZ_CFLAGS)
+FUZZ_HWASAN_FLAGS	+= $(FUZZ_CFLAGS)
+FUZZ_MSAN_FLAGS		+= $(FUZZ_CFLAGS)
+
+FUZZLIB_ASAN_FLAGS	= $(subst fuzzer,fuzzer-no-link,$(FUZZ_ASAN_FLAGS))
+FUZZLIB_HWASAN_FLAGS	= $(subst fuzzer,fuzzer-no-link,$(FUZZ_HWASAN_FLAGS))
+FUZZLIB_MSAN_FLAGS	= $(subst fuzzer,fuzzer-no-link,$(FUZZ_MSAN_FLAGS))
+
+FUZZ_MAKE		= CC=$(FUZZ_CC) \
+			  cmake ../../../CMakeLists.txt -B. -S../../.. \
+			  -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED=OFF && \
+			  $(MAKE)
 
 .PHONY: fuzzers fuzzerclean $(FUZZLIB_PATH)
 
 fuzzers: libxmp_fuzz_asan libxmp_fuzz_msan
 
+# This will build on x86_64 but currently is usable on ARM only.
+ifneq ($(filter aarch64 arm64,$(shell uname -m)),)
+fuzzers: libxmp_fuzz_hwasan
+endif
+
 fuzzerclean:
-	rm -rf $(FUZZLIB_PATH) libxmp_fuzz_asan libxmp_fuzz_msan
+	rm -rf $(FUZZLIB_PATH) libxmp_fuzz_asan libxmp_fuzz_hwasan libxmp_fuzz_msan
 
 $(FUZZLIB_PATH):
 	rm -rf $(FUZZLIB_PATH)
-	mkdir -p $(FUZZLIB_PATH)
-	(BASE=$$(pwd); cd .. && git checkout-index -a --prefix "$$BASE/$(FUZZLIB_PATH)/")
+	mkdir -p $(FUZZLIB_PATH)/asan $(FUZZLIB_PATH)/hwasan $(FUZZLIB_PATH)/msan
 
 $(FUZZLIB_PATH)/libxmp-asan.a: $(FUZZLIB_PATH)
-	(cd $(FUZZLIB_PATH) && \
-		$(AUTOCONF) && \
-		CC="$(FUZZ_CC)" CFLAGS="$(FUZZLIB_ASAN_FLAGS)" LDFLAGS="$(FUZZLIB_ASAN_FLAGS)" ./configure && \
-		$(MAKE) static && \
-		cp lib/libxmp.a libxmp-asan.a && \
-		$(MAKE) distclean)
+	(cd $(FUZZLIB_PATH)/asan && \
+		CFLAGS="$(FUZZLIB_ASAN_FLAGS)" \
+		LDFLAGS="$(FUZZLIB_ASAN_FLAGS)" \
+		$(FUZZ_MAKE) && \
+		mv libxmp.a ../libxmp-asan.a && \
+		$(MAKE) clean)
 
-$(FUZZLIB_PATH)/libxmp-msan.a: $(FUZZLIB_PATH) | $(FUZZLIB_PATH)/libxmp-asan.a
-	(cd $(FUZZLIB_PATH) && \
-		$(AUTOCONF) && \
-		CC="$(FUZZ_CC)" CFLAGS="$(FUZZLIB_MSAN_FLAGS)" LDFLAGS="$(FUZZLIB_MSAN_FLAGS)" ./configure && \
-		$(MAKE) static && \
-		cp lib/libxmp.a libxmp-msan.a && \
-		$(MAKE) distclean)
+$(FUZZLIB_PATH)/libxmp-hwasan.a: $(FUZZLIB_PATH)
+	(cd $(FUZZLIB_PATH)/hwasan && \
+		CFLAGS="$(FUZZLIB_HWASAN_FLAGS)" \
+		LDFLAGS="$(FUZZLIB_HWASAN_FLAGS)" \
+		$(FUZZ_MAKE) && \
+		mv libxmp.a ../libxmp-hwasan.a && \
+		$(MAKE) clean)
+
+$(FUZZLIB_PATH)/libxmp-msan.a: $(FUZZLIB_PATH)
+	(cd $(FUZZLIB_PATH)/msan && \
+		CFLAGS="$(FUZZLIB_MSAN_FLAGS)" \
+		LDFLAGS="$(FUZZLIB_MSAN_FLAGS)" \
+		$(FUZZ_MAKE) && \
+		mv libxmp.a ../libxmp-msan.a && \
+		$(MAKE) clean)
 
 libxmp_fuzz_asan: libxmp_fuzz.c $(FUZZLIB_PATH)/libxmp-asan.a
-	@CMD='$(FUZZ_CC) $(FUZZ_ASAN_FLAGS) -o $@ $< -L$(FUZZLIB_PATH) -lxmp-asan'; \
+	@CMD='$(FUZZ_CC) $(FUZZ_ASAN_FLAGS) -o $@ $< $(FUZZ_LDFLAGS) -lxmp-asan'; \
+	if [ "$(V)" -gt 0 ]; then echo $$CMD; else echo LD $@ ; fi; \
+	eval $$CMD
+
+libxmp_fuzz_hwasan: libxmp_fuzz.c $(FUZZLIB_PATH)/libxmp-hwasan.a
+	@CMD='$(FUZZ_CC) $(FUZZ_HWASAN_FLAGS) -o $@ $< $(FUZZ_LDFLAGS) -lxmp-hwasan'; \
 	if [ "$(V)" -gt 0 ]; then echo $$CMD; else echo LD $@ ; fi; \
 	eval $$CMD
 
 libxmp_fuzz_msan: libxmp_fuzz.c $(FUZZLIB_PATH)/libxmp-msan.a
-	@CMD='$(FUZZ_CC) $(FUZZ_MSAN_FLAGS) -o $@ $< -L$(FUZZLIB_PATH) -lxmp-msan'; \
+	@CMD='$(FUZZ_CC) $(FUZZ_MSAN_FLAGS) -o $@ $< $(FUZZ_LDFLAGS) -lxmp-msan'; \
 	if [ "$(V)" -gt 0 ]; then echo $$CMD; else echo LD $@ ; fi; \
 	eval $$CMD

--- a/test-dev/libxmp_fuzz.sh
+++ b/test-dev/libxmp_fuzz.sh
@@ -30,6 +30,9 @@ case "$COMMAND" in
 	asanx)
 		./libxmp_fuzz_asan -artifact_prefix="ARTIFACTS/" "$@"
 		;;
+	hwasanx)
+		./libxmp_fuzz_hwasan -artifact_prefix="ARTIFACTS/" "$@"
+		;;
 	msanx)
 		./libxmp_fuzz_msan -artifact_prefix="ARTIFACTS/" "$@"
 		;;
@@ -40,6 +43,10 @@ case "$COMMAND" in
 	asan)
 		mkdir -p "CORPUS"
 		./libxmp_fuzz_asan $DEFAULT_PARAMETERS "$@"
+		;;
+	hwasan)
+		mkdir -p "CORPUS"
+		./libxmp_fuzz_hwasan $DEFAULT_PARAMETERS "$@"
 		;;
 	msan)
 		mkdir -p "CORPUS"


### PR DESCRIPTION
The HWAddressSanitizer is very similar to AddressSanitizer except, instead of using redzones and a quarantine that consume a lot of RAM, it uses address tagging (via AArch64 top byte ignore) to detect out-of-bounds accesses and use-after-frees. This significantly reduces the RAM consumed, which has been a constant issue on my Le Potato.

I also reformatted the fuzzer rules yet again to hopefully suck less. Instead of making the fuzzer libraries interdependent to synchronize them, the fuzzer builds now use CMake with different build directories. The alternative was duplicating the copy source tree for each build. This was necessary because the new fuzzer (and potentially other future ones) are optional. Other considerations: .NOTPARALLEL doesn't work on individual rules in fairly recent Make releases, and putting the recursive Make invocations in one rule makes building individual fuzzers dirtier (and neither solution fixes the case of using "make libxmp_fuzz_asan libxmp_fuzz_msan").

This could probably be worked on further to not require nuking the whole build tree every time.

edit: this patch has been sitting around for a while and has been tested successfully on my Le Potato. I am going to go ahead and fuzz on this branch for a while before the rest of the 4.6.1 tickets are resolved but it should be good to merge anyway.