### PR TITLE
Fix read_event_mod/read_event_st3 multisample defaults.

### DIFF
--- a/src/read_event.c
+++ b/src/read_event.c
@@ -286,6 +286,9 @@ static int read_event_mod(struct context_data *ctx, const struct xmp_event *e, i
 
 	/* Check instrument */
 
+	if (IS_VALID_NOTE(e->note - 1) && !is_toneporta) {
+		xc->key = e->note - 1;
+	}
 	if (e->ins) {
 		int ins = e->ins - 1;
 		SET(NEW_INS);
@@ -297,7 +300,7 @@ static int read_event_mod(struct context_data *ctx, const struct xmp_event *e, i
 		RESET_NOTE(NOTE_RELEASE|NOTE_FADEOUT);
 
 		if (IS_VALID_INSTRUMENT(ins)) {
-			sub = get_subinstrument(ctx, ins, e->note - 1);
+			sub = get_subinstrument(ctx, ins, xc->key);
 
 			if (sub != NULL) {
 				new_swap_ins = 1;
@@ -357,7 +360,6 @@ static int read_event_mod(struct context_data *ctx, const struct xmp_event *e, i
 		if (e->note == XMP_KEY_OFF) {
 			SET_NOTE(NOTE_RELEASE);
 		} else if (!is_toneporta && IS_VALID_NOTE(e->note - 1)) {
-			xc->key = e->note - 1;
 			RESET_NOTE(NOTE_END);
 
 			sub = get_subinstrument(ctx, xc->ins, xc->key);
@@ -744,6 +746,9 @@ static int read_event_st3(struct context_data *ctx, const struct xmp_event *e, i
 
 	/* Check instrument */
 
+	if (IS_VALID_NOTE(e->note - 1) && !is_toneporta) {
+		xc->key = e->note - 1;
+	}
 	if (e->ins) {
 		int ins = e->ins - 1;
 		SET(NEW_INS);
@@ -762,7 +767,7 @@ static int read_event_st3(struct context_data *ctx, const struct xmp_event *e, i
 			}
 
 			/* Get new instrument volume */
-			sub = get_subinstrument(ctx, ins, e->note - 1);
+			sub = get_subinstrument(ctx, ins, xc->key);
 			if (sub != NULL && e->note != XMP_KEY_OFF) {
 				set_channel_volume(xc, sub->vol);
 				set_channel_pan(xc, sub->pan);
@@ -788,7 +793,6 @@ static int read_event_st3(struct context_data *ctx, const struct xmp_event *e, i
 				xc->offset.val = 0;
 			}
 		} else if (IS_VALID_NOTE(e->note - 1)) {
-			xc->key = e->note - 1;
 			RESET_NOTE(NOTE_END);
 
 			sub = get_subinstrument(ctx, xc->ins, xc->key);

--- a/test-dev/test_no_note_same_ins_mod.c
+++ b/test-dev/test_no_note_same_ins_mod.c
@@ -107,7 +107,7 @@ TEST(test_no_note_same_ins_mod)
 	/* Row 5 */
 	xmp_play_frame(opaque);
 	check_on(xc, vi, KEY_B5, INS_0,
-		 -1 /* FIXME: INS_0_SUB_1_VOL */, -1 /* FIXME: INS_0_SUB_1_PAN */, INS_0_FADE, "row 5");
+		 INS_0_SUB_1_VOL, INS_0_SUB_1_PAN, INS_0_FADE, "row 5");
 
 	xmp_play_frame(opaque);
 

--- a/test-dev/test_no_note_same_ins_st3.c
+++ b/test-dev/test_no_note_same_ins_st3.c
@@ -108,7 +108,7 @@ TEST(test_no_note_same_ins_st3)
 	/* Row 5 */
 	xmp_play_frame(opaque);
 	check_on(xc, vi, KEY_B5, INS_0,
-		 -1 /* FIXME: INS_0_SUB_1_VOL */, -1 /* FIXME: INS_0_SUB_1_PAN */, INS_0_FADE, "row 5");
+		 INS_0_SUB_1_VOL, INS_0_SUB_1_PAN, INS_0_FADE, "row 5");
 
 	xmp_play_frame(opaque);
 


### PR DESCRIPTION
In `read_event_mod` and `read_event_st3`, `xc->key` is set if `e->note` is a valid note and there is no toneporta. The event is read-only and the toneporta state never changes, therefore `xc->key` can be set before handling the instrument. This allows the subinstrument lookups to use the correct key to get default volume/panning. Previously, default volume was set at the end of the functions using the correct `xc->key` via a convoluted chain of checks.

Fixes minor regressions from #909 and #911. The only multisample format currently using either of these players is Imago Orpheus IMF, which doesn't closely match any of the current read event functions.

(Previously, events with an instrument number but no note or with an invalid note would use subinstrument 0 for defaults instead of the mapped subinstrument.)