### PR TITLE
Add BUILD.md, CONTRIBUTING.md, pull request template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+<!-- Please provide a description of your changes here.
+     You may copy this from the commit text. -->
+
+## Licensing
+
+<!-- Check all applicable checkboxes using 'x'. -->
+
+- [ ] I hereby assign my copyright for this contribution to the libxmp
+      development team under the MIT license (where applicable).
+- [ ] I have read CONTRIBUTING.md and my contribution was made following
+      the policies specified in that document.
+
+<!-- Please add any licensing notes here per CONTRIBUTING.md,
+     including disclosure of potentially unclean code. -->
+
+## Related issues/pull requests
+
+Closes: <!-- Any issue(s)/pull request(s) that this closes, if relevant. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!-- Please provide a description of your changes here.
+     You may copy this from the commit text. -->
+
+## Licensing
+
+<!-- Check all applicable checkboxes using 'x'. -->
+
+- [ ] I hereby assign my copyright for this contribution to the libxmp
+      development team under the MIT license (where applicable).
+- [ ] I have read CONTRIBUTING.md and my contribution was made following
+      the policies specified in that document. None of my contribution was
+      created using LLMs or other generative "AI" software.
+
+<!-- Please add any licensing notes here per CONTRIBUTING.md,
+     including disclosure of potentially unclean code. -->
+
+## Related issues/pull requests
+
+Closes: <!-- Any issue(s)/pull request(s) that this closes, if relevant. -->

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -307,11 +307,11 @@ jobs:
           cmake . -DCMAKE_BUILD_TYPE=Release -DWITH_UNIT_TESTS=ON -B build ${{ matrix.cmakeflags }}
       - name: CMake build
         run: |
-          cmake --build build --target ALL_BUILD
+          cmake --build build --config Release --target ALL_BUILD
       - name: CMake checks
         run: |
           cd build
