### PR TITLE
cmake: remove disabling of MSVC warnings

### DIFF
--- a/cmake/libxmp-checks.cmake
+++ b/cmake/libxmp-checks.cmake
@@ -94,8 +94,6 @@ if(MSVC)
     endif()
     # Disable bogus MSVC warnings
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-    # Tune warnings
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4244 /wd4018 /wd4996 /wd4048 /wd4267 /wd4127")
 else()
     xmp_add_warning_flag("-Wall" ALL)
     xmp_add_warning_flag("-Wwrite-strings" WRITE_STRINGS)

--- a/src/common.h
+++ b/src/common.h
@@ -120,6 +120,7 @@ typedef int tst_uint64[2 * (8 == sizeof(uint64)) - 1];
 #pragma warning(disable:4100) /* unreferenced formal parameter */
 #pragma warning(disable:4389) /* signed/unsigned mismatch ( <, <=, >, >= ) */
 #pragma warning(disable:4018) /* signed/unsigned mismatch ( ==, != ) */
+#pragma warning(disable:4127) /* conditional expression is constant. */
 #pragma warning(disable:4761) /* integral size mismatch in argument; conversion supplied (for MSVC6 and older.) */
 #pragma warning(disable:4244) /* conversion from 'type' to 'int', possible loss of data */
 #pragma warning(disable:4267) /* conversion from 'size_t' to 'type', possible loss of data */
@@ -417,7 +418,6 @@ struct module_data {
 	struct midi_macro_data *midi;
 	int compare_vblank;
 };
-
 
 struct pattern_loop {
 	int start;


### PR DESCRIPTION
we're disabling them in common.h already
