### PR TITLE
Fix xmp_start_player unmuting regression from 4.5.0.

### DIFF
--- a/docs/Changelog
+++ b/docs/Changelog
@@ -100,6 +100,9 @@ Stable versions
 	- PTM: actually fix pattern break hex parameter.
 	- STM: always use 0 for pattern break parameter (ST2 ignores it).
 	- STM: import ST2 tempo values as both speed and BPM.
+	- GDM: don't zero channel volume for muted channels.
+	- Fix xmp_start_player not unmuting non-muted channels (regression
+	  introduced in 4.5.0).
 	Changes by Alice Rowan and ds-sloth:
 	- Minor Impulse Tracker loader performance improvements.
 

--- a/lite/Changelog
+++ b/lite/Changelog
@@ -58,6 +58,8 @@ Stable versions
 	- Fix time tracking bugs when Bxx+Dxx jumps within the same position.
 	- S3M/IT: Cxx followed by Byy on the same row now jumps to pos Y row X.
 	- IT: fix importing channel initial panning for muted channels.
+	- Fix xmp_start_player not unmuting non-muted channels (regression
+	  introduced in 4.5.0).
 	Changes by Alice Rowan and ds-sloth:
 	- Minor Impulse Tracker loader performance improvements.
 

--- a/src/loaders/gdm_load.c
+++ b/src/loaders/gdm_load.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2024 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2026 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -209,7 +209,6 @@ static int gdm_load(struct module_data *m, HIO_HANDLE *f, const int start)
 	for (i = 0; i < 32; i++) {
 		if (panmap[i] == 255) {
 			panmap[i] = 8;
-			mod->xxc[i].vol = 0;
 			mod->xxc[i].flg |= XMP_CHANNEL_MUTE;
 		} else if (panmap[i] == 16) {
 			panmap[i] = 8;

--- a/src/player.c
+++ b/src/player.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2025 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2026 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -1945,13 +1945,12 @@ int xmp_start_player(xmp_context opaque, int rate, int format)
 	p->sequence = 0;
 
 	/* Set default volume and mute status */
-	for (i = 0; i < mod->chn; i++) {
-		if (mod->xxc[i].flg & XMP_CHANNEL_MUTE)
+	for (i = 0; i < XMP_MAX_CHANNELS; i++) {
+		if (i < mod->chn && (mod->xxc[i].flg & XMP_CHANNEL_MUTE)) {
 			p->channel_mute[i] = 1;
-		p->channel_vol[i] = 100;
-	}
-	for (i = mod->chn; i < XMP_MAX_CHANNELS; i++) {
-		p->channel_mute[i] = 0;
+		} else {
+			p->channel_mute[i] = 0;
+		}
 		p->channel_vol[i] = 100;
 	}
 


### PR DESCRIPTION
Prior to 4.5.0, `xmp_start_player` unconditionally unmuted every player channel and formats with mute flags were implemented by zeroing channel volume (`XMP_CHANNEL_MUTE` was informational). This was changed to make `XMP_CHANNEL_MUTE` functional in e99acd32, but this broke unmuting *non-muted* channels.

This bug can be observed by building the latest xmp-cli master (34154d12 or newer) and switching the player between two modules with different muted channels: mute values from the previous module leak into the next module.

This patch also fixes the GDM loader to not clobber channel volumes on load (the equivalent fix for IT was also in 4.5.0: df978f9).