-          ctest -C Debug --output-on-failure
+          ctest -C Release --output-on-failure
       - name: Preparing NMake
         uses: ilammy/msvc-dev-cmd@v1
         with:

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,389 @@
+# Building libxmp
+
+This document covers build commands to compile libxmp.
+See CONTRIBUTING.md for guidelines on how to contribute patches.
+
+This document doesn't cover every configuration option for libxmp.
+See the `./configure` help text, CMakeLists.txt, or the relevant
+Makefile.(arch) for more information.
+
+
+## Autoconf/GNU Make (CLI)
+
+libxmp can be compiled with Autoconf and GNU Make, a POSIX shell, and GCC
+(or clang). This is libxmp's primary build system, and is recommended for
+development on Linux/BSD, macOS, Haiku, and others.
+
+(MSYS2 users will get better compilation times from CMake, but this build
+system is still required to regenerate the other build system Makefiles
+when developing in a git clone of libxmp and adding new compilation units
+or removing existing ones.)
+
+```sh
+# Configure libxmp
+./autogen.sh
+./configure
+
+# Build and test libxmp
+make
+make check
+
+# Run regression tests (only works when building from the Git repository)
+(cd test-dev && autoconf && ./configure)
+make devcheck
+```
+
+GNU Make supports parallel compilation via the command line option `-j#`, where
+`#` is the number of compilation workers. This can be used reduce compilation
+time. If `#` is omitted, GNU Make will spawn as many workers as possible.
+
+```sh
+# Build with 8 workers
+make -j8
+```
+
+### Debug printing
+
+To enable debug printing (warning: it is extremely verbose and should not
+be enabled for CI), edit Makefile, uncomment this line, and rebuild:
+
+```Makefile
+#CFLAGS += -DDEBUG
+```
+
+### Preparing other build systems
+
+This build system is used to regenerate the Makefiles for every other
+build system, which should be performed every time a new compilation unit
+is added:
+
+```sh
+make cmake-prepare
+make vc-prepare
+make watcom-prepare
+make emx-prepare
+```
+
+The regression tests system uses automatically constructed source file lists
+for CMake and NMAKE. Running the regression tests once with the GNU Make
+build system is sufficient to rebuild the list of test source files. Adding
+other new source files to the regression tests requires the following:
+
+```sh
+# Rebuild test-dev/Makefile.vc
+(cd test-dev && make vc-prepare)
+
+# There is currently no target to rebuild test-dev/CMakeLists.txt.
+# Base source files must be edited in manually.
+```
+
+### libxmp-lite (optional)
+
+libxmp-lite can be built alongside libxmp using the following commands.
+(If you are building libxmp-lite from its release tarball, just use the
+same instructions as above.)
+
+```sh
+./configure --enable-lite
+make lite
+make check-lite
+```
+
+### Static library (optional)
+
+Provide the `--enable-static` option to `./configure`, then build as usual:
+
+```sh
+./configure --enable-static
+```
+
+The shared library can also optionally be disabled with `--disable-shared`:
+
+```sh
+./configure --enable-static --disable-shared
+```
+
+### Installing libxmp
+
+This build system can install the library (or libraries) to the `--prefix`
+provided to `./configure` (by default, `/usr/local`).
+
+Combine with `doas` or `sudo` as-needed:
+
+```sh
+make install
+```
+
+
+## CMake (CLI)
+
+libxmp can also be built using CMake. This build system supports GCC, clang,
+and Microsoft Visual C++ (MSVC).
+
+```sh
+# Configure libxmp
+mkdir builddir
+cmake -B builddir -S . -DCMAKE_BUILD_TYPE=Release
+# When building from the Git repository, use this to enable regression tests.
+cmake -B builddir -S . -DCMAKE_BUILD_TYPE=Release -DWITH_UNIT_TESTS=ON
+
+# Build libxmp
+cmake --build builddir
+
+# Test libxmp and run regression tests (if enabled)
+(cd builddir && ctest --output-on-failure)
+```
+
+For MSVC, the configuration must be provided at build time:
+
+```sh
+# Build libxmp
+cmake --build builddir --config Release
+
+# Test libxmp and run regression tests (if enabled)
+cd builddir
+ctest -C Release --output-on-failure
+```
+
+Like GNU Make, CMake supports parallel compilation via the command line
+option `-j#` to reduce compilation time:
+
+```sh
+# Build with 8 workers
+cmake --build builddir -j8
+```
+
+### Debug printing
+
+To enable debug printing (warning: it is extremely verbose and should not
+be enabled for CI), reconfigure with this build type and rebuild.
+
+```sh
+cmake -B builddir -S . -DCMAKE_BUILD_TYPE=Debug
+```
+
+For MSVC, the configuration must be provided at build time:
+
+```sh
+# Build libxmp
+cmake --build builddir --config Debug
+
+# Test libxmp and run regression tests (if enabled)
+cd builddir
+ctest -C Debug --output-on-failure
+```
+
+### libxmp-lite (optional)
+
+libxmp-lite can be built alongside libxmp using the following commands.
+(If you are building libxmp-lite from its release tarball, just use the
+same instructions as above.)
+
+```sh
+cmake -B builddir -S . -DBUILD_LITE=ON
+cmake --build builddir
+(cd builddir && ctest)
+```
+
+### Static library (optional)
+
+The CMake build system builds both the static and shared libraies by default
+for most platforms.
+
+The static library can optionally be disabled with `BUILD_STATIC`:
+
+```sh
+cmake -B builddir -S . -DBUILD_STATIC=OFF
+```
+
+The shared library can optionally be disabled with `BUILD_SHARED`:
+
+```sh
+cmake -B builddir -S . -DBUILD_SHARED=OFF
+```
+
+### Installing libxmp
+
+This build system can install the library (or libraries).
+
+Combine with `doas` or `sudo` as-needed:
+
+```sh
+cmake --install builddir
+```
+
+By default, this installs to `/usr/local`. The install prefix can be
+customized by providing the option `--prefix`:
+
+```sh
+cmake --install builddir --prefix /path/to/my/prefix
+```
+
+
+## Microsoft Visual C++ (MSVC) with NMAKE (CLI)
+
+libxmp does not contain a Visual Studio project, but supports MSVC via
+NMAKE (or CMake, see above). This build system has no configuration step.
+
+```sh
+# Make and check libxmp
+nmake -f Makefile.vc
+nmake -f Makefile.vc check
+
+# Run regression tests (NMAKE)
+cd test-dev
+nmake -f Makefile.vc
+
+# libxmp-lite (optional)
+nmake -f Makefile.vc lite
+nmake -f Makefile.vc check-lite
+```
+
+The MSVC toolchain, command line tools, and Windows SDK (and optionally CMake)
+can be installed independently of Visual Studio using the Visual Studio
+installer. To use these tools, CMD.exe should be launched from one of the
+preconfigured shells installed by the Visual Studio installer.
+
+NMAKE does not support parallel compilation. The regression tests system
+provides `/MP` to MSVC instead. This option is not used in the library
+Makefiles, as it prevents incremental rebuilds. Because of this issue,
+CMake may be preferable for development with MSVC.
+
+### Debug printing
+
+To enable debug printing (warning: it is extremely verbose and should not
+be enabled for CI), edit Makefile.vc, uncomment this line, and rebuild:
+
+```Makefile
+#CFLAGS = $(CFLAGS) /DDEBUG
+```
+
+
+## Open Watcom (CLI)
+
+libxmp has Watcom makefiles for DOS, OS/2, Windows x86, and Linux.
+This build system does not support the regression tests, and probably
+shouldn't be used for serious development.
+
+### Building for DOS using Open Watcom
+
+```sh
+# Make and check libxmp
+wmake -f Makefile.dos
+wmake -f Makefile.dos check
+
+# libxmp-lite (optional)
+wmake -f Makefile.dos lite
+wmake -f Makefile.dos check-lite
+```
+
+### Building for OS/2 using Open Watcom
+
+```sh
+# Make and check libxmp
+wmake -f Makefile.os2
+wmake -f Makefile.os2 check
+
+# libxmp-lite (optional)
+wmake -f Makefile.os2 lite
+wmake -f Makefile.os2 check-lite
+```
+
+### Building for Windows x86 using Open Watcom
+
+```sh
+# Make and check libxmp
+wmake -f Makefile.w32
+wmake -f Makefile.w32 check
+
+# libxmp-lite (optional)
+wmake -f Makefile.w32 lite
+wmake -f Makefile.w32 check-lite
+```
+
+### Building for Linux using Open Watcom
+
+```sh
+# Make and check libxmp
+wmake -f Makefile.lnx
+wmake -f Makefile.lnx check
+
+# libxmp-lite (optional)
+wmake -f Makefile.lnx lite
+wmake -f Makefile.lnx check-lite
+```
+
+### Debug printing
+
+To enable debug printing (warning: it is extremely verbose and should not
+be enabled for CI), edit watcom.mif, uncomment this line, and rebuild:
+
+```Makefile
+#CFLAGS += -DDEBUG
+```
+
+
+## GCC/EMX KLIBC for OS/2 (CLI)
+
+This build system does not support the regression tests, and probably
+shouldn't be used for serious development.
+
+```sh
+# Make and check libxmp
+make -f Makefile.emx
+make -f Makefile.emx check
+
+# libxmp-lite (optional)
+make -f Makefile.emx lite
+make -f Makefile.emx check-lite
+```
+
+### Debug printing
+
+To enable debug printing (warning: it is extremely verbose and should not
+be enabled for CI), edit Makefile.emx, uncomment this line, and rebuild:
+
+```Makefile
+#CFLAGS += -DDEBUG
+```
+
+
+## VSCodium / Code-OSS / Visual Studio Code
+
+These IDEs have built-in Git support and can be configured to use Autoconf,
+CMake, or MSVC build commands. This requires familiarity with the command
+line build instructions. C language support is provided by clangd (or by
+Microsoft C/C++ Intellisense for official Microsoft builds of Code).
+
+Use these default settings:
+
+.vscode/settings.json:
+```json
+{
+  "editor.tabSize": 8,
+  "editor.insertSpaces": false
+}
+```
+
+.clangd:
+```yaml
+Diagnostics:
+  # clangd often just gets this plain wrong and also has no clue that other
+  # architectures may require some system includes that clangd doesn't.
+  UnusedIncludes: None
+```
+
+clangd requires a compile_commands.json file at the root of the workspace
+to determine the compiler and to resolve include paths.
+
+For Autoconf/GNU Make on Linux et al., this file is generated using the
+command line utility `bear`:
+```sh
+bear -- make -j8
+```
+
+For CMake, this file can be generated with the option
+`CMAKE_EXPORT_COMPILE_COMMANDS` during configuration:
+```sh
+cmake -B builddir -S . -DWITH_UNIT_TESTS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,226 @@
+# Contributing to libxmp
+
+The libxmp development team welcomes contributions that follow the
+guidelines of this document.
+
+
+## How should I contribute code?
+
+The current preferred manner of contribution is Git, via GitHub.
+Detailed instructions are available at the end of this document.
+Please read the entire document. Contributors are expected to
+assign copyright/licensing to the libxmp development team and to
+follow the reverse engineering and LLM usage policies detailed below.
+
+
+## License and Copyright Assignment
+
+You will be prompted to copyright assign all code that passes the
+copyrightability threshold to one of the existing license holders
+under the ***MIT license*** during the pull request process, usually
+this specific instance of it (substituting copyright year as needed):
+
+```C
+/* Extended Module Player
+ * Copyright (C) 1996-2026 Claudio Matsuoka and Hipolito Carraro Jr
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+```
+
+This license should be placed at the top of new files. For
+contributions to existing files, copyright will be assigned to the
+existing copyright holder(s).
+
+### Exception: "Contributed" external libraries
+
+External libraries that have been included as "contributed" code in
+libxmp, including Lhasa, xz, miniz, and stb-vorbis all should retain
+their original copyrights. Do not attempt to relicense such code to
+use libxmp's license. These third-party licenses should be stated in
+`docs/CREDITS`.
+
+
+## Reverse engineering policy
+
+libxmp's tracker playback compatibility is largely based on clean-room
+reverse engineering principles, such as black box testing, "wall"
+communication. All contributions should follow clean-room principles,
+unless otherwise not possible (our judgment call, not yours).
+
+https://en.wikipedia.org/wiki/Clean-room_design
+
+Specifically, sources that we do NOT consider to be clean, unless
+the original copyright holders have expressly given permission
+(proof will be requested):
+
+* FOSS/OSS code with licenses more restrictive than the MIT or BSD-3
+  licenses. These licenses include the MPL, (L)GPL, BSD-4, Creative
+  Commons (this should never be used on code), licenses with
+  non-commercial clauses, and ANY type of license that is incompatible
+  with the GNU General Public License versions 2 and 3. Here is a
+  helpful list of licenses, if you aren't sure:
+  https://www.gnu.org/licenses/license-list.en.html
+
+* Software with contradictary license terms; for example, if the
+  developer claims "public domain" in one place, but then states
+  usage conditions elsewhere that are incompatible with code in
+  the public domain.
+
+* Source code with a proprietary license, such as "source available",
+  "all rights reserved", or source code with no stated license (this
+  implicitly means "all rights reserved").
+
+* Disassemblies and decompilations are equivalent in license to their
+  source binary. The (rare) exception is clean-room decompilation
+  efforts made by writing clean source code and comparing the compiled
+  binary output to the original binary.
+
+Small amounts of proprietary code *may* be allowed if they are
+absolutely necessary for compatibility (protected usage) or fail to
+meet the requirements for copyrightability. In this case, please
+clearly state where and how proprietary code was used.
+
+
+## LLM policy
+
+The usage of LLMs, "coding agents", "chat bots", et al. when
+contributing to libxmp, outside of a handful of edge cases, is
+forbidden:
+
+* libxmp and xmp are written in C, which is a notoriously unsafe
+  language. The vast majority of training data on this language is
+  also unsafe, sometimes in subtle ways. An LLM is not a thinking
+  person that can reason through a solution; it is a stochastic
+  algorithm that produces output that statistically looks like it
+  "should be" correct. It can not be trusted to write safe C, and
+  our time would be better spent doing things other than debugging
+  verbose automatically generated code.
+
+* Likewise, automated "agent" issues and patches are almost always
+  a huge waste of time for developers. We don't want to read LLM
+  generated text, either.
+
+* The license of LLM output is fundamentally indeterminate. It is
+  not "public domain", as some claim, and there is no legal precedent
+  for this claim—or *any* other claim—as it hasn't been sufficiently
+  litigated (as of the writing of this document).
+
+  A sane and logical interpretation of the license of LLM training
+  data (and therefore its output) is that it is a derivative of all
+  input data, and thus subject to the same licenses as the input data.
+  Under this interpretation, there is *no* coding model that we are
+  aware of with a clean training set; they *all* contain code with
+  licenses ranging from permissive to proprietary to copyleft,
+  particularly, *mutually exclusive licenses* which are incompatible
+  with our license requirements stated above. It is because of this
+  that we consider *all* LLM output that passes the copyrightability
+  threshold to be tainted and unsuitable for libxmp.
+
+* If you don't enjoy software engineering enough or don't care about
+  tracker module software enough to write your own code, there's a
+  decent chance you're also not going to check your LLM's code for
+  errors before contributing it here. :)
+
+In a small number of situations, the output of an LLM is considered
+acceptable:
+
+* Code generation that fails to pass the copyrightability threshold,
+  in other words, small scale/single line autocomplete.
+
+* Machine translation between languages for the purposes of developer
+  communication. (User-facing translations are better performed by a
+  human.)
+
+* *Trusted* code scanning utilities may be able to provide useful
+  feedback in CI, provided they don't block merging, spam excess
+  comments, or sell our data.
+
+
+## Using of GitHub to contribute (CLI, GCC/Clang)
+
+Create a GitHub account, add your SSH key, fork the libxmp repository
+to your account, clone it locally, and create a new branch for your
+contribution.
+
+```sh
+git clone git@github.com:MyAccount/libxmp.git
+cd libxmp
+```
+
+libxmp can be compiled with Autoconf and GNU Make (or CMake), a POSIX shell,
+and a C compiler.
+
+```sh
+autoconf
+./configure
+make -j8
+
+# CMake
+mkdir builddir
+cmake -B builddir -S . -DWITH_UNIT_TESTS=ON
+cmake --build builddir
+```
+
+While making changes to the libxmp source code, you should verify
+them against libxmp's built-in regression testing system. The basic
+test files are included in both source distributions and the Git
+repository; however, the full regression test suite is *only*
+included in the Git repository.
+
+```sh
+# Basic test (Autoconf)
+make test
+
+# Full regression test suite (Autoconf)
+(cd test-dev && autoconf && ./configure)
+make devcheck -j8
+
+# Full regression test suite (CMake)
+(cd builddir && ctest)
+```
+
+Create a new branch for your contribution:
+
+```sh
+git checkout -b my-patch
+```
+
+After making changes, commit them, and then push the branch to your
+GitHub account's fork.
+
+```sh
+# You will be prompted to write a commit message.
+# The first line should be a short commit summary of about 64
+# characters or fewer; leave the second line blank, and then write
+# a more detailed summary (if needed) on the following lines.
+# These lines should be wrapped to 72 characters.
+git commit -a
+
+git push --set-upstream origin my-patch
+```
+
+Navigate to your GitHub libxmp fork in your web browser of choice,
+find your branch on the Branches page, click the "..." button next
+to the `my-patch` branch to open the menu, and select "New pull
+request". The pull request template will prompt you to assign
+copyright, to verify that you have followed the guidelines of
+this document, and to explain in detail any deviations from these
+guidelines (if any); you can type `x` into the checkboxes, or click
+them after making the pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ acceptable:
   comments, or sell our data.
 
 
-## Using of GitHub to contribute (CLI, GCC/Clang)
+## Using GitHub to contribute (CLI, GCC/Clang)
 
 Create a GitHub account, add your SSH key, fork the libxmp repository
 to your account, clone it locally, and create a new branch for your
@@ -186,7 +186,7 @@ included in the Git repository.
 
 ```sh
 # Basic test (Autoconf)
-make test
+make check
 
 # Full regression test suite (Autoconf)
 (cd test-dev && autoconf && ./configure)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,211 @@
+# Contributing to libxmp
+
+The libxmp development team welcomes contributions that follow the
+guidelines of this document. Please read the entire document. Contributors
+are expected to assign copyright/licensing to the libxmp development team
+and to follow the policies detailed below.
+
+* Do NOT contribute code, issues, pull requests, or documentation created
+  using LLMs, "coding agents", "chat bots", or other generative "AI" software.
+
+* Use clean-room reverse engineering principles wherever possible.
+
+
+## How should I contribute code?
+
+The current preferred manner of contribution is Git, via GitHub.
+Detailed instructions are available at the end of this document.
+
+
+## License and Copyright Assignment
+
+During the pull request process, you will be prompted to assign the copyright
+of your contributed code to one of the existing license holders under
+the ***MIT license*** (also referred to as the ***Expat License*** by FSF):
+
+```C
+/* Extended Module Player
+ * Copyright (C) 1996-2026 Claudio Matsuoka and Hipolito Carraro Jr
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+```
+
+This license should be placed at the top of new source code files
+(substituting the copyright year as needed). For contributions to existing
+source files, copyright will be assigned to the existing copyright holder(s).
+
+### Exception: "Contributed" external libraries
+
+External libraries that have been included as "contributed" code in
+libxmp (including Lhasa, xz, miniz, and stb_vorbis) should retain their
+original copyrights. Do not attempt to relicense such code to use libxmp's
+license. These third-party licenses should be stated in `docs/CREDITS`.
+
+
+## Reverse engineering policy
+
+libxmp's tracker playback compatibility is largely based on clean-room
+reverse engineering principles, such as black box testing and "wall"
+communication. All contributions should follow clean-room principles,
+unless otherwise not possible (our judgment call, not yours).
+
+https://en.wikipedia.org/wiki/Clean-room_design
+
+Specifically, sources that we do NOT consider to be clean, unless
+the original copyright holders have expressly given permission
+(proof will be requested):
+
+* FOSS/OSS code with licenses more restrictive than the MIT and BSD-3
+  licenses, including the (L)GPL, MPL, BSD-4, Creative Commons, and
+  licenses with non-commercial clauses or ANY other requirement
+  incompatible with the GNU General Public License versions 2 and 3.
+  Here is a helpful list of licenses, if you aren't sure:
+  https://www.gnu.org/licenses/license-list.en.html
+
+* Software with contradictary license terms; for example, if the
+  developer claims "public domain" in one place, but then states
+  usage conditions elsewhere.
+
+* Source code with a proprietary license, such as "source available",
+  "all rights reserved", or source code with no stated license
+  (typically, this means "all rights reserved").
+
+* Disassemblies and decompilations are equivalent in license to their
+  source binary. The (rare) exception is clean-room decompilation
+  efforts made by writing clean source code and comparing the compiled
+  binary output to the original binary.
+
+Small amounts of proprietary code *may* be allowed if they are
+absolutely necessary for compatibility (protected usage) or fail to
+meet the requirements for copyrightability. In this case, please
+clearly state where and how proprietary code was used.
+
+
+## LLM policy
+
+The usage of LLMs, "coding agents", "chat bots", et al. when
+contributing to libxmp is prohibited:
+
+* libxmp and xmp are written in C and C++, which are notoriously unsafe
+  languages. The vast majority of training data on these languages are
+  also unsafe, sometimes in subtle ways. An LLM is not a thinking
+  person that can reason through a solution; it is a stochastic
+  algorithm that produces output that statistically looks like it
+  "should be" correct. It can not be trusted to write safe C or C++,
+  and our time would be better spent doing things other than debugging
+  verbose automatically generated code.
+
+* Likewise, "agent" issues, pull requests, and documentation are
+  almost always overly verbose and often contain factual errors.
+  We don't want to read or review LLM generated text. If there is
+  something worth saying, please write it yourself.
+
+* The license of LLM output is fundamentally indeterminate. It is
+  not "public domain", as some claim, and there is no legal precedent
+  for this claim—or *any* other claim—as it hasn't been sufficiently
+  litigated (as of the writing of this document).
+
+  libxmp prefers a sane and logical interpretation of the license of
+  LLM training data and output: the output is a derivative work of the
+  model, and the model is a derivative work of its training data, and
+  thus the former are subjects to the license(s) of the latter.
+
+  Under this interpretation, there is *no* coding model that we are
+  aware of with a clean training set; they *all* contain code with
+  licenses ranging from permissive to proprietary to copyleft,
+  particularly *mutually exclusive licenses* which are incompatible
+  with our license requirements stated above. Thus, *all* LLM output
+  passing the copyrightability threshold is tainted and unsuitable
+  for libxmp.
+
+In a small number of situations, the output of an LLM ***may*** be
+acceptable:
+
+* Code generation that fails to pass the copyrightability threshold:
+  in other words, small scale/single line autocomplete.
+
+* Machine translation between languages for the purposes of developer
+  communication. (This doesn't mean "ask Claude to write for you".)
+
+* *Trusted* code scanning utilities may be able to provide useful
+  feedback, but they should always be checked by a human, shouldn't
+  block merging or spam excess comments if used in CI, and shouldn't
+  profit or train off of our data.
+
+
+## Using Git CLI and GitHub to contribute
+
+If you already know how to use Git CLI (or your IDE's Git integration),
+you can skip most of this section.
+
+Create a GitHub account, add your SSH key, fork the libxmp repository
+to your account, and clone it locally.
+
+```sh
+git clone git@github.com:MyAccount/libxmp.git
+
+# If the default SSH port is blocked by your network, use this instead:
+git clone ssh://git@ssh.github.com:443/MyAccount/libxmp.git
+```
+
+Create a new branch for the changes you are contributing:
+
+```sh
+git checkout -b my-patch
+```
+
+When making changes to the libxmp source code, you should verify that
+your changes don't break any intended behavior using libxmp's built-in
+regression testing system. The basic test files are included in both
+source distributions and the Git repository; however, the full regression
+test suite is *only* included in the Git repository.
+
+libxmp uses GitHub Actions to automatically run the regression tests
+for branches and pull requests, but it is still useful to run them yourself
+before contributing. See BUILD.md for more information.
+
+After making changes, commit them, and then push the branch to your
+GitHub account's fork.
+
+```sh
+# Stage modified and new files for commit using "git add".
+# Some types of files, such as .MOD, must be added with the force (-f) option.
+git add file_1 file_2 file_3
+git add -f my_module.mod
+
+# You will be prompted to write a commit message.
+# The first line should be a short commit summary of about 64
+# characters or fewer; leave the second line blank, and then write
+# a more detailed summary (if needed) on the following lines.
+# These lines should be wrapped to 72 characters.
+git commit
+
+# Push your new commit(s) to your remote GitHub repository.
+git push --set-upstream origin my-patch
+```
+
+Navigate to your GitHub libxmp fork in your web browser of choice,
+find your branch on the Branches page, click the "..." button next
+to the `my-patch` branch to open the menu, and select "New pull
+request". The pull request template will prompt you to assign
+copyright, to verify that you have followed the guidelines of
+this document, and to explain in detail any deviations from these
+guidelines (if any); you can type `x` into the checkboxes, or click
+them after making the pull request.


### PR DESCRIPTION
***** This is very much a draft, currently. Feedback is welcome. *****

* This makes two implicit processes of accepting libxmp pull requests (MIT licensing and copyright assignment) explicit to the contributor.
* Add a new CONTRIBUTING.md file with explicit policies on reverse engineered code and LLM usage, and require pull requests to check a box indicating that this document has been read and followed.
  - AFAIK there's no clear statement anywhere else regarding clean contributions, hence the reverse engineering policy. Encouraging clean implementations and transparency re: which code is potentially "tainted" should also potentially reduce liability for us.
  - Recently, numerous open source projects have received large amounts of LLM slurry and OpenMPT has received large patches (one unsubmitted, two submitted and refused for merge) of dubious quality containing indicators of LLM "authorship". The chardet licensing situation was kind of the last straw for me on this. As noted elsewhere, it's not clear if this will actually prevent bad-faith LLM patches, but it's nice to have a clear position statement for our downstreams nonetheless. Saga Musix has indicated that he also intends to do something similar for OpenMPT/libopenmpt.

Closes: #980