### PR TITLE
Empty sample in oxm modules

### DIFF
--- a/src/loaders/xm_load.c
+++ b/src/loaders/xm_load.c
@@ -422,13 +422,13 @@ static int oggdec(struct module_data *m, HIO_HANDLE *f, struct xmp_sample *xxs, 
 		return -1;
 	}
 
-	if ((xxs->flg & XMP_SAMPLE_16BIT) == 0) {
+	if ((xxs->flg & XMP_SAMPLE_16BIT) == 0 && n > 0) {
 		uint8 *pcm = (uint8 *)pcm16;
 
 		for (i = 0; i < n; i++) {
 			pcm[i] = pcm16[i] >> 8;
 		}
-		pcm = (uint8 *)realloc(pcm16, n == 0 ? 1 : n);
+		pcm = (uint8 *)realloc(pcm16, n);
 		if (pcm == NULL) {
 			free(pcm16);
 			return -1;

--- a/src/loaders/xm_load.c
+++ b/src/loaders/xm_load.c
@@ -417,7 +417,7 @@ static int oggdec(struct module_data *m, HIO_HANDLE *f, struct xmp_sample *xxs, 
 	n = stb_vorbis_decode_memory(data, len, &ch, &rate, &pcm16);
 	free(data);
 
-	if (n <= 0 || ch != 1) {
+	if (n < 0 || ch != 1) {
 		free(pcm16);
 		return -1;
 	}
@@ -428,7 +428,7 @@ static int oggdec(struct module_data *m, HIO_HANDLE *f, struct xmp_sample *xxs, 
 		for (i = 0; i < n; i++) {
 			pcm[i] = pcm16[i] >> 8;
 		}
-		pcm = (uint8 *)realloc(pcm16, n);
+		pcm = (uint8 *)realloc(pcm16, n == 0 ? 1 : n);
 		if (pcm == NULL) {
 			free(pcm16);
 			return -1;


### PR DESCRIPTION
The Four Ages.oxm module have a sample which is Ogg Vorbis packed. When depacking it, it result in a sample with 0 length. Because LibXmp check the result after depacking, which is the length of the depacked sample or negative if failed as <= 0, the load fails. This fix will make sure the module can be loaded correctly.

The realloc change is at least needed on Windows. If not, Xmp.exe just exit.

[Four Ages.zip](https://github.com/user-attachments/files/18288539/Four.Ages.zip)
