### PR TITLE
Add new XMP_PLAYER_MODE defines.

### DIFF
--- a/docs/Changelog
+++ b/docs/Changelog
@@ -5,6 +5,10 @@ Stable versions
 	Changes by Alice Rowan:
 	- New API define: XMP_INST_NO_DEFAULT_PAN for xmp_subinstrument::pan
 	- New API defines: XMP_MARK_SKIP and XMP_MARK_END for xmp_module::xxo
+	- New API defines: XMP_MODE_MPT_MOD, XMP_MODE_MPT_S3M, XMP_MODE_MPT_XM,
+	  XMP_MODE_MPT_IT, XMP_MODE_MPT_ITSMP (ModPlug Tracker <=1.16);
+	  XMP_MODE_LIQUID, XMP_MODE_LIQUID_S3M, XMP_MODE_ORPHEUS. These are
+	  placeholders and not guaranteed to be particularly accurate yet.
 	- Add support for Pack-Ice ("Ice!", "ICE!") depacking.
 	- Add support for Software Visions DMF (Apocalypse Abyss MOD variant).
 	- Replace kernel list helper in iff.c with custom list management

--- a/docs/libxmp.rst
+++ b/docs/libxmp.rst
@@ -1095,6 +1095,14 @@ int xmp_set_player(xmp_context c, int param, int val)
           XMP_MODE_FT2          /* Play using FT2 bug emulation */
           XMP_MODE_IT           /* Play using IT quirks */
           XMP_MODE_ITSMP        /* Play using IT sample mode quirks */
+          XMP_MODE_MPT_MOD      /* Play using MPT quirks (MOD) */
+          XMP_MODE_MPT_S3M      /* Play using MPT quirks (S3M) */
+          XMP_MODE_MPT_XM       /* Play using MPT quirks (XM) */
+          XMP_MODE_MPT_IT       /* Play using MPT quirks (IT) */
+          XMP_MODE_MPT_ITSMP    /* Play using MPT quirks (IT smp. mode) */
+          XMP_MODE_LIQUID       /* Play using Liquid Tracker quirks */
+          XMP_MODE_LIQUID_S3M   /* Play using Liquid Tracker S3M quirks */
+          XMP_MODE_ORPHEUS      /* Play using Imago Orpheus quirks */
 
       By default, formats similar to S3M such as PTM or IMF will use S3M
       replayer (without Scream Tracker 3 quirks/bug emulation), and formats

