### PR TITLE
avoid -Wmissing-prototypes for mkstemp():

### DIFF
--- a/src/mkstemp.c
+++ b/src/mkstemp.c
@@ -3,6 +3,7 @@
 #endif
 
 #include "common.h"
+#include "tempfile.h"
 
 #if !(defined(LIBXMP_NO_PROWIZARD) && defined(LIBXMP_NO_DEPACKERS))
 

--- a/src/tempfile.c
+++ b/src/tempfile.c
@@ -54,7 +54,6 @@
 #define close _close
 #define unlink _unlink
 #define umask _umask
-int mkstemp(char *);
 
 static int get_temp_dir(char *buf, size_t size)
 {

--- a/src/tempfile.h
+++ b/src/tempfile.h
@@ -1,5 +1,5 @@
-#ifndef XMP_PLATFORM_H
-#define XMP_PLATFORM_H
+#ifndef LIBXMP_TEMPFILE_H
+#define LIBXMP_TEMPFILE_H
 
 #include "common.h"
 
@@ -7,6 +7,11 @@ LIBXMP_BEGIN_DECLS
 
 FILE *make_temp_file(char **);
 void unlink_temp_file(char *);
+
+#ifndef HAVE_MKSTEMP
+int libxmp_mkstemp(char *);
+#define mkstemp libxmp_mkstemp
+#endif
 
 LIBXMP_END_DECLS
 


### PR DESCRIPTION
`	src/mkstemp.c:68: warning: no previous prototype for 'mkstemp'`

also rename mkstemp to libxmp_mkstemp, if not available at configuration time.
