### PR TITLE
depackers, arc_unpack: silence MSVC C4310 and C4334 warnings

### DIFF
--- a/src/depackers/arc_unpack.c
+++ b/src/depackers/arc_unpack.c
@@ -129,14 +129,13 @@ static int arc_unpack_init(struct arc_data *arc, int init_width, int max_width, 
     if(max_width < 9 || max_width > 16)
       return -1;
 
-    arc->tree = (struct arc_code *)calloc(1 << max_width, sizeof(struct arc_code));
+    arc->tree = (struct arc_code *)calloc((size_t)(1U << max_width), sizeof(struct arc_code));
     if(!arc->tree)
       return -1;
 
     for(i = 0; i < 256; i++)
     {
       struct arc_code *c = &(arc->tree[i]);
-      c->prev = (arc_uint16)ARC_NO_CODE;
       c->length = 1;
       c->value = i;
     }
@@ -737,7 +736,7 @@ static int arc_huffman_init(struct arc_data * ARC_RESTRICT arc,
       continue;
     }
 
-    iter = 1 << bits;
+    iter = (size_t)(1U << bits);
     for(j = i; j < table_size; j += iter)
     {
       arc->huffman_lookup[j].value = ~index;


### PR DESCRIPTION
```
depackers\arc_unpack.c(139,29): warning C4310: cast truncates constant value

depackers\arc_unpack.c(132,45): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
depackers\arc_unpack.c(740,14): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
```

Curiously ARC_NO_CODE and some other constants are marked with `UL` even though unnecessary, i.e. a simple `U` would have been fine w/o making them 64 bits on LP64. I didn't touch those.
