### PR TITLE
Fix various smix API bugs.

### DIFF
--- a/docs/libxmp.rst
+++ b/docs/libxmp.rst
@@ -1419,8 +1419,9 @@ int xmp_smix_channel_pan(xmp_context c, int chn, int pan)
     :pan: the pan value to set (0 to 255).
 
   **Returns:**
-    0 if the pan value was set, or ``-XMP_ERROR_INVALID`` if parameters
-    are invalid.
+    0 if the pan value was set, ``-XMP_ERROR_INVALID`` in
+    case of invalid parameters, or ``-XMP_ERROR_STATE`` if the player is not
+    in playing state.
 
 .. _xmp_smix_load_sample():
 

--- a/src/control.c
+++ b/src/control.c
@@ -54,6 +54,8 @@ void xmp_free_context(xmp_context opaque)
 	if (ctx->state > XMP_STATE_UNLOADED)
 		xmp_release_module(opaque);
 
+	xmp_end_smix(opaque);
+
 	free(m->instrument_path);
 	free(opaque);
 }

--- a/src/smix.c
+++ b/src/smix.c
@@ -71,16 +71,30 @@ int xmp_start_smix(xmp_context opaque, int chn, int smp)
 {
 	struct context_data *ctx = (struct context_data *)opaque;
 	struct smix_data *smix = &ctx->smix;
+	int smp_alloc;
 
 	if (ctx->state > XMP_STATE_LOADED) {
 		return -XMP_ERROR_STATE;
 	}
 
-	smix->xxi = (struct xmp_instrument *) calloc(smp, sizeof(struct xmp_instrument));
+	if (chn < 1 || smp < 0) {
+		return -XMP_ERROR_INVALID;
+	}
+	/* May already be initialized. Previously, this call
+	 * overwrote the old smix state and leaked it.  */
+	xmp_end_smix(opaque);
+
+	/* Sample count of 0 previously had undefined behavior,
+	 * possibly failing to allocate zero instruments/samples.
+	 * Allow it to allocate on the chance anything used it,
+	 * but do not allow usage of the extra sample. */
+	smp_alloc = MAX(smp, 1);
+
+	smix->xxi = (struct xmp_instrument *) calloc(smp_alloc, sizeof(struct xmp_instrument));
 	if (smix->xxi == NULL) {
 		goto err;
 	}
-	smix->xxs = (struct xmp_sample *) calloc(smp, sizeof(struct xmp_sample));
+	smix->xxs = (struct xmp_sample *) calloc(smp_alloc, sizeof(struct xmp_sample));
 	if (smix->xxs == NULL) {
 		goto err1;
 	}
@@ -167,7 +181,11 @@ int xmp_smix_channel_pan(xmp_context opaque, int chn, int pan)
 	struct module_data *m = &ctx->m;
 	struct channel_data *xc;
 
-	if (chn >= smix->chn || pan < 0 || pan > 255) {
+	if (ctx->state < XMP_STATE_PLAYING) {
+		return -XMP_ERROR_STATE;
+	}
+
+	if (chn >= smix->chn || chn < 0 || pan < 0 || pan > 255) {
 		return -XMP_ERROR_INVALID;
 	}
 
@@ -189,7 +207,7 @@ int xmp_smix_load_sample(xmp_context opaque, int num, const char *path)
 	int chn, rate, bits, size;
 	int retval = -XMP_ERROR_INTERNAL;
 
-	if (num >= smix->ins) {
+	if (num >= smix->ins || num < 0) {
 		retval = -XMP_ERROR_INVALID;
 		goto err;
 	}
@@ -305,7 +323,7 @@ int xmp_smix_release_sample(xmp_context opaque, int num)
 	struct context_data *ctx = (struct context_data *)opaque;
 	struct smix_data *smix = &ctx->smix;
 
-	if (num >= smix->ins) {
+	if (num >= smix->ins || num < 0) {
 		return -XMP_ERROR_INVALID;
 	}
 
@@ -324,6 +342,10 @@ void xmp_end_smix(xmp_context opaque)
 	struct smix_data *smix = &ctx->smix;
 	int i;
 
+	if (smix->xxs == NULL) {
+		return;
+	}
+
 	for (i = 0; i < smix->smp; i++) {
 		xmp_smix_release_sample(opaque, i);
 	}
@@ -332,4 +354,7 @@ void xmp_end_smix(xmp_context opaque)
 	free(smix->xxi);
 	smix->xxs = NULL;
 	smix->xxi = NULL;
+	smix->chn = 0;
+	smix->ins = 0;
+	smix->smp = 0;
 }

--- a/test-dev/Makefile.in
+++ b/test-dev/Makefile.in
@@ -103,8 +103,8 @@ API		= get_format_list create_context free_context \
 		  channel_mute channel_vol inject_event scan_module \
 		  set_tempo_factor set_instrument_path
 
-API_SMIX	= smix_play_instrument smix_load_sample smix_play_sample \
-		  smix_channel_pan
+API_SMIX	= smix_start smix_play_instrument smix_load_sample \
+		  smix_play_sample smix_channel_pan
 
 STORLEK		= 01_arpeggio_pitch_slide \
 		  02_arpeggio_no_value \

--- a/test-dev/all_tests.txt
+++ b/test-dev/all_tests.txt
@@ -295,6 +295,7 @@ test_api_inject_event
 test_api_scan_module
 test_api_set_tempo_factor
 test_api_set_instrument_path
+test_api_smix_start
 test_api_smix_play_instrument
 test_api_smix_load_sample
 test_api_smix_play_sample

--- a/test-dev/test_api_smix_channel_pan.c
+++ b/test-dev/test_api_smix_channel_pan.c
@@ -14,10 +14,18 @@ TEST(test_api_smix_channel_pan)
 	ctx = (struct context_data *)opaque;
 	p = &ctx->p;
 
-	xmp_start_smix(opaque, 1, 2);
-
 	ret = xmp_load_module(opaque, "data/mod.loving_is_easy.pp");
 	fail_unless(ret == 0, "load module");
+
+	/* Try to set pan before initializing */
+	ret = xmp_smix_channel_pan(opaque, 0, 0x55);
+	fail_unless(ret == -XMP_ERROR_STATE, "set pan before init");
+
+	xmp_start_smix(opaque, 1, 2);
+
+	/* Try to set before starting player */
+	ret = xmp_smix_channel_pan(opaque, 0, 0x66);
+	fail_unless(ret == -XMP_ERROR_STATE, "set pan before start player");
 
 	xmp_start_player(opaque, 44100, 0);
 
@@ -37,6 +45,9 @@ TEST(test_api_smix_channel_pan)
 	ret = xmp_smix_channel_pan(opaque, 2, 0x00);
 	fail_unless(ret == -XMP_ERROR_INVALID, "invalid channel");
 
+	ret = xmp_smix_channel_pan(opaque, -1, 0xaa);
+	fail_unless(ret == -XMP_ERROR_INVALID, "invalid channel");
+
 	ret = xmp_smix_channel_pan(opaque, 0, -1);
 	fail_unless(ret == -XMP_ERROR_INVALID, "invalid pan");
 
@@ -51,8 +62,16 @@ TEST(test_api_smix_channel_pan)
 	xmp_play_frame(opaque);
 	fail_unless(vi->pan == 127, "set pan right");
 
-	xmp_release_module(opaque);
+	xmp_end_player(opaque);
 	xmp_end_smix(opaque);
+
+	xmp_start_player(opaque, 44100, 0);
+
+	/* Try to set pan after deinit */
+	xmp_smix_channel_pan(opaque, 0, 0x78);
+	fail_unless(ret == -XMP_ERROR_INVALID, "set pan after deinit");
+
+	xmp_release_module(opaque);
 	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_api_smix_load_sample.c
+++ b/test-dev/test_api_smix_load_sample.c
@@ -21,6 +21,9 @@ TEST(test_api_smix_load_sample)
 	ret = xmp_smix_load_sample(opaque, 2, "data/blip.wav");
 	fail_unless(ret == -XMP_ERROR_INVALID, "load sample in invalid slot");
 
+	ret = xmp_smix_load_sample(opaque, -1, "data/blip.wav");
+	fail_unless(ret == -XMP_ERROR_INVALID, "load sample in invalid slot");
+
 	/* try to load non-existent file */
 	ret = xmp_smix_load_sample(opaque, 0, "doesnt.exist");
 	fail_unless(ret == -XMP_ERROR_SYSTEM, "sample doesn't exist");
@@ -37,9 +40,28 @@ TEST(test_api_smix_load_sample)
 	ret = xmp_smix_load_sample(opaque, 0, "data/blip.wav");
 	fail_unless(ret == 0, "load sample");
 
-	xmp_smix_release_sample(opaque, 0);
+	ret = xmp_smix_release_sample(opaque, 0);
+	fail_unless(ret == 0, "release sample");
 
+	/* Double free sample */
+	ret = xmp_smix_release_sample(opaque, 0);
+	fail_unless(ret == 0, "release sample (double free)");
+
+	/* Invalid sample number */
+	ret = xmp_smix_release_sample(opaque, -1);
+	fail_unless(ret == -XMP_ERROR_INVALID, "release sample with invalid number");
+
+	xmp_end_player(opaque);
 	xmp_end_smix(opaque);
+
+	/* Try to load sample after deinit */
+	ret = xmp_smix_load_sample(opaque, 0, "data/blip.wav");
+	fail_unless(ret == -XMP_ERROR_INVALID, "load sample after deinit");
+
+	/* Try to release sample after deinit */
+	ret = xmp_smix_release_sample(opaque, 0);
+	fail_unless(ret == -XMP_ERROR_INVALID, "release sample after deinit");
+
 	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_api_smix_play_instrument.c
+++ b/test-dev/test_api_smix_play_instrument.c
@@ -33,9 +33,15 @@ TEST(test_api_smix_play_instrument)
 	ret = xmp_smix_play_instrument(opaque, 31, 60, 64, 0);
 	fail_unless(ret == -XMP_ERROR_INVALID, "invalid instrument");
 
+	ret = xmp_smix_play_instrument(opaque, -1, 60, 64, 0);
+	fail_unless(ret == -XMP_ERROR_INVALID, "invalid instrument");
+
 	/* play instrument in invalid channel */
 	ret = xmp_smix_play_instrument(opaque, 31, 60, 64, 1);
-	fail_unless(ret == -XMP_ERROR_INVALID, "invalid instrument");
+	fail_unless(ret == -XMP_ERROR_INVALID, "invalid channel");
+
+	ret = xmp_smix_play_instrument(opaque, 31, 60, 64, -1);
+	fail_unless(ret == -XMP_ERROR_INVALID, "invalid channel");
 
 	ret = xmp_smix_play_instrument(opaque, 2, 60, 64, 0);
 	fail_unless(ret == 0, "play instrument");
@@ -82,8 +88,16 @@ TEST(test_api_smix_play_instrument)
 
 	fail_unless(!xc->period, "note end");
 
-	xmp_release_module(opaque);
+	xmp_end_player(opaque);
 	xmp_end_smix(opaque);
+
+	xmp_start_player(opaque, 44100, 0);
+
+	/* Try to play instrument after deinit */
+	ret = xmp_smix_play_instrument(opaque, 1, 60, 64, 0);
+	fail_unless(ret == -XMP_ERROR_INVALID, "play instrument after deinit");
+
+	xmp_release_module(opaque);
 	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_api_smix_play_sample.c
+++ b/test-dev/test_api_smix_play_sample.c
@@ -38,8 +38,14 @@ TEST(test_api_smix_play_sample)
 	ret = xmp_smix_play_sample(opaque, 2, 60, 64, 0);
 	fail_unless(ret == -XMP_ERROR_INVALID, "invalid sample");
 
+	ret = xmp_smix_play_sample(opaque, -1, 60, 64, 0);
+	fail_unless(ret == -XMP_ERROR_INVALID, "invalid sample");
+
 	/* play sample in invalid channel */
 	ret = xmp_smix_play_sample(opaque, 0, 60, 64, 1);
+	fail_unless(ret == -XMP_ERROR_INVALID, "invalid channel");
+
+	ret = xmp_smix_play_sample(opaque, 0, 60, 64, -1);
 	fail_unless(ret == -XMP_ERROR_INVALID, "invalid channel");
 
 	ret = xmp_smix_play_sample(opaque, 0, 60, 64, 0);
@@ -90,7 +96,15 @@ TEST(test_api_smix_play_sample)
 	xmp_smix_release_sample(opaque, 0);
 	xmp_smix_release_sample(opaque, 1);
 
+	xmp_end_player(opaque);
 	xmp_end_smix(opaque);
+
+	xmp_start_player(opaque, 44100, 0);
+
+	/* Try to play sample after deinit */
+	ret = xmp_smix_play_sample(opaque, 1, 60, 64, 0);
+	fail_unless(ret == -XMP_ERROR_INVALID, "play sample after deinit");
+
 	xmp_free_context(opaque);
 }
 END_TEST

--- a/test-dev/test_api_smix_start.c
+++ b/test-dev/test_api_smix_start.c
@@ -1,0 +1,62 @@
+#include "test.h"
+
+TEST(test_api_smix_start)
+{
+	xmp_context opaque;
+	struct context_data *ctx;
+	struct smix_data *smix;
+	int ret;
+
+	opaque = xmp_create_context();
+	ctx = (struct context_data *)opaque;
+	smix = &ctx->smix;
+
+	/* Invalid channel count */
+	ret = xmp_start_smix(opaque, 0, 2);
+	fail_unless(ret == -XMP_ERROR_INVALID, "invalid channel count");
+	ret = xmp_start_smix(opaque, -1, 2);
+	fail_unless(ret == -XMP_ERROR_INVALID, "invalid channel count");
+
+	/* Invalid sample count */
+	ret = xmp_start_smix(opaque, 1, -1);
+	fail_unless(ret == -XMP_ERROR_INVALID, "invalid sample count");
+
+	/* Correct arguments */
+	ret = xmp_start_smix(opaque, 1, 2);
+	fail_unless(ret == 0, "valid arguments");
+
+	xmp_end_smix(opaque);
+	/* Double free should be safe */
+	xmp_end_smix(opaque);
+
+	/* Start smix after deinit should work without issues. */
+	ret = xmp_start_smix(opaque, 1, 2);
+	fail_unless(ret == 0, "init after deinit");
+	xmp_end_smix(opaque);
+
+	/* Sample count of zero should succeed but report 0 ins/smp. */
+	ret = xmp_start_smix(opaque, 1, 0);
+	fail_unless(ret == 0, "init with 0 samples");
+	fail_unless(smix->chn == 1, "should be 1");
+	fail_unless(smix->ins == 0, "should be 0");
+	fail_unless(smix->smp == 0, "should be 0");
+	fail_unless(smix->xxi != NULL, "should be allocated");
+	fail_unless(smix->xxs != NULL, "should be allocated");
+	/* Shouldn't leak the instrument/sample pointers. */
+	xmp_end_smix(opaque);
+
+	/* Double init should succeed, destroy the prior initialization.
+	 * Previously, this overwrote and leaked the old state. */
+	ret = xmp_start_smix(opaque, 1, 2);
+	fail_unless(ret == 0, "init after deinit");
+
+	ret = xmp_start_smix(opaque, 2, 3);
+	fail_unless(ret == 0, "init after init");
+	fail_unless(smix->chn == 2, "should now be 2");
+	fail_unless(smix->ins == 3, "should now be 3");
+	fail_unless(smix->smp == 3, "should now be 3");
+
+	/* Don't leak when corresponding xmp_end_smix call is missing. */
+	xmp_free_context(opaque);
+}
+END_TEST


### PR DESCRIPTION
* `xmp_free_context`: call `xmp_end_smix` instead of leaking smix data.
* `xmp_start_smix`: call `xmp_end_smix` instead of leaking prior smix data on double-allocation.
* `xmp_start_smix`: reject negative/zero channel counts.
* `xmp_start_smix`: reject negative sample counts, fix zero samples (as this technically worked on platforms that support 0 `nmemb`).
* `xmp_smix_channel_pan`: when outside of the playing state, fail with an error instead of dereferencing a null pointer.
* `xmp_smix_channel_pan`: reject negative channel numbers instead of corrupting the module channels or writing out-of-bounds.
* `xmp_smix_load_sample`: reject negative sample numbers instead of writing out-of-bounds.
* `xmp_smix_release_sample`: reject negative sample numbers instead of writing out-of-bounds.
* `xmp_end_smix`: exit early if no smix data is allocated instead of dereferencing null pointers.
* `xmp_end_smix`: clear `smix->chn`, `smix->ins`, `smix->smp` to prevent other smix calls from crashing after smix has been deinitialized.

This doesn't fix double-allocation in `xmp_smix_load_sample`, which needs a slightly more involved follow-up patch.

I do not consider the `xmp_smix_channel_pan` change to constitute an API change, as the player requirement was implicit (`p->xc_data` is not allocated until `xmp_start_player`, and this call would almost certainly crash prior to using it). I don't know why this wasn't being checked or documented.