### PR TITLE
read_event_ft2: finish cleaning up check instrument block.

### DIFF
--- a/src/read_event.c
+++ b/src/read_event.c
@@ -515,28 +515,7 @@ static int read_event_ft2(struct context_data *ctx, const struct xmp_event *e, i
 	/* Retain previous subinstrument for default volume. */
 	sub = get_subinstrument(ctx, xc->ins, xc->key);
 
-	/* Check instrument */
-
-	/* TODO: finish removal of this block.
-	 */
-	if (ev.ins && key != XMP_KEY_FADE) {
-		SET(NEW_INS);
-		xc->per_flags = 0;
-
-		if (!IS_VALID_INSTRUMENT(ev.ins - 1)) {
-			/* If no note is set FT2 doesn't cut on invalid
-			 * instruments (it keeps playing the previous one).
-			 * If a note is set it cuts the current sample.
-			 */
-			xc->flags = 0;
-
-			if (is_toneporta) {
-				key = 0;
-			}
-		}
-	}
-
-	/* Check subinstrument
+	/* Check instrument
 	 *
 	 * Only update the (sub)instrument if there's a valid note +
 	 * no toneporta/K00. Otherwise, keep the old (sub)instrument.
@@ -574,16 +553,19 @@ static int read_event_ft2(struct context_data *ctx, const struct xmp_event *e, i
 		}
 	}
 	if (ev.ins) {
+		int pan;
+		SET(NEW_INS);
+		xc->per_flags = 0; /* For posterity; not used by XM */
+
 		/* On any line with an instrument, use the active subinstrument
 		 * for default volume and panning. Invalid instruments have
 		 * volume 0 panning 0x80 (test_player_ft2_invalid_ins_defaults).
 		 * Works on lines with K00 (test_player_ft2_k00_defaults).
 		 */
-		int pan = sub ? sub->pan : 0x80;
-
 		xc->volume = sub ? sub->vol : 0;
 		SET(NEW_VOL);
 
+		pan = sub ? sub->pan : 0x80;
 		if (pan >= 0) {
 			xc->pan.val = pan;
 		}


### PR DESCRIPTION
```
SET(NEW_INS);
```
This is a flag that indicates an instrument number was in the event usually. This flag seems to be mainly diagnostic and is only tested in med_extras.c (irrelevant to here) and the invert loop handler (also irrelevant here). The other handlers are varied about how they actually set and clear this. The closest equivalent is the default volume block, so moving it there.

```
xc->per_flags = 0;
```
XM, and the other formats that currently use `read_event_ft2`, do not have any persistent effects implemented as far as I can tell, so this is just here in case someone uses `-e`. The closest equivalent is the default volume block, so moving it there.

```
if (!IS_VALID_INSTRUMENT(ev.ins - 1)) {
  /* If no note is set FT2 doesn't cut on invalid
   * instruments (it keeps playing the previous one).
   * If a note is set it cuts the current sample.
   */
```
Now explained elsewhere, safe to remove.

```
  xc->flags = 0;
```
Does nothing in this case except clears the newly set `NEW_INS`. Since invalid instruments have pretty much the same semantics as valid instruments for XMs, this flag isn't used for much, and there's now precedence for *not* clearing this with invalid instruments (`read_event_mod`), this can go.

```
  if (is_toneporta) {
    key = 0;
  }
}
```
The next usage of key is qualified with `!is_toneporta` and the usage after that does `SET(NEW_NOTE)` (another mainly diagnostic flag that is only used in med_extras.c), then does one of the following:

* `key == XMP_KEY_OFF`: the XM loader loads key off + ins# as `XMP_KEY_FADE`, so this case is irrelevant.
* `key == XMP_KEY_FADE`: is prevented from entering the old instrument block by the xyce-dans_la_rue.xm bugfix, so this case is irrelevant.
* `is_toneporta`: sets key to 0, which is the same thing that the instrument block does, so the instrument block piece can be removed.