### PR TITLE
miniz_tinfl.c: apply CVE-2018-12913 fix from mainstream.

### DIFF
--- a/src/miniz_tinfl.c
+++ b/src/miniz_tinfl.c
@@ -498,6 +498,12 @@ tinfl_status tinfl_decompress(tinfl_decompressor *r, const mz_uint8 *pIn_buf_nex
                         bit_buf >>= code_len;
                         num_bits -= code_len;
 
+                        /* assert(sym2 != 0 && counter != 0); */
+                        if (sym2 == 0 && counter == 0)
+                        {
+                            TINFL_CR_RETURN_FOREVER(40, TINFL_STATUS_FAILED);
+                        }
+
                         pOut_buf_cur[0] = (mz_uint8)counter;
                         if (sym2 & 256)
                         {


### PR DESCRIPTION
Orig. P/R: https://github.com/richgel999/miniz/pull/329.
