### PR TITLE
Fix pattern loop effect in Astroidea XMF

### DIFF
--- a/src/loaders/xmf_load.c
+++ b/src/loaders/xmf_load.c
@@ -211,7 +211,6 @@ static void xmf_translate_effect(struct xmp_event *event, uint8 effect, uint8 pa
 		switch (param >> 4) {
 		case 0x01:		/* fine slide up */
 		case 0x02:		/* fine slide down */
-		case 0x06:		/* pattern loop (broken) */
 		case 0x09:		/* note retrigger (TODO: only once) */
 		case 0x0c:		/* note cut */
 		case 0x0d:		/* note delay */
@@ -224,6 +223,10 @@ static void xmf_translate_effect(struct xmp_event *event, uint8 effect, uint8 pa
 		case 0x04:		/* vibrato waveform */
 			param &= 3;
 			param = param < 3 ? param : 2;
+			xmf_insert_effect(event, effect, param, chn);
+			break;
+
+		case 0x06:		/* pattern loop */
 			xmf_insert_effect(event, effect, param, chn);
 			break;
 


### PR DESCRIPTION
The Astroidea XMF module Astro.xmf (attached) uses the pattern loop effect twice at position 16 / pattern 15. Without this fix, the first loop will play correctly but the last one only play once. Besides that, Xmp think there are two sub-songs / sequences.

The fix make sure that the E60 effect is stored as an event, which indicate the start of the pattern loop.

[Astro.zip](https://github.com/user-attachments/files/19820378/Astro.zip)
