### PR TITLE
player.c (): Fix MSVC C4701 (uninitialized local variable) warning:

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -562,7 +562,7 @@ static void update_invloop(struct context_data *ctx, struct channel_data *xc)
 {
 	struct xmp_sample *xxs = libxmp_get_sample(ctx, xc->smp);
 	struct module_data *m = &ctx->m;
-	int lps, len = -1;
+	int lps = 0, len = -1;
 
 	xc->invloop.count += invloop_table[xc->invloop.speed];
 


### PR DESCRIPTION
`player.c(593,1): warning C4701: potentially uninitialized local variable 'lps' used`

Old gcc versions also emit the same warning:
```
src/player.c: In function `update_invloop':
src/player.c:565: warning: `lps' might be used uninitialized in this function
```

The warning is bogus, though.