--- a/include/xmp.h
+++ b/include/xmp.h
@@ -115,6 +115,14 @@ extern "C" {
 #define XMP_MODE_FT2		8	/* Play using FT2 bug emulation */
 #define XMP_MODE_IT		9	/* Play using IT quirks */
 #define XMP_MODE_ITSMP		10	/* Play using IT sample mode quirks */
+#define XMP_MODE_MPT_MOD	11	/* Play using ModPlug quirks (MOD) */
+#define XMP_MODE_MPT_S3M	12	/* Play using ModPlug quirks (S3M) */
+#define XMP_MODE_MPT_XM		13	/* Play using ModPlug quirks (XM) */
+#define XMP_MODE_MPT_IT		14	/* Play using ModPlug quirks (IT) */
+#define XMP_MODE_MPT_ITSMP	15	/* Play using ModPlug quirks (IT) */
+#define XMP_MODE_LIQUID		16	/* Play using Liquid Tracker quirks */
+#define XMP_MODE_LIQUID_S3M	17	/* Play using Liquid Tracker S3M quirks */
+#define XMP_MODE_ORPHEUS	18	/* Play using Imago Orpheus quirks */
 
 /* mixer types */
 #define XMP_MIXER_STANDARD	0	/* Standard mixer */

--- a/lite/Changelog
+++ b/lite/Changelog
@@ -5,6 +5,10 @@ Stable versions
 	Changes by Alice Rowan:
 	- New API define: XMP_INST_NO_DEFAULT_PAN for xmp_subinstrument::pan
 	- New API defines: XMP_MARK_SKIP and XMP_MARK_END for xmp_module::xxo
+	- New API defines: XMP_MODE_MPT_MOD, XMP_MODE_MPT_S3M, XMP_MODE_MPT_XM,
+	  XMP_MODE_MPT_IT, XMP_MODE_MPT_ITSMP (ModPlug Tracker <=1.16);
+	  XMP_MODE_LIQUID, XMP_MODE_LIQUID_S3M, XMP_MODE_ORPHEUS. These are
+	  placeholders and not guaranteed to be particularly accurate yet.
 	- All internal module time/duration calculations are now in doubles
 	  (fixes off-by-one module time on final tick of some modules).
 	- Fix XM volume effects cxx/dxx accidentally having effects memory.

--- a/src/common.h
+++ b/src/common.h
@@ -323,6 +323,9 @@ int libxmp_snprintf (char *, size_t, const char *, ...) LIBXMP_ATTRIB_PRINTF(3,4
 				 QUIRK_ENVFADE | QUIRK_ITVPOR | QUIRK_KEYOFF | \
 				 QUIRK_VIRTUAL | QUIRK_FILTER | QUIRK_RSTCHN | \
 				 QUIRK_IGSTPOR | QUIRK_S3MRTG | QUIRK_MARKER )
+#define QUIRKS_LIQUID		(QUIRK_FINEFX  | QUIRK_RTONCE)
+#define QUIRKS_ORPHEUS		(QUIRK_FILTER  | QUIRK_MARKER | QUIRK_RSTCHN | \
+				 QUIRK_ARPMEM)
 
 /* Quirks specific to flow effects, especially Pattern Loop. */
 #define FLOW_LOOP_GLOBAL_TARGET	(1 <<  0) /* Global target for all tracks */

