### PR TITLE
add OpenWatcom makefiles targeting Linux

### DIFF
--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -309,6 +309,25 @@ jobs:
         run: |
           wmake -f Makefile.dos distclean
 
+  watcom-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup OpenWatcom
+        uses: open-watcom/setup-watcom@v0
+        with:
+          version: "2.0"
+      - name: WMake Build (Linux)
+        run: |
+          wmake -f Makefile.lnx
+      - name: WMake check (Linux)
+        run: |
+          wmake -f Makefile.lnx check
+      - name: WMake distclean (Linux)
+        run: |
+          wmake -f Makefile.lnx distclean
+
   amiga:
     strategy:
        matrix:

--- a/Makefile.in
+++ b/Makefile.in
@@ -31,8 +31,8 @@ LD_VERSCRIPT	= @LD_VERSCRIPT@
 SHELL		= /bin/sh
 
 DIST		= libxmp-$(VERSION)
-DFILES		= README INSTALL install-sh configure configure.ac config.sub config.guess  \
-		  Makefile.in Makefile.vc Makefile.dos Makefile.os2 Makefile.w32 watcom.mif \
+DFILES		= README INSTALL install-sh configure configure.ac config.sub config.guess Makefile.in  \
+		  Makefile.vc Makefile.dos Makefile.os2 Makefile.w32 Makefile.lnx watcom.mif  \
 		  CMakeLists.txt aclocal.m4 autogen.sh libxmp.map libxmp.pc.in libxmp-config.cmake \
 		  libxmp-config.cmake.autotools libxmp-config-version.cmake.autotools.in
 DDIRS		= docs include src loaders prowiz depackers lhasa lite test cmake m4

--- a/Makefile.lnx
+++ b/Makefile.lnx
@@ -1,0 +1,32 @@
+# Makefile for Linux using Watcom compiler.
+#
+# wmake -f Makefile.lnx
+# - builds the static library xmp_static.lib
+#
+# To disable module depacker functionality:
+#	wmake -f Makefile.lnx USE_DEPACKERS=0
+#
+# To disable ProWizard functionality:
+#	wmake -f Makefile.lnx USE_PROWIZARD=0
+#
+# To build the lite version of the library:
+#	wmake -f Makefile.lnx lite
+
+target = static
+
+USE_PROWIZARD	= 1
+USE_DEPACKERS	= 1
+
+CC = wcc386
+SYSTEM = linux
+
+CFLAGS = -zq -bt=linux -fp5 -fpi87 -mf -oeatxh -w4 -ei -zp8
+# newer OpenWatcom versions enable W303 by default.
+CFLAGS += -wcd=303
+# -5s  :  Pentium stack calling conventions.
+# -5r  :  Pentium register calling conventions.
+CFLAGS += -5s
+CFLAGS += -I"$(%WATCOM)/lh"
+CFLAGS += -DHAVE_PIPE -DHAVE_FORK -DHAVE_EXECVP -DHAVE_FORK
+
+!include watcom.mif

--- a/lite/Makefile.in
+++ b/lite/Makefile.in
@@ -31,11 +31,10 @@ LD_VERSCRIPT	= @LD_VERSCRIPT@
 SHELL		= /bin/sh
 
 DIST		= libxmp-lite-$(VERSION)
-DFILES		= README INSTALL install-sh configure configure.ac config.sub config.guess  \
-		  Makefile.in Makefile.vc Makefile.dos Makefile.os2 Makefile.w32 watcom.mif \
-		  CMakeLists.txt aclocal.m4 autogen.sh libxmp.map libxmp-lite.pc.in Changelog \
-		  libxmp-lite-config.cmake libxmp-lite-config.cmake.autotools \
-		  libxmp-lite-config-version.cmake.autotools.in
+DFILES		= README INSTALL install-sh configure configure.ac config.sub config.guess Makefile.in  \
+		  Makefile.vc Makefile.dos Makefile.os2 Makefile.w32 Makefile.lnx watcom.mif  \
+		  CMakeLists.txt aclocal.m4 autogen.sh libxmp.map libxmp-lite.pc.in libxmp-lite-config.cmake \
+		  libxmp-lite-config.cmake.autotools libxmp-lite-config-version.cmake.autotools.in Changelog
 DDIRS		= include src loaders test cmake m4
 V		= 0
 LIB		= libxmp-lite.a

