### PR TITLE
silence MSVC C4018, C4389, C4244 and C4267 warnings in all source tree

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -118,6 +118,11 @@ typedef int tst_uint64[2 * (8 == sizeof(uint64)) - 1];
 
 #ifdef _MSC_VER
 #pragma warning(disable:4100) /* unreferenced formal parameter */
+#pragma warning(disable:4389) /* signed/unsigned mismatch ( <, <=, >, >= ) */
+#pragma warning(disable:4018) /* signed/unsigned mismatch ( ==, != ) */
+#pragma warning(disable:4761) /* integral size mismatch in argument; conversion supplied (for MSVC6 and older.) */
+#pragma warning(disable:4244) /* conversion from 'type' to 'int', possible loss of data */
+#pragma warning(disable:4267) /* conversion from 'size_t' to 'type', possible loss of data */
 #endif
 
 #ifndef LIBXMP_CORE_PLAYER

--- a/src/depackers/bunzip2.c
+++ b/src/depackers/bunzip2.c
@@ -68,6 +68,10 @@ struct bwdata {
   unsigned int *dbuf;
 };
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4324) /* structure was padded due to alignment specifier */
+#endif
 // Structure holding all the housekeeping data, including IO buffers and
 // memory that persists between calls to bunzip
 struct bunzip_data {
@@ -99,6 +103,9 @@ struct bunzip_data {
   /* libxmp: For I/O error handling */
   jmp_buf jmpbuf;
 };
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 
 /* libxmp addition */
 struct bunzip_output {

--- a/src/loaders/sample.c
+++ b/src/loaders/sample.c
@@ -66,13 +66,13 @@ static void convert_7bit_to_8bit(uint8 *p, int l)
 static void convert_vidc_to_linear(uint8 *p, int l)
 {
 	int i;
+	int8 amp;
 	uint8 x;
 
 	for (i = 0; i < l; i++) {
 		x = p[i];
-		p[i] = vdic_table[x >> 1];
-		if (x & 0x01)
-			p[i] *= -1;
+		amp = vdic_table[x >> 1];
+		p[i] = (uint8)((x & 0x01) ? -amp : amp);
 	}
 }
 


### PR DESCRIPTION
The warnings disabled are `signed/unsigned mismatch` for `<`, `<=`, `>`, `>=`, `==` and `!=`, and `conversion from 'type' to 'int', possible loss of data` stuff.

After this, combined with #801, there is one warning from MSVC that remain:

```
loaders\sample.c(75,12): warning C4245: '*=': conversion from 'int' to 'uint8', signed/unsigned mismatch
```
This is for `p[i] *= -1` where p is an `uint8*`: Anything to do?
