### PR TITLE
Allow loading Archimedes MUSX files with broken SDAT subchunk.

### DIFF
--- a/docs/Changelog
+++ b/docs/Changelog
@@ -4,6 +4,8 @@ Stable versions
 4.7.1 (?):
 	Changes by Alice Rowan:
 	- Fix conversion of MED synth/hybrid finetune.
+	- Allow Archimedes MUSX modules to load if the SDAT instrument
+	  subchunk is broken (fixes 5-OverPar).
 	Changes by Alice Rowan and Ozkan Sezer:
 	- Fix various -fsanitize=shift-base warnings:
 	  Various: QUIRK_FT2ENV and FLOW_LOOP_NO_ROW_SET

--- a/src/loaders/arch_load.c
+++ b/src/loaders/arch_load.c
@@ -423,8 +423,12 @@ static int get_samp(struct module_data *m, uint32 size, HIO_HANDLE *f, void *par
 	hio_read32l(f);
 	mod->xxs[i].lpe = hio_read32l(f);
 
-	if (hio_read32b(f) != MAGIC_SDAT)	/* SDAT */
-		return -1;
+	if (hio_read32b(f) != MAGIC_SDAT) {	/* SDAT */
+		/* This is corrupt in the final sample of 5-OverPar.
+		 * TODO: a more robust IFF handler for these fields would
+		 * be better. */
+		mod->xxs[i].len = 0;
+	}
 	hio_read32l(f);
 	hio_read32l(f);	/* 0x00000000 */
 


### PR DESCRIPTION
Related: #869