### PR TITLE
Fix remaining -fsanitize=shift-base bugs affecting regression tests.

### DIFF
--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -420,7 +420,7 @@ jobs:
       - name: Create and run configure script
         run: |
           export CC=clang
-          export CFLAGS="-fsanitize=address,undefined -fno-sanitize-recover=all -fno-sanitize=shift-base -fno-omit-frame-pointer -g"
+          export CFLAGS="-fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer -g"
           export LDFLAGS="$CFLAGS"
           autoconf; ./configure
           (cd test-dev; autoconf; ./configure)

--- a/docs/Changelog
+++ b/docs/Changelog
@@ -1,6 +1,26 @@
 Stable versions
 ---------------
 
+4.7.1 (?):
+	Changes by Alice Rowan and Ozkan Sezer:
+	- Fix various -fsanitize=shift-base warnings:
+	  Various: QUIRK_FT2ENV and FLOW_LOOP_NO_ROW_SET
+	  src/dataio.c: read32l and read32b
+	  src/far_extras.c: FAR tempo conversion
+	  src/player.c: pitch envelope calculation
+	  src/mix_all.c: 8-bit samples and IT filter
+	  src/mixer.c: downmix_int_32bit
+	  src/loaders/amf_load.c: conversion of pan effect
+	  src/loaders/dbm_load.c: skipping 32-bit samples
+	  src/loaders/flt_load.c: conversion of finetune
+	  src/loaders/hmn_load.c: conversion of finetune
+	  src/loaders/pt3_load.c: conversion of finetune
+	  src/loaders/rtm_load.c: conversion of pan values
+	  src/loaders/umx_load.c: get_fci
+	  src/depackers/bunzip2.c: read_huffman_data
+	  src/depackers/unsqsh.c: get_bits_final
+	  src/depackers/lhasa/lha_file_header.c: decode_ftime
+
 4.7.0 (20260225):
 	Changes by Alice Rowan:
 	- Increase maximum sampling rate (XMP_MAX_SRATE) to 768000.

