### PR TITLE
test_api_get_format_list.c: fix stupid mistake from PR/898

### DIFF
--- a/test-dev/test_api_get_format_list.c
+++ b/test-dev/test_api_get_format_list.c
@@ -6,10 +6,10 @@ TEST(test_api_get_format_list)
 	int i;
 
 	list = xmp_get_format_list();
-	fail_unless(list != 0, "returned NULL");
+	fail_unless(list != NULL, "returned NULL");
 
 	for (i = 0; list[i] != NULL; i++) {
-		fail_unless(*list[i] != NULL, "empty format name");
+		fail_unless(*list[i] != 0, "empty format name");
 	}
 
 	fail_unless(i == 95, "wrong number of formats");


### PR DESCRIPTION
```
test_api_get_format_list.c: In function 'int _test_func_test_api_get_format_list()':
test_api_get_format_list.c:12: warning: NULL used in arithmetic
```
