### PR TITLE
Revert 'miniz_tinfl.c: apply CVE-2018-12913 fix from mainstream.'

### DIFF
--- a/src/miniz_tinfl.c
+++ b/src/miniz_tinfl.c
@@ -498,12 +498,6 @@ tinfl_status tinfl_decompress(tinfl_decompressor *r, const mz_uint8 *pIn_buf_nex
                         bit_buf >>= code_len;
                         num_bits -= code_len;
 
-                        /* assert(sym2 != 0 && counter != 0); */
-                        if (sym2 == 0 && counter == 0)
-                        {
-                            TINFL_CR_RETURN_FOREVER(40, TINFL_STATUS_FAILED);
-                        }
-
                         pOut_buf_cur[0] = (mz_uint8)counter;
                         if (sym2 & 256)
                         {


### PR DESCRIPTION
This reverts commit 4ec860304e2887b5d5855cdf9f649cf5cca7028f

Issues were reported to mainstream: https://github.com/richgel999/miniz/pull/329

I guess we wait and see whether we receive complaints.
Or, should we make an immediate patch release for this??
