### PR TITLE
Fix link failures in builds C++ with compilers.

### DIFF
--- a/src/filter.c
+++ b/src/filter.c
@@ -28,6 +28,7 @@
 #ifndef LIBXMP_CORE_DISABLE_IT
 #include <math.h>
 #include "xmp.h"
+#include "player.h"
 #include "mixer.h"
 
 /*

--- a/src/flow.c
+++ b/src/flow.c
@@ -21,6 +21,7 @@
  */
 
 #include "common.h"
+#include "player.h"
 
 /* Process a pattern loop effect with the parameter fxp. A parameter of 0
  * will set the loop target, and a parameter of 1-15 (most formats) or

--- a/src/med_extras.c
+++ b/src/med_extras.c
@@ -24,6 +24,7 @@
 #include "player.h"
 #include "virtual.h"
 #include "effects.h"
+#include "extras.h"
 #include "med_extras.h"
 
 #ifdef __SUNPRO_C


### PR DESCRIPTION
```
src/player.c:863: undefined reference to `libxmp_med_hold_hack'
src/player.lo: In function `process_frequency':
src/player.c:1317: undefined reference to `libxmp_filter_setup'
src/scan.lo: In function `scan_module':
src/scan.c:534: undefined reference to `libxmp_process_pattern_break'
src/scan.c:544: undefined reference to `libxmp_process_pattern_jump'
src/scan.c:560: undefined reference to `libxmp_process_pattern_break'
src/scan.c:572: undefined reference to `libxmp_process_line_jump'
src/scan.c:595: undefined reference to `libxmp_process_pattern_loop'
src/effects.lo: In function `libxmp_process_fx':
src/effects.c:571: undefined reference to `libxmp_process_pattern_break'
src/effects.c:367: undefined reference to `libxmp_process_pattern_jump'
src/effects.c:377: undefined reference to `libxmp_process_pattern_break'
src/effects.c:1115: undefined reference to `libxmp_process_line_jump'
src/effects.c:412: undefined reference to `libxmp_process_pattern_loop'
````
