### PR TITLE
Merge song file instrument path detection routines.

### DIFF
--- a/src/bitrot/loaders/ssmt_load.c
+++ b/src/bitrot/loaders/ssmt_load.c
@@ -14,10 +14,10 @@
 /* From the deMODifier readme:
  *
  * SoundSmith was arguably the most popular music authoring tool for the
- * Apple IIgs.  Introduced in the IIgs's heyday (which was, accurately 
+ * Apple IIgs.  Introduced in the IIgs's heyday (which was, accurately
  * enough, just about one day), this software inspired the creation
- * of countless numbers of IIgs-specific tunes, several of which were 
- * actually worth listening to.  
+ * of countless numbers of IIgs-specific tunes, several of which were
+ * actually worth listening to.
  */
 
 #include "loader.h"
@@ -76,7 +76,7 @@ static int mtp_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	blocksize = hio_read16l(f);
 	mod->spd = hio_read16l(f);
 	hio_seek(f, 10, SEEK_CUR);		/* skip 10 reserved bytes */
-	
+
 	mod->ins = mod->smp = 15;
 	if (libxmp_init_instrument(m) < 0)
 		return -1;
@@ -182,17 +182,14 @@ static int mtp_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	for (i = 0; i < mod->ins; i++) {
 		struct xmp_instrument *xxi = &mod->xxi[i];
 		HIO_HANDLE *s;
-		char filename[1024];
+		char filename[XMP_MAXPATH];
 		char tmpname[32];
 
-		if (!m->dirname) {
-			return -1;
-		}
-
-		if (!xxi->name[0] || libxmp_copy_name_for_fopen(tmpname, xxi->name, 32))
+		if (libxmp_copy_name_for_fopen(tmpname, xxi->name, 32) != 0)
 			continue;
 
-		snprintf(filename, 1024, "%s%s", m->dirname, tmpname);
+		if (!libxmp_find_instrument_file(m, filename, sizeof(filename), tmpname))
+			continue;
 
 		if ((s = hio_open(filename, "rb")) != NULL) {
 			asif_load(m, s, i);

--- a/src/loaders/common.c
+++ b/src/loaders/common.c
@@ -443,7 +443,7 @@ int libxmp_check_filename_case(const char *dir, const char *name, char *new_name
 int libxmp_check_filename_case(const char *dir, const char *name, char *new_name, int size)
 {
 	int found = 0;
-	int ret;
+	int ret = size;
 	DIR *dirp;
 	struct dirent *d;
 

--- a/src/loaders/common.c
+++ b/src/loaders/common.c
@@ -299,7 +299,7 @@ int libxmp_copy_name_for_fopen(char *dest, const char *name, int n)
 	 * malicious when given to fopen. This should only be used on song files.
 	 */
 	if (!strcmp(name, ".") || strstr(name, "..") ||
-	    name[0] == '\\' || name[0] == '/' || name[0] == ':')
+	    name[0] == '\\' || name[0] == '/' || name[0] == ':' || name[0] == '\0')
 		return -1;
 
 	for (i = 0; i < n - 1; i++) {
@@ -432,16 +432,18 @@ void libxmp_disable_continue_fx(struct xmp_event *event)
 int libxmp_check_filename_case(const char *dir, const char *name, char *new_name, int size)
 {
 	char path[XMP_MAXPATH];
+	int ret;
 	snprintf(path, sizeof(path), "%s/%s", dir, name);
 	if (! (libxmp_get_filetype(path) & XMP_FILETYPE_FILE))
 		return 0;
-	strncpy(new_name, name, size);
-	return 1;
+	ret = snprintf(new_name, size, "%s", name);
+	return (ret < size);
 }
 #else /* target has dirent */
 int libxmp_check_filename_case(const char *dir, const char *name, char *new_name, int size)
 {
 	int found = 0;
+	int ret;
 	DIR *dirp;
 	struct dirent *d;
 
@@ -452,26 +454,51 @@ int libxmp_check_filename_case(const char *dir, const char *name, char *new_name
 	while ((d = readdir(dirp)) != NULL) {
 		if (!strcasecmp(d->d_name, name)) {
 			found = 1;
-			strncpy(new_name, d->d_name, size);
+			ret = snprintf(new_name, size, "%s", d->d_name);
 			break;
 		}
 	}
 
 	closedir(dirp);
 
-	return found;
+	return found ? (ret < size) : 0;
 }
 #endif
 
-void libxmp_get_instrument_path(struct module_data *m, char *path, int size)
+static const char *libxmp_get_instrument_path(struct module_data *m)
 {
+	char *env;
 	if (m->instrument_path) {
-		strncpy(path, m->instrument_path, size);
-	} else if (getenv("XMP_INSTRUMENT_PATH")) {
-		strncpy(path, getenv("XMP_INSTRUMENT_PATH"), size);
-	} else {
-		strncpy(path, ".", size);
+		return m->instrument_path;
+	} else if ((env = getenv("XMP_INSTRUMENT_PATH"))) {
+		return env;
 	}
+	return NULL;
+}
+
+int libxmp_find_instrument_file(struct module_data *m, char *path_dest,
+				int path_dest_len, const char *ins_name)
+{
+	const char *ins_path;
+	char name[256];
+	int ret;
+
+	ins_path = libxmp_get_instrument_path(m);
+	if (ins_path != NULL &&
+	    libxmp_check_filename_case(ins_path, ins_name, name, sizeof(name))) {
+		ret = snprintf(path_dest, path_dest_len, "%s/%s", ins_path, name);
+		path_dest[path_dest_len - 1] = '\0';
+		return (ret < path_dest_len);
+	}
+
+	/* Try the module dir if the instrument path didn't work. */
+	if (m->dirname != NULL &&
+	    libxmp_check_filename_case(m->dirname, ins_name, name, sizeof(name))) {
+		ret = snprintf(path_dest, path_dest_len, "%s%s", m->dirname, name);
+		path_dest[path_dest_len - 1] = '\0';
+		return (ret < path_dest_len);
+	}
+	return 0;
 }
 #endif /* LIBXMP_CORE_PLAYER */
 

--- a/src/loaders/loader.h
+++ b/src/loaders/loader.h
@@ -48,7 +48,7 @@ void	libxmp_decode_protracker_event	(struct xmp_event *, const uint8 *);
 void	libxmp_decode_noisetracker_event(struct xmp_event *, const uint8 *);
 void	libxmp_disable_continue_fx	(struct xmp_event *);
 int	libxmp_check_filename_case	(const char *, const char *, char *, int);
-void	libxmp_get_instrument_path	(struct module_data *, char *, int);
+int	libxmp_find_instrument_file	(struct module_data *, char *, int, const char *);
 void	libxmp_set_type			(struct module_data *, const char *, ...);
 int	libxmp_load_sample		(struct module_data *, HIO_HANDLE *, int,
 					 struct xmp_sample *, const void *);

--- a/src/loaders/mod_load.c
+++ b/src/loaders/mod_load.c
@@ -939,31 +939,30 @@ skip_test:
 
 	flags = (ptkloop && mod->xxs[i].lps == 0) ? SAMPLE_FLAG_FULLREP : 0;
 
-	#ifdef LIBXMP_CORE_PLAYER
+#ifdef LIBXMP_CORE_PLAYER
 	if (libxmp_load_sample(m, f, flags, &mod->xxs[i], NULL) < 0)
 		return -1;
-	#else
+#else
 	if (ptsong) {
 	    HIO_HANDLE *s;
 	    char sn[XMP_MAXPATH];
 	    char tmpname[32];
 	    const char *instname = mod->xxi[i].name;
 
-	    if (!instname[0] || !m->dirname)
+	    if (libxmp_copy_name_for_fopen(tmpname, instname, 32) != 0)
 		continue;
 
-	    if (libxmp_copy_name_for_fopen(tmpname, instname, 32))
+	    if (!libxmp_find_instrument_file(m, sn, sizeof(sn), tmpname))
 		continue;
 
-	    snprintf(sn, XMP_MAXPATH, "%s%s", m->dirname, tmpname);
+	    if ((s = hio_open(sn, "rb")) == NULL)
+		continue;
 
-	    if ((s = hio_open(sn, "rb")) != NULL) {
-	        if (libxmp_load_sample(m, s, flags, &mod->xxs[i], NULL) < 0) {
-		    hio_close(s);
-		    return -1;
-		}
+	    if (libxmp_load_sample(m, s, flags, &mod->xxs[i], NULL) < 0) {
 		hio_close(s);
+		return -1;
 	    }
+	    hio_close(s);
 	} else {
 	    uint8 buf[5];
 	    long pos;
@@ -983,7 +982,7 @@ skip_test:
 	    if (libxmp_load_sample(m, f, flags, &mod->xxs[i], NULL) < 0)
 		return -1;
 	}
-	#endif
+#endif
     }
 
     #ifdef LIBXMP_CORE_PLAYER


### PR DESCRIPTION
I found a few glaring issues that needed addressing while fixing a MED2 loader snprintf truncation warning related to sample loading. The MOD, STM, MED2, and (bitrot) SSMT loaders all contain separate routines to generate the path of an instrument/sample file when loading song files. These are implemented roughly as follows:

* MOD: combine `m->dirname` with the cleaned sample name, open.
* STM: combine `m->dirname` with the cleaned sample name, open.
* SSMT: combine `m->dirname` with the cleaned sample name, open.
* MED2:
  1) Get the instrument path set by `xmp_set_instrument_path` or if it is not set, get the environment variable `XMP_INSTRUMENT_PATH`, or if it is not set, `.`. Combine this with the cleaned sample name and attempt a case-insensitive match, then open.
  2) Combine `m->dirname` with the cleaned sample name, attempt a case-insensitive match, then open. This was added by #416 for consistency with the other loaders.

Clearly, one of these is not like the others! There are a few major issues here.

1) The MOD, STM, and SSMT loaders totally ignore
   `xmp_set_instrument_path` and/or `XMP_INSTRUMENT_PATH`, which
   sucks and means this feature is only useful for MED2, a format
   where literally no test files existed and I had to make my own
   for libxmp's regression tests. Note that this feature allows
   memory modules to load instruments, and `m->dirname` only works
   for file modules.
2) The MOD, STM, and SSMT loaders fail to check for instrument files
   case-insensitively. MOD is from the same platform as MED2 and STM
   is explicitly from a case-insensitive operating system, so this is
   a strange omission.
3) MED2, on the other hand, attempts to check the current directory
   if neither `xmp_set_instrument_path` or `XMP_INSTRUMENT_PATH` is
   set, which is strange and seems like a worse version of loading
   from `m->dirname`. Worse, if this was applied to MOD/STM, it could
   cause new misbehavior that `xmp_set_instrument_path` and
   `XMP_INSTRUMENT_PATH` are less likely to, so I removed it.
   Intentional "regressions" to MED2 are better than to MOD/STM.
4) No failure checks on any of the `snprintf` occurrences, so really
   these `fopen` calls could be opening anything if they truncate.

The new, combined handling for all loaders is now:

1) Get `xmp_set_instrument_path` or `XMP_INSTRUMENT_PATH` if it is
   set, combine it with the cleaned sample name, and attempt a
   case-insensitive search. If all the copies were successful and
   the file was found, open.
2) Get `m->dirname` if it is set, combine it with the cleaned sample
   name, and attempt a case-insensitive search. If all the copies
   were successful and the file was found, open.

TANGENT TIME: `strncpy` is the worst C standard library function. `strncpy` will pad its entire buffer with `\0` even when this isn't wanted or requested, but when the input string is longer than the output buffer, it will not null terminate the output buffer. It is not safe. After merging the handlers to address the above issues, GCC's stringop analyzer found several misuses of this function that have been hiding in plain sight for years and opening us up to more out-of-bounds reads. I've replaced them all with `snprintf` as this also allows the detection of truncation with its return value, which in turn can be carried through as a fail state for sample loading.

Please review carefully: I'm not sure that I actually have any song files around to test with except for the MED2 in test-dev. Marking as a draft for now so I can re-review it myself after some sleep.