### PR TITLE
configure.ac: fail if ar or ranlib isn't found for static builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,9 @@ if test "${enable_static}" = yes; then
   if test "${enable_lite}" = yes; then
      STATIC="$STATIC static-lite"
   fi
+  if test x"$AR" = x: || test  x"$RANLIB" = x: ; then
+     AC_MSG_ERROR([Build tools ar and/or ranlib not found.])
+  fi
   AC_SUBST(STATIC)
 fi
 if test "${enable_shared}" != no; then

--- a/lite/configure.ac
+++ b/lite/configure.ac
@@ -82,6 +82,9 @@ dnl Skip this on platforms where it is just simply busted.
 esac
 
 if test "${enable_static}" = yes; then
+  if test x"$AR" = x: || test  x"$RANLIB" = x: ; then
+     AC_MSG_ERROR([Build tools ar and/or ranlib not found.])
+  fi
   AC_SUBST(STATIC,static)
 fi
 if test "${enable_shared}" != no; then


### PR DESCRIPTION
Fixes: https://github.com/libxmp/libxmp/issues/893