### PR TITLE
Add more VSCode/Codium/clangd gitignore entries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,12 +24,18 @@ test-dev/xmpchk
 
 # VC++ files
 /.vs
-/.vscode
 *.exp
 *.lib
 *.suo
 *.ncb
 Makefile.vc.tmp
+
+# VSCode/clangd files
+/.cache
+/.clangd
+/.vscode
+*.code-workspace
+compile_commands.json
 
 # Module formats
 *.mod


### PR DESCRIPTION
.cache - automatically generated by clangd, contains 100s of files, can cause Code/Codium to complain about untracked changes.
.clangd - local configuration
.vscode - local configuration (moved from VC++ section) *.code-workspace - saved workspace files
compile_commands.json - generated by bear, required by clangd.