### PR TITLE
False positives in Scream Tracker 2

### DIFF
--- a/src/loaders/stm_load.c
+++ b/src/loaders/stm_load.c
@@ -87,6 +87,7 @@ const struct format_loader libxmp_loader_stm = {
 static int stm_test(HIO_HANDLE * f, char *t, const int start)
 {
 	uint8 buf[8];
+	uint16 version;
 
 	hio_seek(f, start + 20, SEEK_SET);
 	if (hio_read(buf, 1, 8, f) < 8)
@@ -102,6 +103,17 @@ static int stm_test(HIO_HANDLE * f, char *t, const int start)
 
 	if (hio_read8(f) > STM_TYPE_MODULE)
 		return -1;
+
+	buf[0] = hio_read8(f);
+	buf[1] = hio_read8(f);
+	version = (100 * buf[0]) + buf[1];
+
+	if (version != 110 &&
+	    version != 200 && version != 210 &&
+	    version != 220 && version != 221) {
+		D_(D_CRIT "Unknown version: %d", version);
+		return -1;
+	}
 
 	hio_seek(f, start + 60, SEEK_SET);
 	if (hio_read(buf, 1, 4, f) < 4)


### PR DESCRIPTION
When I scanned modland to check my own player, I discovered a lot of false positives for Scream Tracker 2. This fix will make them go away, by copying the version check from the load part into the test part as well.

Here is a list of some of the modules I found that created false positives. All from modland:

MegaStation MIDI\DJ Hikari\sss.msm
Piston Collage\12\obj1124-4.ptcop
Piston Collage\3-14\obj0667-1.ptcop
Piston Collage\Agaragara\011.ptcop
Piston Collage\Agaragara\obj0535-4.ptcop
Piston Collage\Bakushi\noname10.ptcop
Piston Collage\Canot\obj1365-1.ptcop
Piston Collage\CFZ\obj0266-1.ptcop
Piston Collage\Colo\obj0439-1.ptcop
Piston Collage\Colo\obj0556-1.ptcop
Piston Collage\Colo\obj0805-1.ptcop
Piston Collage\Colo\obj1051-1.ptcop
Piston Collage\Cthulhu\obj1182-1.ptcop
Piston Collage\Digital Ameba\obj0641-noname.ptcop
Piston Collage\Digital Ameba\poket.ptcop
Piston Collage\Door\obj1092-3.ptcop
Piston Collage\Door\obj1283-1.ptcop
Piston Collage\Firework\obj0646-1.ptcop
Piston Collage\Hina\obj0850-1.ptcop
Piston Collage\Hseiken\eyes without a face.ptcop
Piston Collage\Hseiken\obj0491-1.ptcop
Piston Collage\Hseiken\obj0674-1.ptcop
Piston Collage\Hseiken\obj0694-1.ptcop
Psycle\Maxstack\singularity - by-product.psy
Psycle\Maxstack\singularity - coherence.psy
S98\Masaaki Uno\Yaksa Demo X1\x1yaksa-demo01.s98
S98\Masaaki Uno\Yaksa Demo X1\x1yaksa-demo02.s98
S98\Shigeru Tomita\Super Laydock - Mission Striker\11.s98
S98\Shigeru Tomita\Super Laydock - Mission Striker\14.s98
S98\Shigeru Tomita\Super Laydock - Mission Striker\15.s98
S98\T. Ohtani\Herzog X1\x1herzog-01.s98
S98\T. Ohtani\Herzog X1\x1herzog-02.s98
S98\T. Ohtani\Herzog X1\x1herzog-10.s98
S98\T. Ohtani\Herzog X1\x1herzog-11.s98
S98\T. Ohtani\Herzog X1\x1herzog-12.s98
S98\T. Ohtani\Herzog X1\x1herzog-13.s98