--- a/src/depackers/bunzip2.c
+++ b/src/depackers/bunzip2.c
@@ -330,9 +330,9 @@ static int read_block_header(struct bunzip_data *bd, struct bwdata *bw)
 static int read_huffman_data(struct bunzip_data *bd, struct bwdata *bw)
 {
   struct group_data *hufGroup;
-  int ii, jj, kk, runPos, dbufCount, symCount, selector, nextSym,
+  int ii, jj, kk, dbufCount, symCount, selector, nextSym,
     *byteCount;
-  unsigned hh, *dbuf = bw->dbuf;
+  unsigned hh, runPos, *dbuf = bw->dbuf;
   unsigned char uc;
 
   // We've finished reading and digesting the block header.  Now read this

--- a/src/depackers/lhasa/lha_file_header.c
+++ b/src/depackers/lhasa/lha_file_header.c
@@ -113,10 +113,10 @@ static int check_common_crc(LHAFileHeader *header)
 
 static unsigned int decode_ftime(uint8 *buf)
 {
-	int raw;
+	uint32 raw;
 	struct tm datetime;
 
-	raw = (int) readmem32l(buf);
+	raw = readmem32l(buf);
 
 	if (raw == 0) {
 		return 0;

--- a/src/depackers/unsqsh.c
+++ b/src/depackers/unsqsh.c
@@ -87,7 +87,8 @@ static int get_bits_final(struct io *io, int count)
 	 */
 	int r = readmem24b(io->src + (io->offs >> 3));
 
-	r <<= (io->offs % 8) + 8;
+	//r <<= (io->offs % 8) + 8;
+	r = XMP_ASL(r, (io->offs % 8) + 8);
 	r >>= 32 - count;
 	io->offs += count;
 

--- a/src/far_extras.c
+++ b/src/far_extras.c
@@ -110,7 +110,6 @@ int libxmp_far_translate_tempo(int mode, int fine_change, int coarse,
 		speed = 0;
 		while (divisor > 0xffff) {
 			divisor >>= 1;
-			tempo <<= 1;
 			speed++;
 		}
 		if (speed >= 2)
@@ -120,14 +119,16 @@ int libxmp_far_translate_tempo(int mode, int fine_change, int coarse,
 		 * remaining count before decrementing it but after handling
 		 * each tick, i.e. a count of "3" executes 4 ticks. */
 		speed++;
-		bpm = tempo;
+		/* TODO: non-integer BPMs: use PIT Hz here, make time factor 4.0? */
+		bpm = 1197255u / divisor;
 	} else {
 		/* "Old" FAR tempo
 		 * This runs into the XMP_MIN_BPM limit, but nothing uses it anyway.
 		 * Old tempo mode in the original FAR replayer has 32 ticks,
 		 * but ignores all except every 8th. */
+		/* TODO: this is also is affected by bad divisor math. */
 		speed = 4 << FAR_OLD_TEMPO_SHIFT;
-		bpm = (far_tempos[coarse] + *fine * 2) << FAR_OLD_TEMPO_SHIFT;
+		bpm = (uint16)(far_tempos[coarse] + *fine * 2) << FAR_OLD_TEMPO_SHIFT;
 	}
 
 	if (bpm < XMP_MIN_BPM)

--- a/src/loaders/amf_load.c
+++ b/src/loaders/amf_load.c
@@ -566,7 +566,7 @@ static int amf_load(struct module_data *m, HIO_HANDLE *f, const int start)
 						fxt = FX_SURROUND;
 						fxp = 1;
 					} else if (t3 >= 0xC0 || t3 <= 0x40) {
-						int pan = ((int8)t3 << 1) + 0x80;
+						int pan = ((int8)t3 * 2) + 0x80;
 						fxt = FX_SETPAN;
 						fxp = MIN(0xff, pan);
 					}

--- a/src/loaders/flt_load.c
+++ b/src/loaders/flt_load.c
@@ -412,7 +412,7 @@ static int flt_load(struct module_data *m, HIO_HANDLE * f, const int start)
 		xxs->lps = 2 * mh.ins[i].loop_start;
 		xxs->lpe = xxs->lps + 2 * mh.ins[i].loop_size;
 		xxs->flg = mh.ins[i].loop_size > 1 ? XMP_SAMPLE_LOOP : 0;
-		sub->fin = (int8) (mh.ins[i].finetune << 4);
+		sub->fin = (int8) ((uint8)mh.ins[i].finetune << 4);
 		sub->vol = mh.ins[i].volume;
 		sub->pan = XMP_INST_NO_DEFAULT_PAN;
 		sub->sid = i;

--- a/src/loaders/hmn_load.c
+++ b/src/loaders/hmn_load.c
@@ -235,7 +235,7 @@ static int hmn_load(struct module_data *m, HIO_HANDLE * f, const int start)
 
 		for (j = 0; j < mod->xxi[i].nsm; j++) {
 			mod->xxi[i].sub[j].fin =
-					-(int8)(mh.ins[i].finetune << 3);
+					-(int8)((uint8)mh.ins[i].finetune << 3);
 			mod->xxi[i].sub[j].vol = mh.ins[i].volume;
 			mod->xxi[i].sub[j].pan = XMP_INST_NO_DEFAULT_PAN;
 			mod->xxi[i].sub[j].sid = i;

--- a/src/loaders/pt3_load.c
+++ b/src/loaders/pt3_load.c
@@ -274,7 +274,7 @@ static int ptdt_load(struct module_data *m, HIO_HANDLE *f, const int start)
 		if (mod->xxs[i].len > 0)
 			mod->xxi[i].nsm = 1;
 
-		mod->xxi[i].sub[0].fin = (int8)(mh.ins[i].finetune << 4);
+		mod->xxi[i].sub[0].fin = (int8)((uint8)mh.ins[i].finetune << 4);
 		mod->xxi[i].sub[0].vol = mh.ins[i].volume;
 		mod->xxi[i].sub[0].pan = XMP_INST_NO_DEFAULT_PAN;
 		mod->xxi[i].sub[0].sid = i;

--- a/src/loaders/rtm_load.c
+++ b/src/loaders/rtm_load.c
@@ -299,7 +299,7 @@ static void rtm_translate_effect(uint8 *fxt, uint8 *fxp)
 /* Convert Real Tracker -64..64 pan values into xmp 0..255 pan values. */
 static int rtm_convert_pan(int8 pan)
 {
-	int v = ((int)pan << 1) + 0x80;
+	int v = (pan * 2) + 0x80;
 	CLAMP(v, 0, 255);
 	return v;
 }

--- a/src/loaders/umx_load.c
+++ b/src/loaders/umx_load.c
@@ -110,7 +110,7 @@ static fci_t get_fci (const char *in, int *pos)
 
 				if (in[3] & 0x80) {
 					size++;
-					a |= (in[4] & 0x3f) << 27;
+					a |= (uint32)(in[4] & 0x3f) << 27;
 				}
 			}
 		}

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -130,7 +130,7 @@ static void downmix_int_32bit(int32 *LIBXMP_RESTRICT dest,
 		} else if (smp <= min_value) {
 			*dest = LIM32_LO;
 		} else {
-			*dest = smp << shift;
+			*dest = XMP_ASL(smp, shift);
 		}
 
 		if (offs) *dest = (int32)((uint32)*dest + offs);

--- a/src/player.c
+++ b/src/player.c
@@ -1245,7 +1245,7 @@ static void process_frequency(struct context_data *ctx, int chn, int act)
 		/* IT pitch envelopes are always linear, even in Amiga period
 		 * mode. Each unit in the envelope scale is 1/25 semitone.
 		 */
-		linear_bend += frq_envelope << 7;
+		linear_bend += frq_envelope * 128;
 	}
 
 	/* Arpeggio */


### PR DESCRIPTION
This does NOT fix every such issue in libxmp, just the ones that were preventing -fsanitize=shift-base being enabled on CI.

Closes #991.