### PR TITLE
Fix crash when calling xmp_set_instrument_path with NULL.

### DIFF
--- a/docs/libxmp.rst
+++ b/docs/libxmp.rst
@@ -919,13 +919,15 @@ int xmp_set_instrument_path(xmp_context c, char \*path)
 ```````````````````````````````````````````````````````
 
   Set the path to retrieve external instruments or samples. Used by some
-  formats (such as MED2) to read sample files from a different directory
-  in the filesystem.
+  formats (such as Protracker song files, ST2 song files, and MED2) to
+  read sample files from a different directory in the filesystem.
 
   **Parameters:**
     :c: the player context handle.
 
     :path: the path to retrieve instrument files.
+      A value of ``NULL`` will unset the instrument path.
+      Prior to 4.6.1, this function crashes when ``path`` is ``NULL``.
 
   **Returns:**
     0 if the instrument path was correctly set, or ``-XMP_ERROR_SYSTEM``

--- a/src/control.c
+++ b/src/control.c
@@ -559,8 +559,13 @@ int xmp_set_instrument_path(xmp_context opaque, const char *path)
 	struct context_data *ctx = (struct context_data *)opaque;
 	struct module_data *m = &ctx->m;
 
-	if (m->instrument_path != NULL)
+	if (m->instrument_path != NULL) {
 		free(m->instrument_path);
+		m->instrument_path = NULL;
+	}
+	if (path == NULL) {
+		return 0;
+	}
 
 	m->instrument_path = libxmp_strdup(path);
 	if (m->instrument_path == NULL) {

--- a/src/loaders/common.c
+++ b/src/loaders/common.c
@@ -612,8 +612,13 @@ void libxmp_apply_mpt_preamp(struct module_data *m)
 
 char *libxmp_strdup(const char *src)
 {
-	size_t len = strlen(src) + 1;
-	char *buf = (char *) malloc(len);
+	size_t len;
+	char *buf;
+	if (src == NULL) {
+		return NULL;
+	}
+	len = strlen(src) + 1;
+	buf = (char *) malloc(len);
 	if (buf) {
 		memcpy(buf, src, len);
 	}

--- a/test-dev/Makefile.in
+++ b/test-dev/Makefile.in
@@ -64,7 +64,7 @@ API		= get_format_list create_context free_context \
 		  set_position prev_position set_position_midfx set_row \
 		  set_player stop_module restart_module seek_time \
 		  channel_mute channel_vol inject_event scan_module \
-		  set_tempo_factor
+		  set_tempo_factor set_instrument_path
 
 API_SMIX	= smix_play_instrument smix_load_sample smix_play_sample \
 		  smix_channel_pan

--- a/test-dev/all_tests.txt
+++ b/test-dev/all_tests.txt
@@ -255,6 +255,7 @@ test_api_channel_vol
 test_api_inject_event
 test_api_scan_module
 test_api_set_tempo_factor
+test_api_set_instrument_path
 test_api_smix_play_instrument
 test_api_smix_load_sample
 test_api_smix_play_sample

--- a/test-dev/test_api_set_instrument_path.c
+++ b/test-dev/test_api_set_instrument_path.c
@@ -1,0 +1,51 @@
+#include "test.h"
+
+static const char * const ins_paths[] =
+{
+	"sdjklfsd",
+	"/tmp/libxmp",
+	"C:\\jfkd\\dfklsd"
+};
+
+TEST(test_api_set_instrument_path)
+{
+	xmp_context opaque;
+	struct context_data *ctx;
+	struct module_data *m;
+	int ret;
+	int i;
+
+	opaque = xmp_create_context();
+	fail_unless(opaque != NULL, "failed to create context");
+
+	ctx = (struct context_data *)opaque;
+	m = &ctx->m;
+
+	/* Should be unset at startup */
+	fail_unless(m->instrument_path == NULL, "instrument path is set");
+
+	/* NULL should do nothing */
+	ret = xmp_set_instrument_path(opaque, NULL);
+	fail_unless(ret == 0, "failed to clear instrument path (1)");
+	fail_unless(m->instrument_path == NULL, "failed to clear instrument path (1)");
+
+	/* set instrument path */
+	for (i = 0; i < ARRAY_SIZE(ins_paths); i++) {
+		char msg[80];
+		snprintf(msg, sizeof(msg), "failed to set path (%d)", i + 1);
+
+		ret = xmp_set_instrument_path(opaque, ins_paths[i]);
+		fail_unless(ret == 0, msg);
+		fail_unless(m->instrument_path != NULL, msg);
+		ret = strcmp(m->instrument_path, ins_paths[i]);
+		fail_unless(ret == 0, msg);
+	}
+
+	/* NULL should reset the instrument path */
+	ret = xmp_set_instrument_path(opaque, NULL);
+	fail_unless(ret == 0, "failed to clear instrument path (2)");
+	fail_unless(m->instrument_path == NULL, "failed to clear instrument path (2)");
+
+	xmp_free_context(opaque);
+}
+END_TEST


### PR DESCRIPTION
The API function `xmp_set_instrument_path` crashes when provided with a path of `NULL` due to passing that `NULL` on to `libxmp_strdup`. I've fixed `libxmp_strdup` to return `NULL` when this occurs, and I've revised the behavior of `xmp_set_instrument_path` to clear the instrument path when given `NULL`. This is undefined behavior for `xmp_set_instrument_path` so it should not require a minor version change.