### PR TITLE
fix MSVC C4310 warnings:

### DIFF
--- a/src/loaders/sample.c
+++ b/src/loaders/sample.c
@@ -131,7 +131,7 @@ static void convert_signal(uint8 *p, int l, int r)
 			*w += 0x8000;
 	} else {
 		for (; l--; p++)
-			*p += (char)0x80;	/* cast needed by MSVC++ */
+			*p += (unsigned char)0x80;
 	}
 }
 

--- a/test-dev/test_string_adjustment.c
+++ b/test-dev/test_string_adjustment.c
@@ -3,7 +3,7 @@
 TEST(test_string_adjustment)
 {
 	char string[80] = { 'h', 'e', 'l', 'l', 'o', 1, 2, 30, 31, 127,
-		(char)128, 'w', 'o', 'r', 'l', 'd', ' ', ' ', ' ', 0 };
+		'\x80', 'w', 'o', 'r', 'l', 'd', ' ', ' ', ' ', 0 };
 
 	libxmp_adjust_string(string);
 	fail_unless(strcmp(string, "hello      world") == 0, "adjustment error");


### PR DESCRIPTION
`loaders\sample.c(134,16): warning C4310: cast truncates constant value`
`test-dev\test_string_adjustment.c(6,9): warning C4310: cast truncates constant value`

Closes: https://github.com/libxmp/libxmp/issues/797
