### PR TITLE
Remove remaining loader pattern loop integer division usage.

### DIFF
--- a/docs/Changelog
+++ b/docs/Changelog
@@ -16,6 +16,7 @@ Stable versions
 	- Document xmp_set_position/xmp_next_position/xmp_prev_position
 	  interactions with xmp_stop_module/xmp_restart_module.
 	- Fix stack underflow in Pha Packer loader (CVE-2025-47256).
+	- Slight performance improvements for the Oktalyzer and SFX loaders.
 	Changes by Thomas Neumann:
 	- Fix the pattern loop effect in Astroidea XMF loader.
 	- Fix loading of Extreme Pinball modules.

--- a/src/loaders/okt_load.c
+++ b/src/loaders/okt_load.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2021 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2025 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/loaders/okt_load.c
+++ b/src/loaders/okt_load.c
@@ -104,6 +104,37 @@ static const int fx[32] = {
 	FX_VOLSET		/* 31 */
 };
 
+static int okt_translate_effect(struct xmp_event *event, int fxt, int fxp)
+{
+	if (fxt >= ARRAY_SIZE(fx)) {
+		return -1;
+	}
+	event->fxt = fx[fxt];
+	event->fxp = fxp;
+
+	if ((event->fxt == FX_VOLSET) && (event->fxp > 0x40)) {
+		if (event->fxp <= 0x50) {
+			event->fxt = FX_VOLSLIDE;
+			event->fxp -= 0x40;
+		} else if (event->fxp <= 0x60) {
+			event->fxt = FX_VOLSLIDE;
+			event->fxp = (event->fxp - 0x50) << 4;
+		} else if (event->fxp <= 0x70) {
+			event->fxt = FX_F_VSLIDE_DN;
+			event->fxp = event->fxp - 0x60;
+		} else if (event->fxp <= 0x80) {
+			event->fxt = FX_F_VSLIDE_UP;
+			event->fxp = event->fxp - 0x70;
+		}
+	}
+	if (event->fxt == FX_ARPEGGIO)	/* Arpeggio fixup */
+		event->fxp = (((24 - MSN(event->fxp)) % 12) << 4) | LSN(event->fxp);
+	if (event->fxt == NONE)
+		event->fxt = event->fxp = 0;
+
+	return 0;
+}
+
 static int get_cmod(struct module_data *m, int size, HIO_HANDLE *f, void *parm)
 {
 	struct xmp_module *mod = &m->mod;
@@ -250,7 +281,7 @@ static int get_pbod(struct module_data *m, int size, HIO_HANDLE *f, void *parm)
 	struct local_data *data = (struct local_data *)parm;
 	struct xmp_event *e;
 	uint16 rows;
-	int j;
+	int j, k;
 
 	/* Sanity check */
 	if (!data->has_slen || !data->has_cmod) {
@@ -271,46 +302,33 @@ static int get_pbod(struct module_data *m, int size, HIO_HANDLE *f, void *parm)
 	if (libxmp_alloc_pattern_tracks(mod, data->pattern, rows) < 0)
 		return -1;
 
-	for (j = 0; j < rows * mod->chn; j++) {
-		uint8 note, ins, fxt;
+	for (j = 0; j < rows; j++) {
+		for (k = 0; k < mod->chn; k++) {
+			uint8 note, ins;
+			uint8 c[4];
 
-		e = &EVENT(data->pattern, j % mod->chn, j / mod->chn);
-		memset(e, 0, sizeof(struct xmp_event));
+			e = &EVENT(data->pattern, k, j);
+			memset(e, 0, sizeof(struct xmp_event));
 
-		note = hio_read8(f);
-		ins = hio_read8(f);
+			if (hio_read(c, 1, 4, f) < 4) {
+				D_(D_CRIT "read error in PBOD %d", data->pattern);
+				return -1;
+			}
 
-		if (note) {
-			e->note = 48 + note;
-			e->ins = 1 + ins;
-		}
+			note = c[0];
+			ins = c[1];
 
-		fxt = hio_read8(f);
-		if (fxt >= ARRAY_SIZE(fx)) {
-			return -1;
-		}
-		e->fxt = fx[fxt];
-		e->fxp = hio_read8(f);
+			if (note) {
+				e->note = 48 + note;
+				e->ins = 1 + ins;
+			}
 
-		if ((e->fxt == FX_VOLSET) && (e->fxp > 0x40)) {
-			if (e->fxp <= 0x50) {
-				e->fxt = FX_VOLSLIDE;
-				e->fxp -= 0x40;
-			} else if (e->fxp <= 0x60) {
-				e->fxt = FX_VOLSLIDE;
-				e->fxp = (e->fxp - 0x50) << 4;
-			} else if (e->fxp <= 0x70) {
-				e->fxt = FX_F_VSLIDE_DN;
-				e->fxp = e->fxp - 0x60;
-			} else if (e->fxp <= 0x80) {
-				e->fxt = FX_F_VSLIDE_UP;
-				e->fxp = e->fxp - 0x70;
+			if (okt_translate_effect(e, c[2], c[3]) < 0) {
+				D_(D_CRIT "bad effect in PBOD %d: %02x %02x",
+				   data->pattern, c[2], c[3]);
+				return -1;
 			}
 		}
-		if (e->fxt == FX_ARPEGGIO)	/* Arpeggio fixup */
-			e->fxp = (((24 - MSN(e->fxp)) % 12) << 4) | LSN(e->fxp);
-		if (e->fxt == NONE)
-			e->fxt = e->fxp = 0;
 	}
 	data->pattern++;
 

--- a/src/loaders/sfx_load.c
+++ b/src/loaders/sfx_load.c
@@ -82,11 +82,48 @@ struct sfx_header2 {
 	uint8 order[128];	/* Order list */
 };
 
+static void sfx_translate_effect(struct xmp_event *event, int fxt, int fxp)
+{
+	event->fxp = fxp;
+
+	switch (fxt) {
+	case 0x01:	/* Arpeggio */
+		event->fxt = FX_ARPEGGIO;
+		break;
+	case 0x02:	/* Pitch bend */
+		if (event->fxp >> 4) {
+			event->fxt = FX_PORTA_DN;
+			event->fxp >>= 4;
+		} else if (event->fxp & 0x0f) {
+			event->fxt = FX_PORTA_UP;
+			event->fxp &= 0x0f;
+		}
+		break;
+	case 0x5:	/* Add to volume */
+		event->fxt = FX_VOL_ADD;
+		break;
+	case 0x6:	/* Subtract from volume */
+		event->fxt = FX_VOL_SUB;
+		break;
+	case 0x7:	/* Add semitones to period */
+		event->fxt = FX_PITCH_ADD;
+		break;
+	case 0x8:	/* Subtract semitones from period */
+		event->fxt = FX_PITCH_SUB;
+		break;
+	case 0x3:	/* LED on */
+	case 0x4:	/* LED off */
+	default:
+		event->fxt = event->fxp = 0;
+		break;
+	}
+}
+
 static int sfx_13_20_load(struct module_data *m, HIO_HANDLE *f, const int nins,
 			  const int start)
 {
 	struct xmp_module *mod = &m->mod;
-	int i, j;
+	int i, j, k;
 	struct xmp_event *event;
 	struct sfx_header sfx;
 	struct sfx_header2 sfx2;
@@ -190,47 +227,18 @@ static int sfx_13_20_load(struct module_data *m, HIO_HANDLE *f, const int nins,
 		if (libxmp_alloc_pattern_tracks(mod, i, 64) < 0)
 			return -1;
 
-		for (j = 0; j < 64 * mod->chn; j++) {
-			event = &EVENT(i, j % mod->chn, j / mod->chn);
-			if (hio_read(ev, 1, 4, f) < 4) {
-				D_(D_CRIT "read error at pat %d", i);
-				return -1;
-			}
-
-			event->note = libxmp_period_to_note((LSN(ev[0]) << 8) | ev[1]);
-			event->ins = (MSN(ev[0]) << 4) | MSN(ev[2]);
-			event->fxp = ev[3];
-
-			switch (LSN(ev[2])) {
-			case 0x01:	/* Arpeggio */
-				event->fxt = FX_ARPEGGIO;
-				break;
-			case 0x02:	/* Pitch bend */
-				if (event->fxp >> 4) {
-					event->fxt = FX_PORTA_DN;
-					event->fxp >>= 4;
-				} else if (event->fxp & 0x0f) {
-					event->fxt = FX_PORTA_UP;
-					event->fxp &= 0x0f;
+		for (j = 0; j < 64; j++) {
+			for (k = 0; k < mod->chn; k++) {
+				event = &EVENT(i, k, j);
+				if (hio_read(ev, 1, 4, f) < 4) {
+					D_(D_CRIT "read error at pat %d", i);
+					return -1;
 				}
-				break;
-			case 0x5:	/* Add to volume */
-				event->fxt = FX_VOL_ADD;
-				break;
-			case 0x6:	/* Subtract from volume */
-				event->fxt = FX_VOL_SUB;
-				break;
-			case 0x7:	/* Add semitones to period */
-				event->fxt = FX_PITCH_ADD;
-				break;
-			case 0x8:	/* Subtract semitones from period */
-				event->fxt = FX_PITCH_SUB;
-				break;
-			case 0x3:	/* LED on */
-			case 0x4:	/* LED off */
-			default:
-				event->fxt = event->fxp = 0;
-				break;
+
+				event->note = libxmp_period_to_note((LSN(ev[0]) << 8) | ev[1]);
+				event->ins = (MSN(ev[0]) << 4) | MSN(ev[2]);
+
+				sfx_translate_effect(event, LSN(ev[2]), ev[3]);
 			}
 		}
 	}

--- a/src/loaders/sfx_load.c
+++ b/src/loaders/sfx_load.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2021 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2025 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
The Oktalyzer and SFX loaders are the only remaining loaders that needlessly generate `idiv` instructions, so I've rewritten both to instead use an inner row loop. These are the last two "easy" `idiv` removals, as the rest are necessary for instrument/effects conversion (Startrekker, Digital Tracker, AMOS Music Bank, etc.) or are embedded in the player code and Paula mixers. The player divisions are extremely hard to miss and can be dealt with some other time.

Closes #400.