### PR TITLE
Add debug check for Protracker 3.6 PTDT length.

### DIFF
--- a/src/loaders/iff.c
+++ b/src/loaders/iff.c
@@ -57,6 +57,7 @@ static int iff_process(iff_handle opaque, struct module_data *m, char *id, uint3
 	long pos;
 
 	pos = hio_tell(f);
+	D_(D_INFO "chunk offset: %ld", pos);
 
 	for (i = data->head; i; i = i->next) {
 		if (id && !memcmp(id, i->id, data->id_size)) {
@@ -115,7 +116,7 @@ static int iff_chunk(iff_handle opaque, struct module_data *m, HIO_HANDLE *f, vo
 	} else {
 		size = hio_read32b(f);
 	}
-	D_(D_INFO "size: %d", size);
+	D_(D_INFO "chunk size: %u", (unsigned)size);
 
 	if (hio_error(f)) {
 		/* IFF container issue--exit without error. */


### PR DESCRIPTION
This format misreports the length of its PTDT chunk in several modules due to what appears to be a bug in the original tracker, causing libxmp to attempt to read a bogus chunk from the middle of sample data. The affected modules were fixed by #891. I've added/tweaked IFF debug messages to help debug this in case more of these modules turn up in the future.

Closes #758.