### PR TITLE
Add xmp_seek_time_frame for frame-precise time seeking.

### DIFF
--- a/docs/Changelog
+++ b/docs/Changelog
@@ -10,6 +10,14 @@ Stable versions
 	  In case of existing software misusing the old XMP_MAX_FRAMESIZE, the
 	  minimum value for mixer_data->total_size is the old XMP_MAX_FRAMESIZE
 	  for now.
+	- xmp_seek_time now always seeks (even if the position is the same
+	  as the current position) and uses the start row detected by the scan.
+	- New function: xmp_seek_time_frame, which attempts to seek to the time
+	  requested by the caller within frame precision. This is achieved by
+	  using xmp_seek_time then repeatedly calling xmp_play_frame until the
+	  *next* frame contains the caller-requested time. The caller can then
+	  use xmp_play_frame/xmp_play_buffer to render the requested frame.
+	  WARNING: this is more computationally expensive than xmp_seek_time.
 	- New function: xmp_set_tempo_factor_relative, to set a relative
 	  tempo factor without clobbering the module's tempo factor.
 	- New function: xmp_get_tempo_factor, to get the base tempo factor

--- a/docs/libxmp.rst
+++ b/docs/libxmp.rst
@@ -742,9 +742,12 @@ int xmp_next_position(xmp_context c)
 ````````````````````````````````````
 
   Skip replay to the start of the next position.
-  If the module was stopped with ``xmp_stop_module``, this operation
+  If the module was stopped with `xmp_stop_module()`_, this operation
   restarts the module at position 0. If the module is restarting
   at position 0, this operation does nothing.
+
+  libxmp functions that set the current position do not fully take effect until
+  the next `xmp_play_frame()`_ or `xmp_play_buffer()`_ call.
 
   **Parameters:**
     :c: the player context handle.
@@ -759,9 +762,12 @@ int xmp_prev_position(xmp_context c)
 ````````````````````````````````````
 
   Skip replay to the start of the previous position.
-  If the module was stopped with ``xmp_stop_module``, is restarting at
+  If the module was stopped with `xmp_stop_module()`_, is restarting at
   position 0, or if the previous position is part of a different sequence,
   this operation does nothing.
+
+  libxmp functions that set the current position do not fully take effect until
+  the next `xmp_play_frame()`_ or `xmp_play_buffer()`_ call.
 
   **Parameters:**
     :c: the player context handle.
@@ -776,8 +782,11 @@ int xmp_set_position(xmp_context c, int pos)
 ````````````````````````````````````````````
 
   Skip replay to the start of the given position.
-  If the module was stopped with ``xmp_stop_module``, this operation
+  If the module was stopped with `xmp_stop_module()`_, this operation
   will restart the module at the destination position.
+
+  libxmp functions that set the current position do not fully take effect until
+  the next `xmp_play_frame()`_ or `xmp_play_buffer()`_ call.
 
   **Parameters:**
     :c: the player context handle.
@@ -908,6 +917,9 @@ void xmp_restart_module(xmp_context c)
 
   Restart the currently playing module.
 
+  libxmp functions that set the current position do not fully take effect until
+  the next `xmp_play_frame()`_ or `xmp_play_buffer()`_ call.
+
   **Parameters:**
     :c: the player context handle.
 
@@ -916,7 +928,41 @@ void xmp_restart_module(xmp_context c)
 int xmp_seek_time(xmp_context c, int time)
 ``````````````````````````````````````````
 
-  Skip replay to the specified time.
+  Skip replay to the specified time. This function sets the current position to
+  the position closest to the specified time in the current sequence. This
+  function is fast, but not particularly precise; it does not process any
+  frames to seek closer to the requested time. For a more accurate (but much
+  slower) function, see `xmp_seek_time_frame()`_.
+
+  libxmp functions that set the current position do not fully take effect until
+  the next `xmp_play_frame()`_ or `xmp_play_buffer()`_ call.
+
+  **Parameters:**
+    :c: the player context handle.
+
+    :time: time to seek in milliseconds.
+
+  **Returns:**
+    The new position index, or ``-XMP_ERROR_STATE`` if the player is not
+    in playing state.
+
+.. _xmp_seek_time_frame():
+
+int xmp_seek_time_frame(xmp_context c, int time)
+````````````````````````````````````````````````
+
+  Skip replay to the specified time. This function sets the current position to
+  the position closest to the specified time in the current sequence, then
+  plays frames as-needed (via `xmp_play_frame()`_) until the player is
+  positioned at the frame containing the requested time. The caller can then
+  render this frame with a subsequent call to `xmp_play_frame()`_ or
+  `xmp_play_buffer()`_.
+
+  *Warning:* this function is computationally expensive. It is not
+  guaranteed to call `xmp_play_frame()`_, but may call it numerous times.
+
+  libxmp functions that set the current position do not fully take effect until
+  the next `xmp_play_frame()`_ or `xmp_play_buffer()`_ call.
 
   **Parameters:**
     :c: the player context handle.
