### PR TITLE
Work around erroneous GCC -flto warning in iff.c

### DIFF
--- a/src/loaders/iff.c
+++ b/src/loaders/iff.c
@@ -197,10 +197,9 @@ int libxmp_iff_register(iff_handle opaque, const char *id, iff_loader loader)
 		return -1;
 
 	/* Note: previously was an strncpy */
+	memset(f->id, 0, sizeof(f->id));
 	for (; i < 4 && id && id[i]; i++)
 		f->id[i] = id[i];
-	for (; i < 4; i++)
-		f->id[i] = '\0';
 
 	f->loader = loader;
 	f->next = NULL;


### PR DESCRIPTION
In some cases, GCC is able to emit the erroneous warning:

```
In function 'libxmp_iff_register',
    inlined from 'okt_load' at contrib/libxmp/src/loaders/okt_load.c:387:9:
contrib/libxmp/src/loaders/iff.c:202:24: warning: iteration 2147483643 invokes undefined behavior [-Waggressive-loop-optimizations]
  202 |         for (; i < 4; i++)
      |                        ^
contrib/libxmp/src/loaders/iff.c:202:18: note: within this loop
  202 |         for (; i < 4; i++)
      |
```

I have only been able to reproduce this specifically building MegaZeux with devkitARM for the 3DS. Building libxmp separately with devkitARM does not reproduce this, even with all of the same compiler options.

Easy fix: instead of the second loop, just `memset` `f->id` to 0 before the first loop. It's only 4 bytes and has little risk of being expanded in size, so it should equivalent or faster in performance.

Closes #990.