### PR TITLE
Reset Invert Loop position when a new instrument is encountered.

### DIFF
--- a/docs/Changelog
+++ b/docs/Changelog
@@ -22,6 +22,7 @@ Stable versions
 	- Fix loop detection edge cases broken by S3M/IT marker scan bugs.
 	- Add fix for IT break to module scan (was missed in libxmp 4.5.0.)
 	- Fix restart position for >64k sample and Digital Tracker MODs.
+	- Reset Invert Loop position when a new instrument is encountered.
 	- MOD: make presence of invert loop override tracker ID guesses.
 	  M.K. modules within Amiga limits which use EFx invert loop are
 	  now IDed as Protracker.

--- a/src/player.c
+++ b/src/player.c
@@ -564,6 +564,11 @@ static void update_invloop(struct context_data *ctx, struct channel_data *xc)
 	struct module_data *m = &ctx->m;
 	int lps = 0, len = -1;
 
+	/* If an instrument number is present, reset the position. */
+	if (ctx->p.frame == 0 && TEST(NEW_INS)) {
+		xc->invloop.pos = 0;
+	}
+
 	xc->invloop.count += invloop_table[xc->invloop.speed];
 
 	if (xxs != NULL) {


### PR DESCRIPTION
Fixes Emax/enjoy the silence.mod channel 4. Skipping a test for this one since the current Invert Loop test is a mixer samples test and this would need a more comprehensive test.

You can verify the fix by listening to the aforementioned module with the option `-M0,1,2` and comparing to OpenMPT. Without the fix, channel 4 gradually shifts in timbre over the course of the entire module, but with the fix, its samples are modulated in a much more controlled manner: http://modland.com/pub/modules/Protracker/Emax/enjoy%20the%20silence.mod

Fixes #784.