### PR TITLE
cmake: quote libxmp.map path in LINK_FLAGS for paths with spaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ if(BUILD_SHARED)
     if(HAVE_VISIBILITY AND HAVE_GNU_LD AND UNIX)
         target_compile_definitions(xmp_shared PRIVATE USE_VERSIONED_SYMBOLS=1)
         set_property(TARGET xmp_shared APPEND_STRING PROPERTY
-                     LINK_FLAGS " -Wl,--version-script,${CMAKE_CURRENT_SOURCE_DIR}/libxmp.map")
+                     LINK_FLAGS " -Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/libxmp.map\"")
         message(STATUS "Versioned symbols: ENABLED.")
     else()
         message(STATUS "Versioned symbols: DISABLED")

--- a/lite/CMakeLists.txt
+++ b/lite/CMakeLists.txt
@@ -122,7 +122,7 @@ if(BUILD_SHARED)
     if(HAVE_VISIBILITY AND HAVE_GNU_LD AND UNIX)
         target_compile_definitions(xmp_lite_shared PRIVATE USE_VERSIONED_SYMBOLS=1)
         set_property(TARGET xmp_lite_shared APPEND_STRING PROPERTY
-                     LINK_FLAGS " -Wl,--version-script,${CMAKE_CURRENT_SOURCE_DIR}/libxmp.map")
+                     LINK_FLAGS " -Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/libxmp.map\"")
         message(STATUS "Versioned symbols: ENABLED.")
     else()
         message(STATUS "Versioned symbols: DISABLED")


### PR DESCRIPTION
Fixes: https://github.com/libxmp/libxmp/issues/810

CC @madebr
