### PR TITLE
Simplify read_event_mod sample default volume handling.

### DIFF
--- a/docs/Changelog
+++ b/docs/Changelog
@@ -22,6 +22,7 @@ Stable versions
 	- Correct default of sample default panning values to -1 (no default
 	  panning) for most module formats.
 	- Fix Galaxy Music System 4.0 sample default panning.
+	- Simplify read_event_mod sample default volume handling.
 	Changes by Alice Rowan and ds-sloth:
 	- Minor Impulse Tracker loader performance improvements.
 

--- a/lite/Changelog
+++ b/lite/Changelog
@@ -8,6 +8,7 @@ Stable versions
 	- Fix XM volume effects cxx/dxx accidentally having effects memory.
 	- Correct default of sample default panning values to -1 (no default
 	  panning) for most module formats.
+	- Simplify read_event_mod sample default volume handling.
 	Changes by Alice Rowan and ds-sloth:
 	- Minor Impulse Tracker loader performance improvements.
 


### PR DESCRIPTION
Sample default volume is implemented in a strange way in all of the libxmp_read_event implementations. This needs to be cleaned up, as it's a significant part of why these functions are a headache.

This patch tidies up the handling for read_event_mod ONLY.

Summary of old behavior:
* `new_ins_vol` was set for any `e->ins` present, regardless of validity.
* Instrument volume was applied based on the subinstrument from a valid `e->ins` ONLY in cases of toneporta (and `!xc->split`), which unsets `new_ins_vol`.
* `new_ins_vol` was unset in the case of `e->note == XMP_KEY_OFF`.
* There was a fully redundant clearing of `new_ins_vol` in cases of no toneporta and no valid subinstrument for the key. This case was already filtered by the early return.
* The event volume is then applied to `xc->volume` and the effects are run. If any of these change `xc->volume`, they will `SET(NEW_VOL)`.
* The early return prevents instrument volume from being applied when there is no valid subinstrument.
* In backwards fashion, FINALLY the instrument volume is applied if `e->ins && sub && new_ins_vol && !TEST(NEW_VOL) && !xc->split`. Note the `sub` value here might not be from `e->ins` in cases of toneporta, hence the earlier special case for toneporta.

New behavior:
* `xc->volume` is now set directly for a valid subinstrument of `e->ins` if `e->note != XMP_KEY_OFF and !xc->split`. This is performed before handling `e->volume` and effects, thus they will naturally overwrite this value when setting volume.

The new behavior should be 100% equivalent and closer to how these old player routines actually behave.