### PR TITLE
Apply fix from #99 to the module scan too.

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -594,8 +594,9 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 		xc->vol.fslide2 = -fxp;
 		break;
 	case FX_IT_BREAK:	/* Pattern break with hex parameter */
-		if (!f->loop_chn)
-		{
+		/* IT break is not applied if a lower channel looped (2.00+).
+		 * (Labyrinth of Zeux ZX_11.it "Raceway"). */
+		if (f->loop_chn == 0) {
 			p->flow.pbreak = 1;
 			p->flow.jumpline = fxp;
 		}

--- a/src/scan.c
+++ b/src/scan.c
@@ -513,8 +513,9 @@ static int scan_module(struct context_data *ctx, int ep, int chain)
 			m->scan_cnt[ord][row] = MIN(x, 255);
 			frame_count += (p1 & 0x0f) * speed;
 		}
-
-		if (f1 == FX_IT_BREAK) {
+		/* IT break is not applied if a lower channel looped (2.00+).
+		 * (Labyrinth of Zeux ZX_11.it "Raceway"). */
+		if (f1 == FX_IT_BREAK && loop_chn < 0) {
 		    break_row = p1;
 		    last_row = 0;
 		}


### PR DESCRIPTION
The fix from 70d98fc6, which changed IT pattern break to not be handled if a lower channel performed a loop, has also been applied to the scan. This fixes the reported duration of ZX_11.it (should be 1m14s, was reporting 1m11s).

[ZX_11.it.zip](https://github.com/user-attachments/files/18124416/ZX_11.it.zip)