### PR TITLE
Fix bugs in position seek functions and clarify API seek edge cases.

### DIFF
--- a/docs/Changelog
+++ b/docs/Changelog
@@ -1,6 +1,21 @@
 Stable versions
 ---------------
 
+4.6.3 (?):
+	Changes by Alice Rowan:
+	- Fix crashes when xmp_set_position is used to set a negative position.
+	  Negative positions now correctly return -XMP_ERROR_INVALID.
+	- Fix crashes when xmp_set_row is used to set a negative row.
+	  Negative positions now correctly return -XMP_ERROR_INVALID.
+	- Fix hangs when xmp_prev_position is used on the first position of
+	  a sequence which is preceded by an S3M/IT skip marker.
+	- Fix out-of-bounds reads when xmp_next_position is used at the end of
+	  a 256 position module.
+	- Fix hangs when seeking to an end-of-module marker caused by these
+	  positions getting assigned a non-existent sequence.
+	- Document xmp_set_position/xmp_next_position/xmp_prev_position
+	  interactions with xmp_stop_module/xmp_restart_module.
+
 4.6.2 (20250224):
 	Changes by Alice Rowan:
 	- Fix MED effect 1Fxy (delay and retrigger). The new implementation

--- a/docs/libxmp.rst
+++ b/docs/libxmp.rst
@@ -734,13 +734,16 @@ int xmp_next_position(xmp_context c)
 ````````````````````````````````````
 
   Skip replay to the start of the next position.
+  If the module was stopped with ``xmp_stop_module``, this operation
+  restarts the module at position 0. If the module is restarting
+  at position 0, this operation does nothing.
 
   **Parameters:**
     :c: the player context handle.
 
   **Returns:**
-    The new position index, or ``-XMP_ERROR_STATE`` if the player is not
-    in playing state.
+    The new position index, -1 if the module is restarting at position
+    0, or ``-XMP_ERROR_STATE`` if the player is not in playing state.
 
 .. _xmp_prev_position():
 
@@ -748,6 +751,9 @@ int xmp_prev_position(xmp_context c)
 ````````````````````````````````````
 
   Skip replay to the start of the previous position.
+  If the module was stopped with ``xmp_stop_module``, is restarting at
+  position 0, or if the previous position is part of a different sequence,
+  this operation does nothing.
 
   **Parameters:**
     :c: the player context handle.
@@ -762,6 +768,8 @@ int xmp_set_position(xmp_context c, int pos)
 ````````````````````````````````````````````
 
   Skip replay to the start of the given position.
+  If the module was stopped with ``xmp_stop_module``, this operation
+  will restart the module at the destination position.
 
   **Parameters:**
     :c: the player context handle.
@@ -769,8 +777,9 @@ int xmp_set_position(xmp_context c, int pos)
     :pos: the position index to set.
 
   **Returns:**
-    The new position index, ``-XMP_ERROR_INVALID`` of the new position is
-    invalid or ``-XMP_ERROR_STATE`` if the player is not in playing state.
+    The new position index, -1 if the module is restarting at
+    position 0, ``-XMP_ERROR_INVALID`` of the new position is invalid,
+    or ``-XMP_ERROR_STATE`` if the player is not in playing state.
 
 .. _xmp_set_row():
 