@@ -939,8 +985,8 @@ int xmp_channel_mute(xmp_context c, int chn, int status)
 
     :chn: the channel to mute or unmute.
 
-    :status: 0 to mute channel, 1 to unmute, 2 the inverse of the current channel status, or -1 to query the
-      current channel status.
+    :status: 0 to mute channel, 1 to unmute, 2 the inverse of the current
+      channel status, or -1 to query the current channel status.
 
   **Returns:**
     The previous channel status, or ``-XMP_ERROR_STATE`` if the player is not
@@ -1163,7 +1209,8 @@ int xmp_set_player(xmp_context c, int param, int val)
 
       By default, formats similar to S3M such as PTM or IMF will use S3M
       replayer (without Scream Tracker 3 quirks/bug emulation), and formats
-      similar to XM such as RTM and MDL will use the XM replayer (without             FT2 quirks/bug emulation).
+      similar to XM such as RTM and MDL will use the XM replayer (without
+      FT2 quirks/bug emulation).
 
       Multichannel MOD files will use the XM replayer, and Scream Tracker 3
       MOD files will use S3M replayer with ST3 quirks. S3M files will use

--- a/include/xmp.h
+++ b/include/xmp.h
@@ -393,6 +393,7 @@ LIBXMP_EXPORT double      xmp_get_tempo_factor_relative(xmp_context);
 LIBXMP_EXPORT void        xmp_stop_module     (xmp_context);
 LIBXMP_EXPORT void        xmp_restart_module  (xmp_context);
 LIBXMP_EXPORT int         xmp_seek_time       (xmp_context, int);
+LIBXMP_EXPORT int         xmp_seek_time_frame (xmp_context, int);
 LIBXMP_EXPORT int         xmp_channel_mute    (xmp_context, int, int);
 LIBXMP_EXPORT int         xmp_channel_vol     (xmp_context, int, int);
 LIBXMP_EXPORT int         xmp_set_player      (xmp_context, int, int);

--- a/libxmp.map
+++ b/libxmp.map
@@ -79,4 +79,5 @@ XMP_4.7 {
     xmp_get_tempo_factor;
     xmp_get_tempo_factor_relative;
     xmp_set_tempo_factor_relative;
+    xmp_seek_time_frame;
 } XMP_4.5;

--- a/lite/Changelog
+++ b/lite/Changelog
@@ -10,6 +10,14 @@ Stable versions
 	  In case of existing software misusing the old XMP_MAX_FRAMESIZE, the
 	  minimum value for mixer_data->total_size is the old XMP_MAX_FRAMESIZE
 	  for now.
+	- xmp_seek_time now always seeks (even if the position is the same
+	  as the current position) and uses the start row detected by the scan.
+	- New function: xmp_seek_time_frame, which attempts to seek to the time
+	  requested by the caller within frame precision. This is achieved by
+	  using xmp_seek_time then repeatedly calling xmp_play_frame until the
+	  *next* frame contains the caller-requested time. The caller can then
+	  use xmp_play_frame/xmp_play_buffer to render the requested frame.
+	  WARNING: this is more computationally expensive than xmp_seek_time.
 	- New function: xmp_set_tempo_factor_relative, to set a relative
 	  tempo factor without clobbering the module's tempo factor.
 	- New function: xmp_get_tempo_factor, to get the base tempo factor

