### PR TITLE
depackers, xz: Fix MSVC C4128 warning:

### DIFF
--- a/src/depackers/xz_dec_stream.c
+++ b/src/depackers/xz_dec_stream.c
@@ -11,6 +11,10 @@
 #include "xz_stream.h"
 #include "crc32.h"
 
+static const unsigned char HEADER_MAGIC[HEADER_MAGIC_SIZE] = {
+	0xFD, '7', 'z', 'X', 'Z', 0x00
+};
+
 #define xz_crc32 libxmp_crc32_A
 
 #ifdef XZ_USE_CRC64

--- a/src/depackers/xz_stream.h
+++ b/src/depackers/xz_stream.h
@@ -18,7 +18,7 @@
 
 #define STREAM_HEADER_SIZE 12
 
-#define HEADER_MAGIC "\3757zXZ"
+/* #define HEADER_MAGIC "\3757zXZ" */
 #define HEADER_MAGIC_SIZE 6
 
 #define FOOTER_MAGIC "YZ"


### PR DESCRIPTION
`depackers\xz_dec_stream.c(424,7): warning C4125: decimal digit terminates octal escape sequence`
