### PR TITLE
Fix xmp_seek_time double-to-int conversion.

### DIFF
--- a/src/control.c
+++ b/src/control.c
@@ -239,7 +239,8 @@ int xmp_seek_time(xmp_context opaque, int time)
 	struct context_data *ctx = (struct context_data *)opaque;
 	struct player_data *p = &ctx->p;
 	struct module_data *m = &ctx->m;
-	int i, t;
+	double t;
+	int i;
 
 	if (ctx->state < XMP_STATE_PLAYING)
 		return -XMP_ERROR_STATE;
@@ -252,8 +253,12 @@ int xmp_seek_time(xmp_context opaque, int time)
 		if (libxmp_get_sequence(ctx, i) != p->sequence) {
 			continue;
 		}
+		/* TODO: using rounding to preserve compatibility with
+		 * the old (bad) int conversion here until this API
+		 * function can be fixed or replaced. */
 		t = m->xxo_info[i].time;
-		if (time >= t) {
+		CLAMP(t, 0.0, (double)INT_MAX);
+		if (time >= (int)t) {
 			set_position(ctx, i, 1);
 			break;
 		}


### PR DESCRIPTION
This conversion was added by the double scan times patch (#879) and I missed adding the guards for it. `xmp_seek_time` needs to clamp and then explicitly round the double to preserve the exact behavior of the old integer `xxo_info` time values here.

Building the updated `xmp_seek_time` regression test with UBSan without the control.c fix should reproduce this error:

```
test 570: test_player_scan: src/control.c:255:7: runtime error: 9.32571e+09 is outside the range of representable values of type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/control.c:255:7
**fail**
```