--- a/lite/Makefile.lnx
+++ b/lite/Makefile.lnx
@@ -1,0 +1,23 @@
+# Makefile for Linux using Watcom compiler.
+#
+# wmake -f Makefile.lnx
+# - builds the static library xmplite_static.lib
+#
+# To disable Impulse Tracker support :
+#	wmake -f Makefile.lnx DISABLE_IT=1
+#
+target = static
+
+CC = wcc386
+SYSTEM = linux
+
+CFLAGS = -zq -bt=linux -fp5 -fpi87 -mf -oeatxh -w4 -ei -zp8
+# newer OpenWatcom versions enable W303 by default.
+CFLAGS += -wcd=303
+# -5s  :  Pentium stack calling conventions.
+# -5r  :  Pentium register calling conventions.
+CFLAGS += -5s
+CFLAGS += -I"$(%WATCOM)/lh"
+#CFLAGS += -DHAVE_PIPE -DHAVE_FORK -DHAVE_EXECVP -DHAVE_FORK
+
+!include watcom.mif

--- a/lite/watcom.mif.in
+++ b/lite/watcom.mif.in
@@ -68,8 +68,13 @@ check-build: test/$(TESTNAME) .symbolic
 	$(CMD_CP) $(DLLNAME) test
 !endif
 
+!ifdef __UNIX__
+check: check-build .symbolic
+	cd test && ./$(TESTNAME)
+!else
 check: check-build .symbolic
 	cd test & $(TESTNAME)
+!endif
 
 clean: .symbolic
 	rm -f $(OBJS)

--- a/watcom.mif
+++ b/watcom.mif
@@ -320,16 +320,26 @@ check-build: test/$(TESTNAME) .symbolic
 	$(CMD_CP) $(DLLNAME) test
 !endif
 
+!ifdef __UNIX__
+check: check-build .symbolic
+	cd test && ./$(TESTNAME)
+!else
 check: check-build .symbolic
 	cd test & $(TESTNAME)
+!endif
 
 checklite-build: test/$(TESTNAME_LITE) .symbolic
 !ifneq target static
 	$(CMD_CP) $(DLLNAME_LITE) test
 !endif
 
+!ifdef __UNIX__
+check-lite: checklite-build .symbolic
+	cd test && ./$(TESTNAME_LITE)
+!else
 check-lite: checklite-build .symbolic
 	cd test & $(TESTNAME_LITE)
+!endif
 
 clean: .symbolic
 	rm -f src/*.obj

--- a/watcom.mif.in
+++ b/watcom.mif.in
@@ -111,16 +111,26 @@ check-build: test/$(TESTNAME) .symbolic
 	$(CMD_CP) $(DLLNAME) test
 !endif
 
+!ifdef __UNIX__
+check: check-build .symbolic
+	cd test && ./$(TESTNAME)
+!else
 check: check-build .symbolic
 	cd test & $(TESTNAME)
+!endif
 
 checklite-build: test/$(TESTNAME_LITE) .symbolic
 !ifneq target static
 	$(CMD_CP) $(DLLNAME_LITE) test
 !endif
 
+!ifdef __UNIX__
+check-lite: checklite-build .symbolic
+	cd test && ./$(TESTNAME_LITE)
+!else
 check-lite: checklite-build .symbolic
 	cd test & $(TESTNAME_LITE)
+!endif
 
 clean: .symbolic
 	rm -f src/*.obj


### PR DESCRIPTION
Tested by generating an xmp binary for i686-linux with oss audio and running on i686- and x86_64-linux.
