### PR TITLE
cmake: set maximum policy to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4...3.5)
+cmake_minimum_required(VERSION 3.4...3.10)
 project(libxmp VERSION 4.6.0 LANGUAGES C)
 
 set(LIBXMP_DEFINES)

--- a/lite/CMakeLists.txt
+++ b/lite/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4...3.5)
+cmake_minimum_required(VERSION 3.4...3.10)
 project(libxmplite VERSION 4.6.0 LANGUAGES C)
 
 set(LIBXMP_DEFINES)


### PR DESCRIPTION
compatibility with CMake < 3.10 will be removed in a future CMake version

( CC: @madebr )