--- a/src/common.h
+++ b/src/common.h
@@ -575,6 +575,7 @@ struct flow_control {
 #define ROWDELAY_FIRST_FRAME	(1 << 1)
 	int rowdelay;		/* For IT pattern row delay */
 	int rowdelay_set;
+	int force_reposition;
 };
 
 struct virt_channel {
@@ -692,6 +693,7 @@ void	libxmp_free_scan	(struct context_data *);
 int	libxmp_scan_sequences	(struct context_data *);
 int	libxmp_get_sequence	(struct context_data *, int);
 int	libxmp_set_player_mode	(struct context_data *);
+double	libxmp_get_frame_time	(struct context_data *);
 void	libxmp_reset_flow	(struct context_data *);
 
 int8	read8s			(FILE *, int *err);

--- a/src/control.c
+++ b/src/control.c
@@ -220,6 +220,7 @@ void xmp_stop_module(xmp_context opaque)
 		return;
 
 	p->pos = -2;
+	libxmp_reset_flow(ctx);
 }
 
 void xmp_restart_module(xmp_context opaque)
@@ -232,6 +233,7 @@ void xmp_restart_module(xmp_context opaque)
 
 	p->loop_count = 0;
 	p->pos = -1;
+	libxmp_reset_flow(ctx);
 }
 
 int xmp_seek_time(xmp_context opaque, int time)
@@ -239,7 +241,9 @@ int xmp_seek_time(xmp_context opaque, int time)
 	struct context_data *ctx = (struct context_data *)opaque;
 	struct player_data *p = &ctx->p;
 	struct module_data *m = &ctx->m;
+	struct ord_data *oinfo;
 	double t;
+	int pos;
 	int i;
 
 	if (ctx->state < XMP_STATE_PLAYING)
@@ -266,6 +270,72 @@ int xmp_seek_time(xmp_context opaque, int time)
 	if (i < 0) {
 		xmp_set_position(opaque, 0);
 	}
+
+	/* Get the correct start row + force the next xmp_play_frame call to
+	 * do a reposition, which updates properties such as BPM and global
+	 * volume and normally doesn't happen within the same position: */
+	pos = p->pos >= 0 ? p->pos : m->seq_data[p->sequence].entry_point;
+
+	oinfo = &m->xxo_info[pos];
+	p->flow.jumpline = oinfo->start_row;
+	p->flow.force_reposition = 1;
+
+	/* For the first p->current_time + libxmp_get_frame_time check
+	 * in xmp_seek_time_frame: */
+	p->current_time = oinfo->time;
+	p->bpm = oinfo->bpm;
+
+	return p->pos < 0 ? 0 : p->pos;
+}
+
+int xmp_seek_time_frame(xmp_context opaque, int time)
+{
+	struct context_data *ctx = (struct context_data *)opaque;
+	struct player_data *p = &ctx->p;
+	struct module_data *m = &ctx->m;
+	double max_time, t;
+	int ret, i;
+
+	if ((ret = xmp_seek_time(opaque, time)) < 0) {
+		return ret;
+	}
+
+	/* set_position/xmp_set_position doesn't actually complete the seek;
+	 * may need to play frames from the start of the new position until
+	 * the player is at the closest frame to the requested time.
+	 * TODO: it may be possible to get closer times for xmp_play_buffer
+	 * users.
+	 */
+#if 0
+	D_(D_INFO "%d %d init: %.06f, %.06f >=? %.06f", p->pos, p->flow.jumpline,
+		p->current_time, p->current_time + libxmp_get_frame_time(ctx),
+		(double)time);
+#endif
+
+	max_time = m->seq_data[p->sequence].duration - 0.1;
+	t = MIN((double)time, max_time);
+
+	/* Try to find the correct frame (this may take a while).
+	 * TODO: temporarily put the mixer in a lower rate? */
+	for (i = 0; i < (1 << 13); i++) {
+		double prev = p->current_time;
+
+		/* TODO: the actual BPM isn't known until mid-frame. */
+		if (p->current_time + libxmp_get_frame_time(ctx) > t) {
+			break;
+		}
+		if (xmp_play_frame(opaque) < 0 || p->current_time < prev) {
+			break;
+		}
+#if 0
+		D_(D_INFO "%d %d %d: %.06f >=? %.06f", p->pos, p->row, p->frame,
+			p->current_time + libxmp_get_frame_time(ctx), t);
+#endif
+	}
+
+	/* Force an xmp_play_buffer refresh so the new (wrong) frame data
+	 * doesn't confuse the caller: */
+	xmp_play_buffer(opaque, NULL, 0, 0);
 
 	return p->pos < 0 ? 0 : p->pos;
 }

