### PR TITLE
Fix MSVC CI log spam.

### DIFF
--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -267,7 +267,7 @@ jobs:
           cmake . -DCMAKE_BUILD_TYPE=Release -DWITH_UNIT_TESTS=ON -B build ${{ matrix.cmakeflags }}
       - name: CMake build
         run: |
-          cmake --build build --config Debug --target ALL_BUILD
+          cmake --build build --target ALL_BUILD
       - name: CMake checks
         run: |
           cd build


### PR DESCRIPTION
The regression test config was overriding the previous fix by specifying `--config Debug`? Not sure I understand the interplay between `CMAKE_BUILD_TYPE` and `--config` (and the docs don't really help...), but getting rid of this fixes the problem.