### PR TITLE
Use doubles for all module time/duration calculations.

### DIFF
--- a/docs/Changelog
+++ b/docs/Changelog
@@ -6,6 +6,8 @@ Stable versions
 	- Add support for Software Visions DMF (Apocalypse Abyss MOD variant).
 	- Replace kernel list helper in iff.c with custom list management
 	  to fix numerous otherwise unfixable KallistiOS redefinition warnings.
+	- All internal module time/duration calculations are now in doubles
+	  (fixes off-by-one module time on final tick of some modules).
 
 4.6.3 (20250511):
 	Changes by Alice Rowan:

--- a/lite/Changelog
+++ b/lite/Changelog
@@ -1,6 +1,11 @@
 Stable versions
 ---------------
 
+4.6.4 (?):
+	Changes by Alice Rowan:
+	- All internal module time/duration calculations are now in doubles
+	  (fixes off-by-one module time on final tick of some modules).
+
 4.6.3 (20250511):
 	Changes by Alice Rowan:
 	- Fix crashes when xmp_set_position is used to set a negative position.

--- a/src/common.h
+++ b/src/common.h
@@ -465,10 +465,10 @@ int libxmp_snprintf (char *, size_t, const char *, ...) LIBXMP_ATTRIB_PRINTF(3,4
 #define IS_AMIGA_MOD()	(IS_PLAYER_MODE_MOD() && IS_PERIOD_MODRNG())
 
 struct ord_data {
+	double time;			/* replay time (ms) at start of ord */
 	int speed;
 	int bpm;
 	int gvl;
-	int time; /* TODO: double */
 	int start_row;
 #ifndef LIBXMP_CORE_PLAYER
 	int st26_speed;
@@ -581,7 +581,7 @@ struct virt_channel {
 };
 
 struct scan_data {
-	int time;			/* replay time in ms */ /* TODO: double */
+	double time;			/* replay time in ms */
 	int row;
 	int ord;
 	int num;

--- a/src/player.c
+++ b/src/player.c
@@ -2261,6 +2261,8 @@ void xmp_get_frame_info(xmp_context opaque, struct xmp_frame_info *info)
 	struct mixer_data *s = &ctx->s;
 	struct module_data *m = &ctx->m;
 	struct xmp_module *mod = &m->mod;
+	double current_time;
+	double total_time;
 	int chn, i;
 
 	if (ctx->state < XMP_STATE_LOADED)
@@ -2282,13 +2284,19 @@ void xmp_get_frame_info(xmp_context opaque, struct xmp_frame_info *info)
 		info->num_rows = 0;
 	}
 
+	/* API still uses integers for time... */
+	current_time = p->current_time;
+	total_time = p->scan[p->sequence].time;
+	CLAMP(current_time, 0.0, (double)INT_MAX);
+	CLAMP(total_time, 0.0, (double)INT_MAX);
+
 	info->row = p->row;
 	info->frame = p->frame;
 	info->speed = p->speed;
 	info->bpm = p->bpm;
-	info->total_time = p->scan[p->sequence].time;
+	info->total_time = (int)total_time;
 	info->frame_time = (int)(libxmp_get_frame_time(ctx) * 1000.0);
-	info->time = p->current_time;
+	info->time = (int)current_time;
 	info->buffer = s->buffer;
 
 	info->total_size = XMP_MAX_FRAMESIZE;


### PR DESCRIPTION
This fixes off-by-one module time values on the final tick of some modules caused by replacing the current time with a truncated time value calculated during the scan and stored to an int. (#877, also affected ZALZA - Tekilla groove.xm)

This issue was partially worked around before in #803 / 4ff4097e by adding clamps on float-to-int conversions. These have been moved directly to the places where API values are initialized off of them.

Closes #877.