--- a/src/scan.c
+++ b/src/scan.c
@@ -238,14 +238,13 @@ static double scan_module(struct context_data *ctx, int ep, int chain)
 #ifndef LIBXMP_CORE_PLAYER
             info->st26_speed = st26_speed;
 #endif
-        }
+	    info->start_row = f.jumpline;
+	}
 
 	if (info->start_row == 0 && ord != 0) {
 	    if (ord == ep) {
 		start_time = time + m->time_factor * frame_count * base_time / bpm;
 	    }
-
-	    info->start_row = f.jumpline;
 	}
 
 	/* Get tracks in advance to speed up the event parsing loop. */

--- a/test-dev/test_api_seek_time.c
+++ b/test-dev/test_api_seek_time.c
@@ -1,16 +1,24 @@
 #include "test.h"
 
-int pos_ode2ptk[] = {
-	0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 
-	2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 
-	5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8, 9, 9, 9, 9, 
-	10, 10, 10, 11, 11, 11, 11, 12, 12, 12, 12, 13, 13, 
-	13, 13, 14, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 
-	17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 
+/* Test xmp_seek_time and xmp_seek_time_frame. */
+
+struct pos_row_frame {
+	int pos;
+	int row;
+	int frame;
+};
+
+static const int pos_ode2ptk[] = {
+	0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2,
+	2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5,
+	5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8, 9, 9, 9, 9,
+	10, 10, 10, 11, 11, 11, 11, 12, 12, 12, 12, 13, 13,
+	13, 13, 14, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16,
+	17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
 	17, 17, 17, 17, 17, 17, 17, 17, 17, 17
 };
 
-int pos_dlr[] = {
+static const int pos_dlr[] = {
 	0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4,
 	5, 5, 5, 5, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8, 9, 9,
 	9, 9, 10, 10, 10, 11, 11, 11, 11, 12, 12, 12, 12, 13,
@@ -19,6 +27,91 @@ int pos_dlr[] = {
 	20, 20, 21, 21, 21, 21, 22, 22, 22, 22, 23, 23, 23,
 	24, 24, 24, 24, 25, 25, 25, 25, 26, 26, 26, 27, 27
 };
+
+
+static const int seek_frame_times[] = {
+	0, -10, -10000, INT_MIN, 10000, 32767, INT_MAX, 12345
+};
+
+static const struct pos_row_frame frame_ode2ptk[] = {
+	{  0,  0, 0 },
+	{  0,  0, 0 },
+	{  0,  0, 0 },
+	{  0,  0, 0 },
+	{  2,  1, 2 },
+	{  5, 63, 1 },
+	{ 17, 39, 7 },
+	{  2, 20, 5 },
+};
+
+static const struct pos_row_frame frame_dlr[] = {
+	{  0,  0, 0 },
+	{  0,  0, 0 },
+	{  0,  0, 0 },
+	{  0,  0, 0 },
+	{  3, 13, 0 },
+	{  9, 23, 2 },
+	{ 44, 62, 2 },
+	{  3, 53, 2 },
+};
+
+static void test_seek_orders(xmp_context opaque, const int *table,
+	const char *test)
+{
+	char buf[128];
+	int ret, i;
+
+	for (i = 0; i < 100; i++) {
+		ret = xmp_seek_time(opaque, i * 1000);
+		snprintf(buf, sizeof(buf),
+			"xmp_seek_time to %ds failed in '%s': expected ord %d, got %d",
+			i, test, table[i], ret);
+		fail_unless(ret == table[i], buf);
+
+		ret = xmp_seek_time_frame(opaque, i * 1000);
+		snprintf(buf, sizeof(buf),
+			"xmp_seek_time_frame to %ds failed in '%s': expected ord %d, got %d",
+			i, test, table[i], ret);
+		fail_unless(ret == table[i], buf);
+	}
+}
+
+/* Because all API seeks leave stale data in the row/frame vars,
+ * one frame needs to be played after every seek to get accurate info. */
+static void test_seek_frames(xmp_context opaque,
+	const struct pos_row_frame *table, const char *test)
+{
+	struct context_data *ctx = (struct context_data *)opaque;
+	struct module_data *m = &ctx->m;
+	struct player_data *p = &ctx->p;
+	char buf[128];
+	size_t i;
+	int ret;
+
+	for (i = 0; i < ARRAY_SIZE(seek_frame_times); i++) {
+		ret = xmp_seek_time(opaque, seek_frame_times[i]);
+		xmp_play_frame(opaque);
+		snprintf(buf, sizeof(buf),
+			"xmp_seek_time to %ds failed in '%s': expected %d %d 0, got %d %d %d",
+			seek_frame_times[i], test,
+			table[i].pos, m->xxo_info[ret].start_row,
+			ret, p->row, p->frame);
+		fail_unless(ret == table[i].pos, buf);
+		fail_unless(p->row == m->xxo_info[ret].start_row, buf);
+		fail_unless(p->frame == 0, buf);
+
+		ret = xmp_seek_time_frame(opaque, seek_frame_times[i]);
+		xmp_play_frame(opaque);
+		snprintf(buf, sizeof(buf),
+			"xmp_seek_time_frame to %ds failed in '%s': expected %d %d %d, got %d %d %d",
+			seek_frame_times[i], test,
+			table[i].pos, table[i].row, table[i].frame,
+			ret, p->row, p->frame);
+		fail_unless(ret == table[i].pos, buf);
+		fail_unless(p->row == table[i].row, buf);
+		fail_unless(p->frame == table[i].frame, buf);
+	}
+}
 
 static void test_order_times(xmp_context opaque, const char *test)
 {
@@ -55,8 +148,6 @@ static void test_order_times(xmp_context opaque, const char *test)
 TEST(test_api_seek_time)
 {
 	xmp_context ctx;
-	int ret;
-	int i;
 
 	/* Seek ode2ptk */
 
@@ -64,11 +155,9 @@ TEST(test_api_seek_time)
 	xmp_load_module(ctx, "data/ode2ptk.mod");
 	xmp_start_player(ctx, 8000, 0);
 
-	for (i = 0; i < 100; i++) {
-		ret = xmp_seek_time(ctx, i * 1000);
-		fail_unless(ret == pos_ode2ptk[i], "seek error");
-	}
+	test_seek_orders(ctx, pos_ode2ptk, "ode2ptk");
 	test_order_times(ctx, "ode2ptk");
+	test_seek_frames(ctx, frame_ode2ptk, "ode2ptk");
 
 	xmp_release_module(ctx);
 	xmp_free_context(ctx);
@@ -79,11 +168,9 @@ TEST(test_api_seek_time)
 	xmp_load_module(ctx, "data/m/xyce-dans_la_rue.xm");
 	xmp_start_player(ctx, 8000, 0);
 
-	for (i = 0; i < 100; i++) {
-		ret = xmp_seek_time(ctx, i * 1000);
-		fail_unless(ret == pos_dlr[i], "seek error");
-	}
+	test_seek_orders(ctx, pos_dlr, "dans_la_rue");
 	test_order_times(ctx, "dans_la_rue");
+	test_seek_frames(ctx, frame_dlr, "dans_la_rue");
 
 	xmp_release_module(ctx);
 	xmp_free_context(ctx);


### PR DESCRIPTION
Fixes some longstanding issues with `xmp_seek_time`:

* `xmp_seek_time` now always repositions regardless of the current position.
* `xmp_seek_time` now tries to seek to the correct starting row (as determined by the scan, which required a fix).

Also, adds a new API function called `xmp_seek_time_frame`, which calls `xmp_seek_time` then renders/discards frames until the next frame contains the time requested by the caller (or closest valid time). This is a much more expensive function call.

I also added API notes to all of the position seek functions to clarify that they do not fully take effect until the next frame is rendered.

Fixes #734.

-----

~~This patch is a draft for now because we may not want to make an existing API function suddenly be much more computationally expensive. The alternative is to keep the repositioning and start row fixes on `xmp_seek_time`, but to move the seek-to-tick behavior to a separate wrapper function called something like `xmp_seek_time_precise`.~~ Done, as `xmp_seek_time_frame`.  (The new function should fully replace `xmp_seek_time` in libxmp 5, whenever that is.) 