### PR TITLE
Add libxmp_path functions to replace XMP_MAXPATH.

### DIFF
--- a/Makefile.vc
+++ b/Makefile.vc
@@ -56,6 +56,7 @@ OBJS	= \
  src\hmn_extras.obj \
  src\extras.obj \
  src\smix.obj \
+ src\path.obj \
  src\filetype.obj \
  src\memio.obj \
  src\tempfile.obj \

--- a/cmake/libxmp-sources.cmake
+++ b/cmake/libxmp-sources.cmake
@@ -25,6 +25,7 @@ set(LIBXMP_SRC_LIST
     src/hmn_extras.c
     src/extras.c
     src/smix.c
+    src/path.c
     src/filetype.c
     src/memio.c
     src/tempfile.c

--- a/lite/src/Makefile
+++ b/lite/src/Makefile
@@ -7,7 +7,7 @@ SRC_OBJS	= virtual.o format.o period.o player.o read_event.o \
 SRC_DFILES	= Makefile $(SRC_OBJS:.o=.c) md5.c md5.h common.h effects.h \
 		  format.h lfo.h mixer.h mix_all.h period.h player.h virtual.h \
 		  precomp_lut.h hio.h callbackio.h memio.h mdataio.h tempfile.h \
-		  rng.h
+		  path.h rng.h
 
 SRC_PATH	= src
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,14 +2,14 @@
 SRC_OBJS	= virtual.o format.o period.o player.o read_event.o dataio.o \
 		  misc.o mkstemp.o md5.o lfo.o scan.o control.o far_extras.o \
 		  med_extras.o filter.o effects.o flow.o mixer.o mix_all.o rng.o \
-		  load_helpers.o load.o hio.o hmn_extras.o extras.o smix.o \
+		  load_helpers.o load.o hio.o hmn_extras.o extras.o smix.o path.o \
 		  filetype.o memio.o tempfile.o mix_paula.o miniz_tinfl.o win32.o
 
 SRC_DFILES	= Makefile $(SRC_OBJS:.o=.c) common.h effects.h \
 		  format.h lfo.h mixer.h mix_all.h period.h player.h virtual.h \
 		  md5.h precomp_lut.h tempfile.h med_extras.h hio.h rng.h \
 		  hmn_extras.h extras.h callbackio.h memio.h mdataio.h \
-		  far_extras.h paula.h precomp_blep.h miniz.h
+		  far_extras.h paula.h precomp_blep.h miniz.h path.h
 
 SRC_PATH	= src
 

--- a/src/bitrot/loaders/ssmt_load.c
+++ b/src/bitrot/loaders/ssmt_load.c
@@ -22,6 +22,7 @@
 
 #include "loader.h"
 #include "asif.h"
+#include "../path.h"
 
 
 static int mtp_test (HIO_HANDLE *, char *, const int);
@@ -182,16 +183,19 @@ static int mtp_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	for (i = 0; i < mod->ins; i++) {
 		struct xmp_instrument *xxi = &mod->xxi[i];
 		HIO_HANDLE *s;
-		char filename[XMP_MAXPATH];
+		struct libxmp_path sp;
 		char tmpname[32];
 
 		if (libxmp_copy_name_for_fopen(tmpname, xxi->name, 32) != 0)
 			continue;
 
-		if (!libxmp_find_instrument_file(m, filename, sizeof(filename), tmpname))
+		libxmp_path_init(&sp);
+		if (libxmp_find_instrument_file(m, &sp, tmpname) != 0)
 			continue;
 
-		if ((s = hio_open(filename, "rb")) != NULL) {
+		s = hio_open(sp.path, "rb");
+		libxmp_path_free(&sp);
+		if (s != NULL) {
 			asif_load(m, s, i);
 			hio_close(s);
 		}

--- a/src/common.h
+++ b/src/common.h
@@ -56,14 +56,6 @@
 #define LIBXMP_RESTRICT
 #endif
 
-#if defined(_MSC_VER) ||  defined(__WATCOMC__) || defined(__EMX__)
-#define XMP_MAXPATH _MAX_PATH
-#elif defined(PATH_MAX)
-#define XMP_MAXPATH  PATH_MAX
-#else
-#define XMP_MAXPATH  1024
-#endif
-
 #if defined(__MORPHOS__) || defined(__AROS__) || defined(__AMIGA__) \
  || defined(__amigaos__) || defined(__amigaos4__) || defined(AMIGA)
 #define LIBXMP_AMIGA	1

--- a/src/loaders/loader.h
+++ b/src/loaders/loader.h
@@ -6,6 +6,8 @@
 #include "../format.h"
 #include "../hio.h"
 
+struct libxmp_path; /* ../path.h */
+
 /* Sample flags */
 #define SAMPLE_FLAG_DIFF	0x0001	/* Differential */
 #define SAMPLE_FLAG_UNS		0x0002	/* Unsigned */
@@ -49,8 +51,8 @@ void	libxmp_set_xxh_defaults		(struct xmp_module *);
 void	libxmp_decode_protracker_event	(struct xmp_event *, const uint8 *);
 void	libxmp_decode_noisetracker_event(struct xmp_event *, const uint8 *);
 void	libxmp_disable_continue_fx	(struct xmp_event *);
-int	libxmp_check_filename_case	(const char *, const char *, char *, int);
-int	libxmp_find_instrument_file	(struct module_data *, char *, int, const char *);
+int	libxmp_check_filename_case	(struct libxmp_path *, const char *, const char *);
+int	libxmp_find_instrument_file	(struct module_data *, struct libxmp_path *, const char *);
 void	libxmp_set_type			(struct module_data *, const char *, ...);
 int	libxmp_load_sample		(struct module_data *, HIO_HANDLE *, int,
 					 struct xmp_sample *, const void *);

--- a/src/loaders/med4_load.c
+++ b/src/loaders/med4_load.c
@@ -29,6 +29,7 @@
 #include "med.h"
 #include "loader.h"
 #include "../med_extras.h"
+#include "../path.h"
 
 #define MAGIC_MED4	MAGIC4('M','E','D',4)
 #undef MED4_DEBUG
@@ -445,7 +446,7 @@ static int med4_load_instrument(HIO_HANDLE *f, struct module_data *m,
 static int med4_load_external_instrument(HIO_HANDLE *f, struct module_data *m,
 	int i, int *smp_idx, struct temp_inst *temp_inst)
 {
-	char path[XMP_MAXPATH];
+	struct libxmp_path sp;
 	char ins_name[32];
 	HIO_HANDLE *s = NULL;
 	int length;
@@ -454,10 +455,13 @@ static int med4_load_external_instrument(HIO_HANDLE *f, struct module_data *m,
 	if (libxmp_copy_name_for_fopen(ins_name, m->mod.xxi[i].name, 32) != 0)
 		return 0;
 
-	if (!libxmp_find_instrument_file(m, path, sizeof(path), ins_name))
+	libxmp_path_init(&sp);
+	if (libxmp_find_instrument_file(m, &sp, ins_name) != 0)
 		return 0;
 
-	if ((s = hio_open(path, "rb")) == NULL) {
+	s = hio_open(sp.path, "rb");
+	libxmp_path_free(&sp);
+	if (s == NULL) {
 		return 0;
 	}
 

--- a/src/loaders/mmd_common.c
+++ b/src/loaders/mmd_common.c
@@ -28,6 +28,7 @@
 #include "med.h"
 #include "loader.h"
 #include "../med_extras.h"
+#include "../path.h"
 
 #ifdef DEBUG
 const char *const mmd_inst_type[] = {
@@ -989,7 +990,7 @@ int mmd_load_instrument(HIO_HANDLE *f, struct module_data *m, int i, int smp_idx
 int med_load_external_instrument(HIO_HANDLE *f, struct module_data *m, int i)
 {
 	struct xmp_module *mod = &m->mod;
-	char path[XMP_MAXPATH];
+	struct libxmp_path sp;
 	char ins_name[32];
 	HIO_HANDLE *s = NULL;
 
@@ -1001,10 +1002,13 @@ int med_load_external_instrument(HIO_HANDLE *f, struct module_data *m, int i)
 		mod->xxs[i].flg & XMP_SAMPLE_LOOP ? 'L' : ' ',
 		mod->xxi[i].sub[0].vol);
 
-	if (!libxmp_find_instrument_file(m, path, sizeof(path), ins_name))
+	libxmp_path_init(&sp);
+	if (libxmp_find_instrument_file(m, &sp, ins_name) != 0)
 		return 0;
 
-	if ((s = hio_open(path, "rb")) == NULL) {
+	s = hio_open(sp.path, "rb");
+	libxmp_path_free(&sp);
+	if (s == NULL) {
 		return 0;
 	}
 

--- a/src/loaders/mod_load.c
+++ b/src/loaders/mod_load.c
@@ -42,6 +42,7 @@
 #include <ctype.h>
 #include "loader.h"
 #include "mod.h"
+#include "../path.h"
 
 #ifndef LIBXMP_CORE_PLAYER
 struct mod_magic {
@@ -1058,17 +1059,20 @@ skip_test:
 #else
 	if (ptsong) {
 	    HIO_HANDLE *s;
-	    char sn[XMP_MAXPATH];
+	    struct libxmp_path sp;
 	    char tmpname[32];
 	    const char *instname = mod->xxi[i].name;
 
 	    if (libxmp_copy_name_for_fopen(tmpname, instname, 32) != 0)
 		continue;
 
-	    if (!libxmp_find_instrument_file(m, sn, sizeof(sn), tmpname))
+	    libxmp_path_init(&sp);
+	    if (libxmp_find_instrument_file(m, &sp, tmpname) != 0)
 		continue;
 
-	    if ((s = hio_open(sn, "rb")) == NULL)
+	    s = hio_open(sp.path, "rb");
+	    libxmp_path_free(&sp);
+	    if (s == NULL)
 		continue;
 
 	    if (libxmp_load_sample(m, s, flags, &mod->xxs[i], NULL) < 0) {

--- a/src/loaders/stm_load.c
+++ b/src/loaders/stm_load.c
@@ -21,6 +21,7 @@
  */
 
 #include "loader.h"
+#include "../path.h"
 #include "../period.h"
 
 #define STM_TYPE_SONG	0x01
@@ -397,17 +398,20 @@ static int stm_load(struct module_data *m, HIO_HANDLE * f, const int start)
 
 		if (sfh.type == STM_TYPE_SONG) {
 			HIO_HANDLE *s;
-			char sn[XMP_MAXPATH];
+			struct libxmp_path sp;
 			char tmpname[32];
 			const char *instname = mod->xxi[i].name;
 
 			if (libxmp_copy_name_for_fopen(tmpname, instname, 32) != 0)
 				continue;
 
-			if (!libxmp_find_instrument_file(m, sn, sizeof(sn), tmpname))
+			libxmp_path_init(&sp);
+			if (libxmp_find_instrument_file(m, &sp, tmpname) != 0)
 				continue;
 
-			if ((s = hio_open(sn, "rb")) == NULL)
+			s = hio_open(sp.path, "rb");
+			libxmp_path_free(&sp);
+			if (s == NULL)
 				continue;
 
 			if (libxmp_load_sample(m, s, SAMPLE_FLAG_UNS, &mod->xxs[i], NULL) < 0) {

--- a/src/path.c
+++ b/src/path.c
@@ -1,0 +1,197 @@
+/* Extended Module Player
+ * Copyright (C) 1996-2025 Claudio Matsuoka and Hipolito Carraro Jr
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "path.h"
+
+#include <assert.h>
+
+
+void libxmp_path_init(struct libxmp_path *p)
+{
+	memset(p, 0, sizeof(struct libxmp_path));
+}
+
+void libxmp_path_free(struct libxmp_path *p)
+{
+	free(p->path);
+	p->path = NULL;
+}
+
+void libxmp_path_move(struct libxmp_path *dest, struct libxmp_path *src)
+{
+	libxmp_path_free(dest);
+	*dest = *src;
+	src->path = NULL;
+}
+
+static int fix_size(struct libxmp_path *p, size_t sz)
+{
+	if (!p->path || p->alloc < sz) {
+		void *tmp = realloc(p->path, sz);
+		if (!tmp) {
+			return -1;
+		}
+		p->path = (char *)tmp;
+		p->alloc = sz;
+	}
+	return 0;
+}
+
+static int is_slash(char c)
+{
+	return c == '\\' || c == '/';
+}
+
+/* Some console SDKs (3DS, possibly others) handle duplicate and trailing
+ * slashes very poorly. This function should be used to guarantee any path
+ * created by these functions will not have these issues. */
+static void clean_slashes(struct libxmp_path *p, size_t pos)
+{
+	size_t i, j;
+	if (pos >= p->length)
+		return;
+
+	/* Normalize to /, detect duplicates */
+	for (i = pos; i < p->length; i++) {
+		if (is_slash(p->path[i])) {
+			p->path[i] = '/';
+			if (i + 1 < p->length && is_slash(p->path[i + 1])) {
+				break;
+			}
+		}
+	}
+	/* Clean duplicates if they exist */
+	for (j = i; i < p->length; ) {
+		if (is_slash(p->path[i])) {
+			p->path[j++] = '/';
+			i++;
+			while (i < p->length && is_slash(p->path[i])) {
+				i++;
+			}
+		} else {
+			p->path[j++] = p->path[i++];
+		}
+	}
+	/* Trim trailing slash, except at index 0 */
+	if (j > 1 && is_slash(p->path[j - 1])) {
+		j--;
+	}
+	p->path[j] = '\0';
+	p->length = j;
+}
+
+int libxmp_path_set(struct libxmp_path *p, const char *new_path)
+{
+	size_t sz;
+
+	if (new_path == NULL) {
+		return -1;
+	}
+	sz = strlen(new_path) + 1u;
+
+	if (fix_size(p, sz) < 0) {
+		return -1;
+	}
+	memcpy(p->path, new_path, sz);
+	p->length = sz - 1u;
+
+	clean_slashes(p, 0);
+	return 0;
+}
+
+int libxmp_path_truncate(struct libxmp_path *p, size_t new_sz)
+{
+	if (new_sz > p->length) {
+		return 0;
+	}
+	if (fix_size(p, new_sz + 1u) < 0) {
+		return -1;
+	}
+	p->path[new_sz] = '\0';
+	p->length = new_sz;
+	if (new_sz) {
+		clean_slashes(p, new_sz - 1u);
+	}
+	return 0;
+}
+
+int libxmp_path_suffix_at(struct libxmp_path *p, size_t ext_pos, const char *ext)
+{
+	size_t sz;
+
+	if (ext == NULL || ext_pos > p->length) {
+		return -1;
+	}
+	sz = strlen(ext) + 1u;
+
+	if (fix_size(p, ext_pos + sz) < 0) {
+		return -1;
+	}
+	memcpy(p->path + ext_pos, ext, sz);
+	p->length = ext_pos + sz - 1u;
+
+	clean_slashes(p, ext_pos ? ext_pos - 1u : 0);
+	return 0;
+}
+
+int libxmp_path_append(struct libxmp_path *p, const char *append_path)
+{
+	size_t append_sz;
+	size_t new_sz;
+	size_t old_sz;
+
+	if (append_path == NULL) {
+		return -1;
+	}
+	append_sz = strlen(append_path) + 1;
+	new_sz = p->length + 1u + append_sz;
+	old_sz = p->length;
+
+	if (new_sz < p->length || fix_size(p, new_sz) < 0) {
+		return -1;
+	}
+	p->path[p->length++] = '/';
+	memcpy(p->path + p->length, append_path, append_sz);
+	p->length = new_sz - 1u;
+
+	clean_slashes(p, old_sz ? old_sz - 1u : 0);
+	return 0;
+}
+
+int libxmp_path_join(struct libxmp_path *p, const char *prefix_path,
+	const char *suffix_path)
+{
+	int ret;
+
+	if (prefix_path == NULL || suffix_path == NULL) {
+		return -1;
+	}
+
+	ret = snprintf(NULL, 0, "%s/%s", prefix_path, suffix_path);
+	if (ret < 0 || fix_size(p, (size_t)ret + 1u) < 0) {
+		return -1;
+	}
+	p->length = snprintf(p->path, p->alloc, "%s/%s", prefix_path, suffix_path);
+
+	clean_slashes(p, 0);
+	return 0;
+}

--- a/src/path.h
+++ b/src/path.h
@@ -1,0 +1,48 @@
+/* Extended Module Player
+ * Copyright (C) 1996-2025 Claudio Matsuoka and Hipolito Carraro Jr
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef LIBXMP_PATH_H
+#define LIBXMP_PATH_H
+
+#include "common.h"
+
+struct libxmp_path
+{
+	char *path;
+	size_t length;
+	size_t alloc;
+};
+
+LIBXMP_BEGIN_DECLS
+
+void	libxmp_path_init	(struct libxmp_path *);
+void	libxmp_path_free	(struct libxmp_path *);
+void	libxmp_path_move	(struct libxmp_path *dest, struct libxmp_path *src);
+int	libxmp_path_set		(struct libxmp_path *, const char *);
+int	libxmp_path_truncate	(struct libxmp_path *, size_t);
+int	libxmp_path_suffix_at	(struct libxmp_path *, size_t, const char *);
+int	libxmp_path_append	(struct libxmp_path *, const char *);
+int	libxmp_path_join	(struct libxmp_path *, const char *, const char *);
+
+LIBXMP_END_DECLS
+
+#endif /* LIBXMP_PATH_H */

--- a/src/tempfile.c
+++ b/src/tempfile.c
@@ -38,6 +38,14 @@
 #include <sys/stat.h>
 #endif
 
+#if defined(_MSC_VER) ||  defined(__WATCOMC__) || defined(__EMX__)
+#define XMP_MAXPATH _MAX_PATH
+#elif defined(PATH_MAX)
+#define XMP_MAXPATH  PATH_MAX
+#else
+#define XMP_MAXPATH  1024
+#endif
+
 #include "tempfile.h"
 
 #ifdef _WIN32

--- a/test-dev/CMakeLists.txt
+++ b/test-dev/CMakeLists.txt
@@ -22,6 +22,7 @@ set(DEVTEST_SRC
     ../src/hio.c
     ../src/lfo.c
     ../src/load_helpers.c
+    ../src/path.c
     ../src/period.c
     ../src/memio.c
     ../src/dataio.c

--- a/test-dev/Makefile.in
+++ b/test-dev/Makefile.in
@@ -659,6 +659,7 @@ TESTS		= $(READ_TESTS) \
 		  $(DEPACK_TESTS) \
 		  $(PROWIZARD_TESTS) \
 		  string_adjustment \
+		  path \
 		  $(LOADER_TESTS) \
 		  $(API_TESTS) \
 		  $(QUIRK_TESTS) \
@@ -692,7 +693,7 @@ SRC_PATH	= ../src
 
 TEST_INTERNAL	= md5.o win32.o hio.o load_helpers.o loaders/itsex.o dataio.o scan.o \
 		  loaders/sample.o loaders/common.o filetype.o period.o memio.o \
-		  depackers/xfnmatch.o far_extras.o flow.o lfo.o rng.o
+		  depackers/xfnmatch.o far_extras.o flow.o lfo.o rng.o path.o
 
 T_OBJS 		= $(addprefix $(TEST_PATH)/,$(TEST_OBJS)) \
 		  $(addprefix $(SRC_PATH)/,$(TEST_INTERNAL))

--- a/test-dev/Makefile.vc
+++ b/test-dev/Makefile.vc
@@ -28,6 +28,7 @@ XMP_SOURCES	= \
  ..\src\flow.c \
  ..\src\lfo.c \
  ..\src\rng.c \
+ ..\src\path.c \
 
 ALL_SOURCES	= $(SOURCES) $(TEST_SOURCES) $(XMP_SOURCES)
 

--- a/test-dev/all_tests.txt
+++ b/test-dev/all_tests.txt
@@ -67,6 +67,7 @@ test_prowizard_zen
 test_prowizard_fuchs
 test_prowizard_starpack
 test_string_adjustment
+test_path
 test_loader_6chn
 test_loader_mod_adpcm4
 test_loader_mod_noterange

--- a/test-dev/test_path.c
+++ b/test-dev/test_path.c
@@ -1,0 +1,167 @@
+#include "test.h"
+#include "../src/path.h"
+
+/* Test macros, rather than functions, to preserve caller line numbers */
+
+#define test_move(dest, src, expected) \
+do { \
+	libxmp_path_move((dest), (src)); \
+	if ((expected) == NULL) { \
+		fail_unless((dest)->path == NULL, "should be null"); \
+	} else { \
+		/* Silence nonsensical compiler warning */ \
+		const char *e = (expected) ? (expected) : "stfu"; \
+		fail_unless(!strcmp((dest)->path, e), (dest)->path); \
+	} \
+} while(0)
+
+#define test_set(dest, value, expected) \
+do { \
+	ret = libxmp_path_set((dest), (value)); \
+	fail_unless(ret == 0, "failed alloc"); \
+	fail_unless(!strcmp((dest)->path, (expected)), (dest)->path); \
+} while(0)
+
+#define test_truncate(dest, num, expected) \
+do { \
+	ret = libxmp_path_truncate((dest), (num)); \
+	fail_unless(ret == 0, "failed alloc"); \
+	fail_unless(!strcmp((dest)->path, (expected)), (dest)->path); \
+} while(0)
+
+#define test_suffix_at(dest, ext_pos, ext, expected) \
+do { \
+	ret = libxmp_path_suffix_at((dest), (ext_pos), (ext)); \
+	if ((expected) == NULL) { \
+		fail_unless(ret == -1, "ext pos should cause failure"); \
+	} else { \
+		/* Silence nonsensical compiler warning */ \
+		const char *e = (expected) ? (expected) : "stfu"; \
+		fail_unless(ret == 0, "failed alloc or check"); \
+		fail_unless(!strcmp((dest)->path, e), (dest)->path); \
+	} \
+} while(0)
+
+#define test_append(dest, value, expected) \
+do { \
+	ret = libxmp_path_append((dest), (value)); \
+	fail_unless(ret == 0, "failed alloc or length overflowed"); \
+	fail_unless(!strcmp((dest)->path, (expected)), (dest)->path); \
+} while(0)
+
+#define test_join(dest, value_a, value_b, expected) \
+do { \
+	ret = libxmp_path_join((dest), (value_a), (value_b)); \
+	fail_unless(ret == 0, "failed alloc or length overflowed"); \
+	fail_unless(!strcmp((dest)->path, (expected)), (dest)->path); \
+} while(0)
+
+
+TEST(test_path)
+{
+	struct libxmp_path sp;
+	struct libxmp_path sp2;
+	int ret;
+
+	libxmp_path_init(&sp);
+	/* Valid to free on init */
+	libxmp_path_free(&sp);
+
+	/* Set */
+	libxmp_path_init(&sp);
+	test_set(&sp, "test path", "test path");
+	test_set(&sp, "another_path", "another_path");
+	test_set(&sp, "i//luv//slashes//", "i/luv/slashes");
+	test_set(&sp, "//////lololol///////////", "/lololol");
+	test_set(&sp, "//////", "/");
+	test_set(&sp, "c:\\this\\too", "c:/this/too");
+	test_set(&sp, "z:\\\\lmao\\\\\\\\", "z:/lmao");
+
+	ret = libxmp_path_set(&sp, NULL);
+	fail_unless(ret == -1, "fail on NULL");
+
+	libxmp_path_free(&sp);
+	libxmp_path_free(&sp); /* Junk data but should be okay to free */
+
+	/* Move */
+	libxmp_path_init(&sp);
+	libxmp_path_init(&sp2);
+	test_set(&sp, "path a", "path a");
+	test_set(&sp2, "path b", "path b");
+	test_move(&sp, &sp2, "path b");
+	libxmp_path_free(&sp);
+	libxmp_path_free(&sp2); /* Junk data but should be okay to free */
+
+	libxmp_path_init(&sp);
+	libxmp_path_init(&sp2);
+	test_set(&sp, "path a", "path a");
+	test_move(&sp, &sp2, NULL);
+
+	/* Truncate */
+	libxmp_path_init(&sp);
+	test_set(&sp, "a/test/path", "a/test/path");
+	test_truncate(&sp, 10000, "a/test/path");
+	test_truncate(&sp, 8, "a/test/p");
+	test_truncate(&sp, 7, "a/test");
+	test_truncate(&sp, 6, "a/test");
+	test_truncate(&sp, 2, "a");
+	test_truncate(&sp, 1, "a");
+	test_truncate(&sp, 0, "");
+	libxmp_path_free(&sp);
+
+	/* Suffix at */
+	libxmp_path_init(&sp);
+	test_set(&sp, "another/path.s3m", "another/path.s3m");
+	test_suffix_at(&sp, 12, ".mod", "another/path.mod");
+	test_suffix_at(&sp, 17, ".AS", NULL);
+	test_suffix_at(&sp, 16, ".nt", "another/path.mod.nt");
+	test_suffix_at(&sp, 10000, ".abc", NULL);
+	test_suffix_at(&sp, 16, ".AS", "another/path.mod.AS");
+	test_suffix_at(&sp, 12, ".mod", "another/path.mod");
+	test_suffix_at(&sp, 17, ".nt", NULL);
+	test_suffix_at(&sp, 8, "\\/\\//loool.it", "another/loool.it");
+
+	ret = libxmp_path_suffix_at(&sp, 5, NULL);
+	fail_unless(ret == -1, "fail on NULL");
+
+	libxmp_path_free(&sp);
+
+	/* Append */
+	libxmp_path_init(&sp);
+	test_append(&sp, "hellow!11", "/hellow!11");
+	test_truncate(&sp, 0, "");
+	test_append(&sp, "/\\/\\/owo\\//\\//", "/owo");
+	test_set(&sp, "init", "init");
+	test_append(&sp, "more path", "init/more path");
+	test_set(&sp, "first/", "first");
+	test_append(&sp, "second", "first/second");
+	test_append(&sp, "/third", "first/second/third");
+	test_append(&sp, "", "first/second/third"); /* unintended but works */
+
+	ret = libxmp_path_append(&sp, NULL);
+	fail_unless(ret == -1, "fail on NULL");
+
+	libxmp_path_free(&sp);
+
+	/* Join */
+	libxmp_path_init(&sp);
+	test_join(&sp, "first", "second", "first/second");
+	test_join(&sp, "/first/second/", "/third/fourth/",
+			"/first/second/third/fourth");
+	test_join(&sp, "//\\//\\//woah//", "\\//\\better//clean\\\\this\\/",
+			"/woah/better/clean/this");
+
+	test_join(&sp, "first", "", "first"); /* unintended but works */
+	test_join(&sp, "", "second", "/second"); /* unintended but works */
+	test_join(&sp, "", "", "/"); /* unintended but works */
+
+	ret = libxmp_path_join(&sp, "a", NULL);
+	fail_unless(ret == -1, "fail on NULL");
+	ret = libxmp_path_join(&sp, NULL, "b");
+	fail_unless(ret == -1, "fail on NULL");
+	ret = libxmp_path_join(&sp, NULL, NULL);
+	fail_unless(ret == -1, "fail on NULL");
+
+	libxmp_path_free(&sp);
+}
+END_TEST

--- a/watcom.mif
+++ b/watcom.mif
@@ -80,6 +80,7 @@ OBJS= &
  src/hmn_extras.obj &
  src/extras.obj &
  src/smix.obj &
+ src/path.obj &
  src/filetype.obj &
  src/memio.obj &
  src/tempfile.obj &


### PR DESCRIPTION
This patch replaces most instances of fixed-size stack buffers
for paths with heap path functions, offering the following benefits:

* Full path buffers are no longer placed on the stack. In Linux,
  `XMP_MAXPATH` is defined to 4096(!), and for most other platforms
  it is defined to 1024. In some cases, libxmp would create multiple
  of these buffers. For comparison, the default stack size for new
  threads in dkP SDKs is 8192.
* Path sizes are no longer limited by an arbitrary value defined in
  a header somewhere. Aside from old Windows versions, these values
  seem to rarely have any basis in reality.
* Since this uses dedicated functions, I added a slash-cleaning
  routine, since this can sometimes be a problem in console SDKs.
  Previously, libxmp was putting hardcoded slashes in `snprintf` calls.

I left the tempfile.c usage in-place and moved the definition of `XMP_MAXPATH` to tempfile.c, since it affects several platforms I can't easily test right now.

Closes #776.