--- a/src/load_helpers.c
+++ b/src/load_helpers.c
@@ -1,5 +1,5 @@
 /* Extended Module Player
- * Copyright (C) 1996-2025 Claudio Matsuoka and Hipolito Carraro Jr
+ * Copyright (C) 1996-2026 Claudio Matsuoka and Hipolito Carraro Jr
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -543,7 +543,7 @@ int libxmp_set_player_mode(struct context_data *ctx)
 		break;
 	case XMP_MODE_FT2:
 		m->c4rate = C4_NTSC_RATE;
-		m->quirk = QUIRKS_FT2 | QUIRK_FT2BUGS;
+		m->quirk = QUIRKS_FT2 | QUIRK_FT2ENV | QUIRK_FT2BUGS;
 		m->flow_mode = FLOW_MODE_GENERIC;
 		m->read_event_type = READ_EVENT_FT2;
 		break;
@@ -559,6 +559,57 @@ int libxmp_set_player_mode(struct context_data *ctx)
 		m->quirk &= ~(QUIRK_VIRTUAL | QUIRK_RSTCHN);
 		m->flow_mode = FLOW_MODE_IT_210;
 		m->read_event_type = READ_EVENT_IT;
+		break;
+	case XMP_MODE_MPT_MOD:
+		m->c4rate = C4_NTSC_RATE;
+		m->quirk = 0;
+		m->flow_mode = FLOW_MODE_MPT_116;
+		m->read_event_type = READ_EVENT_MOD;
+		m->period_type = PERIOD_AMIGA;
+		break;
+	case XMP_MODE_MPT_S3M:
+		q = m->quirk & (QUIRK_VSALL | QUIRK_ARPMEM);
+		m->c4rate = C4_NTSC_RATE;
+		m->quirk = QUIRKS_ST3 | q;
+		m->flow_mode = FLOW_MODE_MPT_116;
+		m->read_event_type = READ_EVENT_ST3;
+		break;
+	case XMP_MODE_MPT_XM:
+		m->c4rate = C4_NTSC_RATE;
+		m->quirk = QUIRKS_FT2 | QUIRK_FT2ENV;
+		m->flow_mode = FLOW_MODE_MPT_116;
+		m->read_event_type = READ_EVENT_FT2;
+		break;
+	case XMP_MODE_MPT_IT:
+		m->c4rate = C4_NTSC_RATE;
+		m->quirk = QUIRKS_IT | QUIRK_VIBHALF | QUIRK_VIBINV;
+		m->flow_mode = FLOW_MODE_MPT_116;
+		m->read_event_type = READ_EVENT_IT;
+		break;
+	case XMP_MODE_MPT_ITSMP:
+		m->c4rate = C4_NTSC_RATE;
+		m->quirk = QUIRKS_IT | QUIRK_VIBHALF | QUIRK_VIBINV;
+		m->quirk &= ~(QUIRK_VIRTUAL | QUIRK_RSTCHN);
+		m->flow_mode = FLOW_MODE_MPT_116;
+		m->read_event_type = READ_EVENT_IT;
+		break;
+	case XMP_MODE_LIQUID:
+		m->c4rate = C4_NTSC_RATE;
+		m->quirk = QUIRKS_LIQUID;
+		m->flow_mode = FLOW_MODE_LIQUID;
+		m->read_event_type = READ_EVENT_ST3;
+		break;
+	case XMP_MODE_LIQUID_S3M:
+		m->c4rate = C4_NTSC_RATE;
+		m->quirk = QUIRKS_LIQUID;
+		m->flow_mode = FLOW_MODE_LIQUID_COMPAT;
+		m->read_event_type = READ_EVENT_ST3;
+		break;
+	case XMP_MODE_ORPHEUS:
+		m->c4rate = C4_NTSC_RATE;
+		m->quirk = QUIRKS_ORPHEUS;
+		m->flow_mode = FLOW_MODE_ORPHEUS;
+		m->read_event_type = READ_EVENT_ST3;
 		break;
 	default:
 		return -1;

--- a/src/loaders/imf_load.c
+++ b/src/loaders/imf_load.c
@@ -550,7 +550,7 @@ static int imf_load(struct module_data *m, HIO_HANDLE *f, const int start)
     }
 
     m->c4rate = C4_NTSC_RATE;
-    m->quirk |= QUIRK_FILTER | QUIRK_MARKER | QUIRK_RSTCHN | QUIRK_ARPMEM;
+    m->quirk |= QUIRKS_ORPHEUS;
     m->flow_mode = FLOW_MODE_ORPHEUS;
     m->read_event_type = READ_EVENT_ST3;
 

--- a/src/loaders/liq_load.c
+++ b/src/loaders/liq_load.c
@@ -732,7 +732,7 @@ next_pattern:
 	    return -1;
     }
 
-    m->quirk |= QUIRK_FINEFX | QUIRK_RTONCE;
+    m->quirk |= QUIRKS_LIQUID;
     m->flow_mode = (lh.flags & LIQ_FLAG_SCREAM_TRACKER_COMPAT) ?
 		   FLOW_MODE_LIQUID_COMPAT : FLOW_MODE_LIQUID;
     m->read_event_type = READ_EVENT_ST3;

--- a/src/loaders/no_load.c
+++ b/src/loaders/no_load.c
@@ -349,7 +349,7 @@ static int no_load(struct module_data *m, HIO_HANDLE *f, const int start)
 			return -1;
 	}
 
-	m->quirk |= QUIRK_FINEFX | QUIRK_RTONCE;
+	m->quirk |= QUIRKS_LIQUID;
 	m->flow_mode = FLOW_MODE_LIQUID;
 	m->read_event_type = READ_EVENT_ST3;
 


### PR DESCRIPTION
Adds several new `XMP_PLAYER_MODE` defines for trackers due to get their own player event routines within the next few versions:

* ModPlug Tracker <=1.16, early OpenMPT: `XMP_MODE_MPT_MOD`, `XMP_MODE_MPT_S3M`, `XMP_MODE_MPT_XM`, `XMP_MODE_MPT_IT`, `XMP_MODE_MPT_ITSMP`
* Liquid Tracker: `XMP_MODE_LIQUID`, `XMP_MODE_LIQUID_S3M`
* Imago Orpheus: `XMP_MODE_ORPHEUS`

These presets are probably not especially useful yet, though.