### PR TITLE
bump version to 4.6.1, update changelogs, update copyright dates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.4...3.10)
-project(libxmp VERSION 4.6.0 LANGUAGES C)
+project(libxmp VERSION 4.6.1 LANGUAGES C)
 
 set(LIBXMP_DEFINES)
 set(LIBXMPLITE_DEFINES)

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 m4_define([libxmp_VERSION_MAJOR_m4], [4])
 m4_define([libxmp_VERSION_MINOR_m4], [6])
-m4_define([libxmp_VERSION_PATCH_m4], [0])
+m4_define([libxmp_VERSION_PATCH_m4], [1])
 m4_define([libxmp_VERSION_m4], libxmp_VERSION_MAJOR_m4[.]libxmp_VERSION_MINOR_m4[.]libxmp_VERSION_PATCH_m4)
 
 AC_PREREQ(2.60)

--- a/docs/Changelog
+++ b/docs/Changelog
@@ -58,6 +58,7 @@ Stable versions
 	  * [Both] Stopped incorrectly applying QUIRK_S3MLOOP, QUIRK_VOLPDN,
 	    QUIRK_S3MRTG, and QUIRK_MARKER.
 	- Fix loading of Poly Tracker (PTM) empty sample names.
+	- Fix Real Tracker loader on targets where char is unsigned by default.
 	- Fix out-of-bounds reads in His Master's Noise Mupp instruments.
 	- Fix slow ProWizard testing.
 	- Fix Paula mixer state leak after changing XMP_PLAYER_MODE.
@@ -69,11 +70,13 @@ Stable versions
 	- Passing NULL to xmp_set_instrument_path() now unsets the instrument
 	  path instead of crashing.
 	- Merge song file instrument path detection routines.
+	- Fix module scan pattern delay counting.
 	- Add compatibility for non-standard Pattern Loop implementations:
 	  Scream Tracker 3.01b; Scream Tracker 3.03b+; Impulse Tracker 1.00;
 	  Impulse Tracker 1.04 to 2.09; Modplug Tracker 1.16; Digital Tracker
 	  <=2.04; Digital Tracker 1.9; Octalyser; Imago Orpheus; Liquid Tracker;
 	  Poly Tracker. (MOD, FT2, and IT 2.10+ were already supported.)
+	- Fixed numerous defects found by fuzzing.
 	Changes by Thomas Neumann:
 	- Fix XM envelope handling
 	- Bug fixes to DSMI loader
@@ -2048,5 +2051,4 @@ Development (unreleased) versions
 
 0.05 and before:
 	- Lots of changes.
-
 

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -6,7 +6,7 @@ A tracker module player library
 -------------------------------
 
 :Author: Claudio Matsuoka and Hipolito Carraro Jr.
-:Date: June 2023
+:Date: December 2024
 :Version: 4.6
 :Manual section: 3
 :Manual group: Extended Module Player

--- a/include/xmp.h
+++ b/include/xmp.h
@@ -9,11 +9,11 @@
 extern "C" {
 #endif
 
-#define XMP_VERSION "4.6.0"
-#define XMP_VERCODE 0x040600
+#define XMP_VERSION "4.6.1"
+#define XMP_VERCODE 0x040601
 #define XMP_VER_MAJOR 4
 #define XMP_VER_MINOR 6
-#define XMP_VER_RELEASE 0
+#define XMP_VER_RELEASE 1
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
 # if defined(LIBXMP_STATIC)

--- a/lite/CMakeLists.txt
+++ b/lite/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.4...3.10)
-project(libxmplite VERSION 4.6.0 LANGUAGES C)
+project(libxmplite VERSION 4.6.1 LANGUAGES C)
 
 set(LIBXMP_DEFINES)
 set(LIBXMP_CFLAGS)

--- a/lite/Changelog
+++ b/lite/Changelog
@@ -19,6 +19,9 @@ Stable versions
 	  sample rate or BPM changes.
 	- Passing NULL to xmp_set_instrument_path() now unsets the instrument
 	  path instead of crashing.
+	- Fix module scan pattern delay counting.
+	- Add compatibility for non-standard IT Pattern Loop implementations.
+	- Fixed numerous defects found by fuzzing.
 	Changes by Thomas Neumann:
 	- Fix XM envelope handling
 	- Fix XM restart position, so that it is possible to play
@@ -407,3 +410,4 @@ Stable versions
 
 4.2.0 (20140302):
 	- forked from libxmp 4.2.5 and removed unnecessary features
+

--- a/lite/configure.ac
+++ b/lite/configure.ac
@@ -1,6 +1,6 @@
 m4_define([libxmplite_VERSION_MAJOR_m4], [4])
 m4_define([libxmplite_VERSION_MINOR_m4], [6])
-m4_define([libxmplite_VERSION_PATCH_m4], [0])
+m4_define([libxmplite_VERSION_PATCH_m4], [1])
 m4_define([libxmplite_VERSION_m4], libxmplite_VERSION_MAJOR_m4[.]libxmplite_VERSION_MINOR_m4[.]libxmplite_VERSION_PATCH_m4)
 
 AC_PREREQ(2.60)

--- a/src/depackers/arc_unpack.c
+++ b/src/depackers/arc_unpack.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 2021-2022 Alice Rowan <petrifiedrowan@gmail.com>
+ * Copyright (C) 2021-2024 Alice Rowan <petrifiedrowan@gmail.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/effects.c
+++ b/src/effects.c
@@ -425,7 +425,9 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 			fxp <<= 4;
 			goto fx_setpan;
 		case EX_RETRIG:		/* Retrig note */
+#ifndef LIBXMP_CORE_PLAYER
 		    fx_retrig:
+#endif
 			SET(RETRIG);
 			xc->retrig.val = fxp;
 			xc->retrig.count = fxp + 1;

--- a/src/loaders/arch_load.c
+++ b/src/loaders/arch_load.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2022 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/loaders/dbm_load.c
+++ b/src/loaders/dbm_load.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2021 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/loaders/mgt_load.c
+++ b/src/loaders/mgt_load.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2021 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/loaders/no_load.c
+++ b/src/loaders/no_load.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2021 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/loaders/rtm_load.c
+++ b/src/loaders/rtm_load.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2022 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
also fix a minor 'unused label' warning in lite builds.
