### PR TITLE
mixer.c: Fix MSVC warning C4113.

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -111,7 +111,7 @@ MIX_FN(stereoout_mono_a500);
 MIX_FN(stereoout_mono_a500_filter);
 #endif
 
-typedef void (*MIX_FP) (struct mixer_voice *, int32 *, int, int, int, int, int, int, int);
+typedef void (*MIX_FP) (struct mixer_voice* LIBXMP_RESTRICT, int32* LIBXMP_RESTRICT, int, int, int, int, int, int, int);
 
 static const MIX_FP nearest_mixers[] = {
 	LIST_MIX_FUNCTIONS(nearest),


### PR DESCRIPTION
```
mixer.c(117,2): warning C4113: 'void (__cdecl *)(mixer_voice *restrict ,int32 *restrict ,int,int,int,int,int,int,int)' differs in parameter lists from 'const MIX_FP'
mixer.c(120,2): warning C4113: 'void (__cdecl *)(mixer_voice *restrict ,int32 *restrict ,int,int,int,int,int,int,int)' differs in parameter lists from 'const MIX_FP'
mixer.c(125,2): warning C4113: 'void (__cdecl *)(mixer_voice *restrict ,int32 *restrict ,int,int,int,int,int,int,int)' differs in parameter lists from 'const MIX_FP'
mixer.c(128,2): warning C4113: 'void (__cdecl *)(mixer_voice *restrict ,int32 *restrict ,int,int,int,int,int,int,int)' differs in parameter lists from 'const MIX_FP'
mixer.c(133,2): warning C4113: 'void (__cdecl *)(mixer_voice *restrict ,int32 *restrict ,int,int,int,int,int,int,int)' differs in parameter lists from 'const MIX_FP'
mixer.c(136,2): warning C4113: 'void (__cdecl *)(mixer_voice *restrict ,int32 *restrict ,int,int,int,int,int,int,int)' differs in parameter lists from 'const MIX_FP'
mixer.c(148,2): warning C4113: 'void (__cdecl *)(mixer_voice *restrict ,int32 *restrict ,int,int,int,int,int,int,int)' differs in parameter lists from 'const MIX_FP'
mixer.c(152,2): warning C4113: 'void (__cdecl *)(mixer_voice *restrict ,int32 *restrict ,int,int,int,int,int,int,int)' differs in parameter lists from 'const MIX_FP'
```