### PR TITLE
CMake: Win32: fix installation of .cmake scripts on MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,7 +301,7 @@ add_subdirectory(docs)
 
 include(CMakePackageConfigHelpers)
 
-if(WIN32)
+if(WIN32 AND NOT MINGW)
     set(cmake_install_cmakdir "cmake")
     set(cmake_install_cmakdir_lite "cmake")
 else()


### PR DESCRIPTION
After compiling the source codes of libxmp, installing on MinGW will put the scripts for CMake in a wrong position.

<img width="1072" height="498" alt="immagine" src="https://github.com/user-attachments/assets/fc34891e-d2d5-459e-83a1-dd24fa22cb8e" />
Actually they should be installed into the `lib` directory instead.
Attached patch fixes this issue.