### PR TITLE
xmp_set_tempo_factor no longer modifies frame time prior to rescan.

### DIFF
--- a/docs/Changelog
+++ b/docs/Changelog
@@ -18,6 +18,9 @@ Stable versions
 	- Fix stack underflow in Pha Packer loader (CVE-2025-47256).
 	- Slight performance improvements for the Oktalyzer and SFX loaders.
 	- Fix broken conversion of ProRunner 2.0 pattern data.
+	- xmp_set_tempo_factor no longer alters frame time calculation for
+	  xmp_get_frame_info. Frame time is now updated to account for the
+	  new time factor after calling xmp_scan_module.
 	Changes by Thomas Neumann:
 	- Fix the pattern loop effect in Astroidea XMF loader.
 	- Fix loading of Extreme Pinball modules.

--- a/docs/libxmp.rst
+++ b/docs/libxmp.rst
@@ -530,7 +530,8 @@ void xmp_scan_module(xmp_context c)
   Scan the loaded module for sequences and timing. Scanning is automatically
   performed by `xmp_load_module()`_ and this function should be called only
   if `xmp_set_player()`_ is used to change player timing (with parameter
-  ``XMP_PLAYER_VBLANK``) in libxmp 4.0.2 or older.
+  ``XMP_PLAYER_VBLANK``) in libxmp 4.0.2 or older, or if
+  `xmp_set_tempo_factor`_ is used to change the base tempo factor.
 
   **Parameters:**
     :c: the player context handle.
@@ -710,6 +711,9 @@ void xmp_get_frame_info(xmp_context c, struct xmp_frame_info \*info)
       `xmp_play_frame()`_ is called. Fields ``buffer`` and ``buffer_size``
       contain the pointer to the sound buffer PCM data and its size. The
       buffer size will be no larger than ``XMP_MAX_FRAMESIZE``.
+      Fields ``time``, ``total_time``, and ``frame_time`` are based on the
+      base tempo factor set when the module was last scanned (see
+      `xmp_set_tempo_factor`_ and `xmp_scan_module`_).
 
 .. _xmp_end_player():
 
@@ -802,7 +806,16 @@ int xmp_set_row(xmp_context c, int row)
 int xmp_set_tempo_factor(xmp_context c, double val)
 ```````````````````````````````````````````````````
 
-  *[Added in libxmp 4.5]* Modify the replay tempo multiplier.
+  *[Added in libxmp 4.5]* Modify the current base tempo multiplier.
+  This value is a property of the currently loaded module, not of
+  the player: the default value of the tempo factor is ``1.0``
+  for most modules, ``0.264`` for MED/OctaMED tempo mode modules,
+  ``4.0 / rows_per_beat`` for MED/OctaMED BPM mode modules, and
+  roughly ``0.401373`` for Farandole Composer modules.
+
+  This function does not recalculate the playback times returned by
+  `xmp_get_frame_info`_. To recalculate these times, call
+  `xmp_scan_module`_ after setting the tempo factor.
 
   **Parameters:**
     :c: the player context handle.

--- a/lite/Changelog
+++ b/lite/Changelog
@@ -15,6 +15,9 @@ Stable versions
 	  positions getting assigned a non-existent sequence.
 	- Document xmp_set_position/xmp_next_position/xmp_prev_position
 	  interactions with xmp_stop_module/xmp_restart_module.
+	- xmp_set_tempo_factor no longer alters frame time calculation for
+	  xmp_get_frame_info. Frame time is now updated to account for the
+	  new time factor after calling xmp_scan_module.
 
 4.6.2 (20250224):
 	

--- a/src/common.h
+++ b/src/common.h
@@ -571,8 +571,8 @@ struct player_data {
 	int player_flags;
 	int flags;
 
-	double current_time;
-	double frame_time;
+	double scan_time_factor;	/* m->time_factor for most recent scan */
+	double current_time;		/* current time based on scan time factor */
 
 	int loop_count;
 	int sequence;

--- a/src/effects.c
+++ b/src/effects.c
@@ -520,7 +520,6 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 		if (fxp < min_bpm)
 			fxp = min_bpm;
 		p->bpm = fxp;
-		p->frame_time = m->time_factor * m->rrate / p->bpm;
 		break;
 	}
 
@@ -539,7 +538,6 @@ void libxmp_process_fx(struct context_data *ctx, struct channel_data *xc, int ch
 				fxp = XMP_MIN_BPM;
 			p->bpm = fxp;
 		}
-		p->frame_time = m->time_factor * m->rrate / p->bpm;
 		break;
 	case FX_IT_ROWDELAY:
 		if (!f->rowdelay_set) {

--- a/src/far_extras.c
+++ b/src/far_extras.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2021 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2025 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -149,7 +149,6 @@ static void libxmp_far_update_tempo(struct context_data *ctx, int fine_change)
 	    me->coarse_tempo, &me->fine_tempo, &speed, &bpm) == 0) {
 		p->speed = speed;
 		p->bpm = bpm;
-		p->frame_time = m->time_factor * m->rrate / p->bpm;
 	}
 }
 

--- a/src/load_helpers.c
+++ b/src/load_helpers.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2025 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -414,6 +414,7 @@ void libxmp_load_epilogue(struct context_data *ctx)
 	p->filter = 0;
 	p->mode = XMP_MODE_AUTO;
 	p->flags = p->player_flags;
+	p->scan_time_factor = m->time_factor;
 #ifndef LIBXMP_CORE_PLAYER
 	module_quirks(ctx);
 #endif

--- a/src/scan.c
+++ b/src/scan.c
@@ -783,6 +783,10 @@ int libxmp_scan_sequences(struct context_data *ctx)
 	}
 	m->num_sequences = seq;
 
+	/* Correct playback time calculation to match new base tempo factor. */
+	p->current_time = p->current_time * (m->time_factor / p->scan_time_factor);
+	p->scan_time_factor = m->time_factor;
+
 	/* Now place entry points in the public accessible array */
 	for (i = 0; i < m->num_sequences; i++) {
 		m->seq_data[i].entry_point = temp_ep[i];


### PR DESCRIPTION
Previously, the value set by xmp_set_tempo_factor was being applied immediately to frame time calculations, but not to the scanned sequence and order time calculations. This would result in playback time incorrectly "drifting" and then resetting when using tempo factors aside from the module's original tempo factor.

The time factor used for the most recent scan is now stored and used to generate the frame time when calculating the playback time. This allows users to alter the tempo factor with xmp_set_tempo_factor and get consistent playback times based on the original scan.

Calling xmp_scan_module will update the frame time calculation to use the new tempo factor (same as it updated the sequence/order time values prior). I've updated libxmp.rst to hopefully clarify some of these behaviors.

Fixes #836.