--- a/src/common.h
+++ b/src/common.h
@@ -416,11 +416,15 @@ int libxmp_snprintf (char *, size_t, const char *, ...) LIBXMP_ATTRIB_PRINTF(3,4
 #define MED_TIME_FACTOR		2.64
 #define FAR_TIME_FACTOR		4.01373	/* See far_extras.c */
 
+#define NO_SEQUENCE		MAX_SEQUENCES
 #define MAX_SEQUENCES		255
 #define MAX_SAMPLE_SIZE		0x10000000
 #define MAX_SAMPLES		1024
 #define MAX_INSTRUMENTS		255
 #define MAX_PATTERNS		256
+
+#define XMP_MARK_SKIP		0xfe /* S3M/IT (QUIRK_MARKER) skip position */
+#define XMP_MARK_END		0xff /* S3M/IT (QUIRK_MARKER) end position */
 
 #define IS_PLAYER_MODE_MOD()	(m->read_event_type == READ_EVENT_MOD)
 #define IS_PLAYER_MODE_FT2()	(m->read_event_type == READ_EVENT_FT2)

--- a/src/player.c
+++ b/src/player.c
@@ -1724,7 +1724,8 @@ static void next_order(struct context_data *ctx)
 		p->ord++;
 
 		/* Restart module */
-		mark = HAS_QUIRK(QUIRK_MARKER) && p->ord < mod->len && mod->xxo[p->ord] == 0xff;
+		mark = HAS_QUIRK(QUIRK_MARKER) && p->ord < mod->len &&
+		       mod->xxo[p->ord] == XMP_MARK_END;
 		if (p->ord >= mod->len || mark) {
 			if (mod->rst > mod->len ||
 			    mod->xxo[mod->rst] >= mod->pat ||
@@ -2035,7 +2036,7 @@ int xmp_play_frame(xmp_context opaque)
 		return -XMP_END;
 	}
 
-	if (HAS_QUIRK(QUIRK_MARKER) && mod->xxo[p->ord] == 0xff) {
+	if (HAS_QUIRK(QUIRK_MARKER) && mod->xxo[p->ord] == XMP_MARK_END) {
 		return -XMP_END;
 	}
 

--- a/test-dev/Makefile.in
+++ b/test-dev/Makefile.in
@@ -69,8 +69,8 @@ API		= get_format_list create_context free_context \
 		  test_module_from_file test_module_from_memory \
 		  test_module_from_callbacks \
 		  start_player play_buffer \
-		  set_position prev_position set_position_midfx set_row \
-		  set_player stop_module restart_module seek_time \
+		  set_position next_position prev_position set_position_midfx \
+		  set_row set_player stop_module restart_module seek_time \
 		  channel_mute channel_vol inject_event scan_module \
 		  set_tempo_factor set_instrument_path
 

--- a/test-dev/all_tests.txt
+++ b/test-dev/all_tests.txt
@@ -250,6 +250,7 @@ test_api_test_module_from_callbacks
 test_api_start_player
 test_api_play_buffer
 test_api_set_position
+test_api_next_position
 test_api_prev_position
 test_api_set_position_midfx
 test_api_set_row

--- a/test-dev/test_api_next_position.c
+++ b/test-dev/test_api_next_position.c
@@ -1,0 +1,91 @@
+#include "test.h"
+
+TEST(test_api_next_position)
+{
+	xmp_context opaque;
+	struct context_data *ctx;
+	struct player_data *p;
+	int state, ret;
+	int i;
+
+	opaque = xmp_create_context();
+	ctx = (struct context_data *)opaque;
+	p = &ctx->p;
+
+	state = xmp_get_player(opaque, XMP_PLAYER_STATE);
+	fail_unless(state == XMP_STATE_UNLOADED, "state error");
+
+	ret = xmp_next_position(opaque);
+	fail_unless(ret == -XMP_ERROR_STATE, "state check error");
+
+	create_simple_module(ctx, 2, 2);
+	libxmp_free_scan(ctx);
+	set_order(ctx, 0, 0);
+	set_order(ctx, 1, 1);
+	set_order(ctx, 2, 0);
+
+	libxmp_prepare_scan(ctx);
+	libxmp_scan_sequences(ctx);
+
+	xmp_start_player(opaque, 44100, 0);
+	fail_unless(p->ord == 0, "didn't start at pattern 0");
+
+	ret = xmp_next_position(opaque);
+	fail_unless(ret == 1, "next position error");
+	xmp_play_frame(opaque);
+	fail_unless(p->ord == 1, "didn't change to next position");
+
+	xmp_set_position(opaque, 2);
+	xmp_play_frame(opaque);
+	fail_unless(p->ord == 2, "didn't set position 2");
+
+	ret = xmp_next_position(opaque);
+	fail_unless(ret == 2, "not in position 2");
+
+	/* xmp_next_position should restart a stopped module. */
+	xmp_stop_module(opaque);
+	ret = xmp_play_frame(opaque);
+	fail_unless(ret == -XMP_END, "didn't stop module");
+	ret = xmp_next_position(opaque);
+	fail_unless(ret == -1, "didn't change to position -1");
+	xmp_play_frame(opaque);
+	fail_unless(p->ord == 0, "not in position 0");
+
+	/* xmp_next_position should not advance a restarting module. */
+	xmp_restart_module(opaque);
+	ret = xmp_next_position(opaque);
+	fail_unless(ret == -1, "not at position -1");
+	ret = xmp_next_position(opaque);
+	fail_unless(ret == -1, "not at position -1");
+	ret = xmp_next_position(opaque);
+	fail_unless(ret == -1, "not at position -1");
+	xmp_play_frame(opaque);
+	fail_unless(p->ord == 0, "not in position 0");
+
+	/* xmp_next_position should not be confused by a module
+	 * with 256 positions. */
+	xmp_end_player(opaque);
+
+	libxmp_free_scan(ctx);
+	set_order(ctx, 0, 0);
+	for (i = 1; i < 256; i++)
+		set_order(ctx, i, XMP_MARK_SKIP);
+	set_quirk(ctx, QUIRK_MARKER, READ_EVENT_IT);
+	libxmp_prepare_scan(ctx);
+	libxmp_scan_sequences(ctx);
+
+	xmp_start_player(opaque, 44100, 0);
+	fail_unless(p->ord == 0, "didn't start at pattern 0");
+	ret = xmp_next_position(opaque);
+	fail_unless(ret == 255, "next position error");
+	xmp_play_frame(opaque);
+	fail_unless(p->ord == 0, "not in position 0");
+	ret = xmp_next_position(opaque);
+	fail_unless(ret == 255, "next position error");
+	ret = xmp_next_position(opaque);
+	fail_unless(ret == 255, "not in position 255");
+
+	xmp_release_module(opaque);
+	xmp_free_context(opaque);
+}
+END_TEST

--- a/test-dev/test_api_set_position.c
+++ b/test-dev/test_api_set_position.c
@@ -22,7 +22,7 @@ TEST(test_api_set_position)
 	set_order(ctx, 0, 0);
 	set_order(ctx, 1, 1);
 	set_order(ctx, 2, 0);
-	set_order(ctx, 3, 0xff); /* End marker. */
+	set_order(ctx, 3, XMP_MARK_END); /* End marker. */
 	set_quirk(ctx, QUIRK_MARKER, READ_EVENT_IT);
 
 	libxmp_prepare_scan(ctx);
@@ -41,7 +41,40 @@ TEST(test_api_set_position)
 	xmp_play_frame(opaque);
 	fail_unless(p->ord == 0, "didn't wrap to position 0");
 
+	/* xmp_set_position restarts a stopped module. */
+	xmp_stop_module(opaque);
+	ret = xmp_play_frame(opaque);
+	fail_unless(ret == -XMP_END, "didn't stop module");
+	ret = xmp_set_position(opaque, 0);
+	fail_unless(ret == -1, "didn't set position to -1");
+	xmp_play_frame(opaque);
+	fail_unless(p->ord == 0, "not in position 0");
+	xmp_stop_module(opaque);
+	ret = xmp_play_frame(opaque);
+	fail_unless(ret == -XMP_END, "didn't stop module");
+	ret = xmp_set_position(opaque, 2);
+	fail_unless(ret == 2, "didn't set position to 2");
+	xmp_play_frame(opaque);
+	fail_unless(p->ord == 2, "not in position 2");
+
+	/* xmp_set_position works with a restarting module. */
+	xmp_restart_module(opaque);
+	ret = xmp_set_position(opaque, 1);
+	fail_unless(ret == 1, "didn't set position to 1");
+	xmp_play_frame(opaque);
+	fail_unless(p->ord == 1, "not in position 1");
+
 	ret = xmp_set_position(opaque, 4);
+	fail_unless(ret == -XMP_ERROR_INVALID, "return value error");
+	ret = xmp_set_position(opaque, 256);
+	fail_unless(ret == -XMP_ERROR_INVALID, "return value error");
+	ret = xmp_set_position(opaque, INT_MAX);
+	fail_unless(ret == -XMP_ERROR_INVALID, "return value error");
+	ret = xmp_set_position(opaque, -1);
+	fail_unless(ret == -XMP_ERROR_INVALID, "return value error");
+	ret = xmp_set_position(opaque, -256);
+	fail_unless(ret == -XMP_ERROR_INVALID, "return value error");
+	ret = xmp_set_position(opaque, INT_MIN);
 	fail_unless(ret == -XMP_ERROR_INVALID, "return value error");
 
 	xmp_release_module(opaque);

--- a/test-dev/test_api_set_row.c
+++ b/test-dev/test_api_set_row.c
@@ -20,7 +20,7 @@ TEST(test_api_set_row)
 	create_simple_module(ctx, 1, 1);
 	libxmp_free_scan(ctx);
 	set_order(ctx, 0, 0);
-	set_order(ctx, 1, 0xff); /* End marker. */
+	set_order(ctx, 1, XMP_MARK_END); /* End marker. */
 	set_quirk(ctx, QUIRK_MARKER, READ_EVENT_IT);
 
 	libxmp_prepare_scan(ctx);
@@ -34,7 +34,13 @@ TEST(test_api_set_row)
 	xmp_play_frame(opaque);
 	fail_unless(p->row == 1, "didn't set row 1");
 
+	ret = xmp_set_row(opaque, -1);
+	fail_unless(ret == -XMP_ERROR_INVALID, "return value error");
+	ret = xmp_set_row(opaque, INT_MIN);
+	fail_unless(ret == -XMP_ERROR_INVALID, "return value error");
 	ret = xmp_set_row(opaque, 64);
+	fail_unless(ret == -XMP_ERROR_INVALID, "return value error");
+	ret = xmp_set_row(opaque, INT_MAX);
 	fail_unless(ret == -XMP_ERROR_INVALID, "return value error");
 
 	/* Go to end marker. */

--- a/test-dev/test_player_scan.c
+++ b/test-dev/test_player_scan.c
@@ -1,13 +1,39 @@
 #include "test.h"
 
+static void check_sequences(xmp_context opaque, const char *test)
+{
+	struct context_data *ctx = (struct context_data *)opaque;
+	struct module_data *m = &ctx->m;
+	struct player_data *p = &ctx->p;
+	char buf[128];
+	int i;
+
+	/* There should be no junk sequences after the valid ones. */
+	for (i = m->num_sequences; i < MAX_SEQUENCES; i++) {
+		snprintf(buf, sizeof(buf), "junk entry point in '%s' @ %d", test, i);
+		fail_unless(m->seq_data[i].entry_point == 0, buf);
+		snprintf(buf, sizeof(buf), "junk duration in '%s' @ %d", test, i);
+		fail_unless(m->seq_data[i].duration == 0, buf);
+	}
+	/* There should be no sequences past the last sequence. */
+	for (i = 0; i < m->mod.len; i++) {
+		snprintf(buf, sizeof(buf), "bad sequence '%02x' in '%s' @ %d",
+			 p->sequence_control[i], test, i);
+		fail_unless(p->sequence_control[i] < m->num_sequences ||
+			p->sequence_control[i] == NO_SEQUENCE, buf);
+	}
+}
+
 TEST(test_player_scan)
 {
 	xmp_context opaque;
+	struct context_data *ctx;
 	struct xmp_frame_info info;
 	int ret;
 
 	opaque = xmp_create_context();
 	fail_unless(opaque != NULL, "can't create context");
+	ctx = (struct context_data *)opaque;
 
 	ret = xmp_load_module(opaque, "data/ode2ptk.mod");
 	fail_unless(ret == 0, "can't load module");
@@ -15,6 +41,7 @@ TEST(test_player_scan)
 	xmp_start_player(opaque, 44100, 0);
 	xmp_get_frame_info(opaque, &info);
 	fail_unless(info.total_time == 85472, "incorrect total time");
+	check_sequences(opaque, "ode2ptk");
 
 	/* This is a very long OctaMED module with 256 orders of 3200 rows,
 	 * at BPM 28/LPB 1, speed 32. Currently the scan can't report the
@@ -26,6 +53,22 @@ TEST(test_player_scan)
 	xmp_start_player(opaque, XMP_MIN_SRATE, 0);
 	xmp_get_frame_info(opaque, &info);
 	fail_unless(info.total_time == INT_MAX, "incorrect total time");
+	check_sequences(opaque, "longest.med");
+
+	/* Make sure S3M/IT end markers aren't assigned invalid sequences. */
+	xmp_release_module(opaque);
+	create_simple_module(ctx, 2, 2);
+	libxmp_free_scan(ctx);
+	set_order(ctx, 0, XMP_MARK_SKIP);
+	set_order(ctx, 1, 0);
+	set_order(ctx, 2, XMP_MARK_END);
+	set_order(ctx, 3, XMP_MARK_END); /* May not be given a real sequence */
+	set_quirk(ctx, QUIRK_MARKER, READ_EVENT_IT);
+	libxmp_prepare_scan(ctx);
+	libxmp_scan_sequences(ctx);
+
+	xmp_start_player(opaque, XMP_MIN_SRATE, 0);
+	check_sequences(opaque, "s3m/it markers");
 
 	xmp_end_player(opaque);
 	xmp_release_module(opaque);


### PR DESCRIPTION
+ Fix crashes when using `xmp_set_position` to set a negative position. This now returns `-XMP_ERROR_INVALID` instead.
+ Fix crashes when using `xmp_set_row` to set a negative row. This now returns `-XMP_ERROR_INVALID` instead.
+ Fix hangs when `xmp_prev_position` is used on the first position of a sequence which is preceded by an S3M/IT skip marker.
+ Fix hangs when seeking to S3M/IT end-of-module markers assigned to a non-existent sequences.
+ Fix out-of-bounds reads past the end of `mod->xxo` when `xmp_next_position` is used at the end of a 256 position module.
+ Added `xmp_next_position` regression test.
+ Added `xmp_set_position`, `xmp_next_position`, `xmp_prev_position`, `xmp_set_row`, and `xmp_seek_time` calls to libxmp_fuzz.c.
+ Added `xmp_set_position`/`xmp_next_position`/`xmp_prev_position` interactions with `xmp_stop_module`/`xmp_restart_module` and -1 return value bugs for `xmp_set_position`/`xmp_next_position` to libxmp.rst. `xmp_prev_position` return value of -1 bug was previously fixed in libxmp 4.2.0; the other two have been around so long I just documented them instead of fixing them.

Fixes #839.
