### PR TITLE
Moved the check for edit history out of the midi configuration part

### DIFF
--- a/src/loaders/it_load.c
+++ b/src/loaders/it_load.c
@@ -1275,13 +1275,14 @@ static int it_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	for (i = 0; i < mod->pat; i++)
 		pp_pat[i] = hio_read32l(f);
 
+	/* Skip edit history if it exists. */
+	if (ifh.special & IT_EDIT_HISTORY) {
+		int skip = hio_read16l(f) * 8;
+		if (hio_error(f) || (skip && hio_seek(f, skip, SEEK_CUR) < 0))
+			goto err4;
+	}
+
 	if ((ifh.flags & IT_MIDI_CONFIG) || (ifh.special & IT_SPEC_MIDICFG)) {
-		/* Skip edit history if it exists. */
-		if (ifh.special & IT_EDIT_HISTORY) {
-			int skip = hio_read16l(f) * 8;
-			if (hio_error(f) || (skip && hio_seek(f, skip, SEEK_CUR) < 0))
-				goto err4;
-		}
 		if (load_it_midi_config(m, f) < 0)
 			goto err4;
 	}


### PR DESCRIPTION
When making a check for usage of DSP effects/VST plug-ins, I found out that some modules do have edit history but not midi configuration. Then the file pointer was at the wrong place when I needed to do my extra check.

Currently, it does not make any difference for Xmp, since it make a seek when loading instruments/samples. But if you want in the future to support some of the extra OpenMpt features, this fix will help :-)

An example module is Digital loop by Saga Musix (https://modland.com/pub/modules/Impulsetracker/Saga%20Musix/digital%20loop.it)