### PR TITLE
Update libxmp.rst and examples to set XMP_PLAYER_DEFPAN to 50.

### DIFF
--- a/docs/Changelog
+++ b/docs/Changelog
@@ -3,6 +3,9 @@ Stable versions
 
 4.7.1 (?):
 	Changes by Alice Rowan:
+	- Add xmp_set_player(ctx, XMP_PLAYER_DEFPAN, 50) to relevant examples
+	  in libxmp.rst and in the examples directory, clarify it must be
+	  used BEFORE calling xmp_load_module, and recommend its usage.
 	- Fix XM channel default instrument memory (should be no instrument).
 	- Fix IT high offset being applied when no Oxx effect is present.
 	- Fix IT offsets >length setting the offset to sample end instead of 0

--- a/docs/libxmp.rst
+++ b/docs/libxmp.rst
@@ -71,6 +71,8 @@ sound file::
         /* Create the player context */
         c = xmp_create_context();
 
+        xmp_set_player(c, XMP_PLAYER_DEFPAN, 50);
+
         /* Load our module */
         if (xmp_load_module(c, argv[1]) != 0) {
             fprintf(stderr, "can't load module\n");
@@ -171,6 +173,7 @@ data. The module will play when ``SDL_PauseAudio(0)`` is called::
                 return 1;
 
         sound_init(ctx, 44100, 2);
+        xmp_set_player(ctx, XMP_PLAYER_DEFPAN, 50);
         xmp_load_module(ctx, argv[1]);
         xmp_start_player(ctx, 44100, 0);
 
@@ -1177,13 +1180,15 @@ int xmp_set_player(xmp_context c, int param, int val)
       computation of module duration without decompressing and
       loading large sample data, and is useful when duration information
       is needed for a module that won't be played immediately.
+      This option must be specified **before** calling `xmp_load_module()`_.
 
     * *[Added in libxmp 4.2]* Player volumes: Set the player master volume
       or the external sample mixer master volume. Valid values are 0 to 100.
 
     * *[Added in libxmp 4.3]* Default pan separation: percentual left/right
       pan separation in formats with only left and right channels. Default
-      is 100%.
+      is 100%, but 50% is recommended for most audio playback situations.
+      This option must be specified **before** calling `xmp_load_module()`_.
 
 .. raw:: pdf
 
@@ -1303,6 +1308,7 @@ as background music, and plays the sample when a key is pressed::
         xmp_start_smix(ctx, 1, 1);
         xmp_smix_load_sample(ctx, 0, "blip.wav");
 
+        xmp_set_player(ctx, XMP_PLAYER_DEFPAN, 50);
         xmp_load_module(ctx, "music.mod");
         xmp_start_player(ctx, 44100, 0);
         xmp_set_player(ctx, XMP_PLAYER_VOLUME, 40);

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,13 +1,16 @@
 
-CC = gcc
-CFLAGS = -O3 -Wall -I../include
-LD = gcc
-LDFLAGS =
+CC ?= gcc
+CFLAGS := -O3 -Wall -I../include $(CFLAGS)
+LD = $(CC)
+LDFLAGS ?=
 LIBS = -lxmp
+
+EXAMPLE_EXES	= player-simple player-showpatterns showinfo player-getbuffer player-openal player-openal-buffer
+EXAMPLE_EXES_SDL= player-sdl player-sdl2 player-sdl-smix player-sdl2-smix
 
 all: examples
 
-examples: player-simple player-showpatterns showinfo player-getbuffer player-openal player-openal-buffer
+examples: $(EXAMPLE_EXES)
 
 player-simple: player-simple.o alsa.o
 	$(LD) -o $@ $(LDFLAGS) $+ -lasound $(LIBS)
@@ -54,3 +57,10 @@ player-sdl2-smix: player-sdl2-smix.o
 
 player-sdl2-smix.o: player-sdl-smix.c
 	$(CC) $(CFLAGS) -c $+ -o $@ $$(pkg-config --cflags sdl2)
+
+clean:
+	@rm -f $(EXAMPLE_EXES)
+	@rm -f $(EXAMPLE_EXES:=.exe)
+	@rm -f $(EXAMPLE_EXES_SDL)
+	@rm -f $(EXAMPLE_EXES_SDL:=.exe)
+	@rm *.o

--- a/examples/player-getbuffer.c
+++ b/examples/player-getbuffer.c
@@ -23,6 +23,8 @@ int main(int argc, char **argv)
 
 	ctx = xmp_create_context();
 
+	xmp_set_player(ctx, XMP_PLAYER_DEFPAN, 50);
+
 	for (i = 1; i < argc; i++) {
 		if (xmp_load_module(ctx, argv[i]) < 0) {
 			fprintf(stderr, "%s: error loading %s\n", argv[0],

--- a/examples/player-openal-buffer.c
+++ b/examples/player-openal-buffer.c
@@ -81,6 +81,8 @@ int main(int argc, char **argv)
 
 	ctx = xmp_create_context();
 
+	xmp_set_player(ctx, XMP_PLAYER_DEFPAN, 50);
+
 	for (i = 1; i < argc; i++) {
 		if (xmp_load_module(ctx, argv[i]) < 0) {
 			fprintf(stderr, "%s: error loading %s\n", argv[0],

--- a/examples/player-openal.c
+++ b/examples/player-openal.c
@@ -73,6 +73,8 @@ int main(int argc, char **argv)
 
 	ctx = xmp_create_context();
 
+	xmp_set_player(ctx, XMP_PLAYER_DEFPAN, 50);
+
 	for (i = 1; i < argc; i++) {
 		if (xmp_load_module(ctx, argv[i]) < 0) {
 			fprintf(stderr, "%s: error loading %s\n", argv[0],

--- a/examples/player-sdl-smix.c
+++ b/examples/player-sdl-smix.c
@@ -39,9 +39,22 @@ static int sdl_init(xmp_context ctx)
 	return 0;
 }
 
-static void sdl_deinit()
+static void sdl_deinit(void)
 {
 	SDL_CloseAudio();
+}
+
+static int sdl_poll_exit(void)
+{
+	SDL_Event ev;
+
+	while (SDL_PollEvent(&ev)) {
+		switch (ev.type) {
+		case SDL_QUIT:
+			return 1;
+		}
+	}
+	return 0;
 }
 
 static void play_instrument(xmp_context ctx, int ins)
@@ -63,6 +76,8 @@ int main(int argc, char **argv)
 		fprintf(stderr, "%s: can't initialize sound\n", argv[0]);
 		exit(1);
 	}
+
+	xmp_set_player(ctx, XMP_PLAYER_DEFPAN, 50);
 
 	for (i = 1; i < argc; i++) {
 		if (xmp_load_module(ctx, argv[i]) < 0) {
@@ -87,7 +102,7 @@ int main(int argc, char **argv)
 			playing = 1;
 			SDL_PauseAudio(0);
 
-			while (playing) {
+			while (playing && !sdl_poll_exit()) {
 				int ins;
 				printf("Instrument to play: ");
 				scanf("%d", &ins);

--- a/examples/player-sdl.c
+++ b/examples/player-sdl.c
@@ -39,9 +39,22 @@ static int sdl_init(xmp_context ctx)
 	return 0;
 }
 
-static void sdl_deinit()
+static void sdl_deinit(void)
 {
 	SDL_CloseAudio();
+}
+
+static int sdl_poll_exit(void)
+{
+	SDL_Event ev;
+
+	while (SDL_PollEvent(&ev)) {
+		switch (ev.type) {
+		case SDL_QUIT:
+			return 1;
+		}
+	}
+	return 0;
 }
 
 int main(int argc, char **argv)
@@ -57,6 +70,8 @@ int main(int argc, char **argv)
 		fprintf(stderr, "%s: can't initialize sound\n", argv[0]);
 		exit(1);
 	}
+
+	xmp_set_player(ctx, XMP_PLAYER_DEFPAN, 50);
 
 	for (i = 1; i < argc; i++) {
 		if (xmp_load_module(ctx, argv[i]) < 0) {
@@ -77,7 +92,7 @@ int main(int argc, char **argv)
 			playing = 1;
 			SDL_PauseAudio(0);
 
-			while (playing) {
+			while (playing && !sdl_poll_exit()) {
 				SDL_Delay(10);
 				xmp_get_frame_info(ctx, &fi);
 				printf("%3d/%3d %3d/%3d\r", fi.pos,

--- a/examples/player-showpatterns.c
+++ b/examples/player-showpatterns.c
@@ -53,6 +53,8 @@ int main(int argc, char **argv)
 
 	ctx = xmp_create_context();
 
+	xmp_set_player(ctx, XMP_PLAYER_DEFPAN, 50);
+
 	for (i = 1; i < argc; i++) {
 		if (xmp_load_module(ctx, argv[i]) < 0) {
 			fprintf(stderr, "%s: error loading %s\n", argv[0],

--- a/examples/player-simple.c
+++ b/examples/player-simple.c
@@ -28,6 +28,8 @@ int main(int argc, char **argv)
 
 	ctx = xmp_create_context();
 
+	xmp_set_player(ctx, XMP_PLAYER_DEFPAN, 50);
+
 	for (i = 1; i < argc; i++) {
 		if (xmp_load_module(ctx, argv[i]) < 0) {
 			fprintf(stderr, "%s: error loading %s\n", argv[0],

--- a/examples/showinfo.c
+++ b/examples/showinfo.c
@@ -74,6 +74,11 @@ int main(int argc, char **argv)
 
 	ctx = xmp_create_context();
 
+	/* Since this is a diagnostic utility, it may be more useful to
+	 * use the real initial panning for hard-panned formats instead
+	 * of 50% pan separation. */
+	xmp_set_player(ctx, XMP_PLAYER_DEFPAN, 100);
+
 	for (i = 1; i < argc; i++) {
 		if (xmp_load_module(ctx, argv[i]) < 0) {
 			fprintf(stderr, "%s: error loading %s\n", argv[0],


### PR DESCRIPTION
* In all places where relevant, the examples set the panning separation now. The showinfo example sets it to 100 with a comment explaining why, and the rest set it to 50.
* libxmp.rst now explicitly states that `XMP_PLAYER_SMPCTL` and `XMP_PLAYER_DEFPAN` must be provided before loading a module.
* Fix examples/Makefile when `CC`, `CFLAGS`, `LDFLAGS` are externally set.
* Add a clean rule to examples/Makefile.
* Fix SDL examples ignoring exit events.

Assuming default panning is the problem with #1002, this addresses everything actionable regarding that issue that doesn't require a major version change. (Changelog entry here should go before the one from #1013.)

(I did not add SDL3 versions of the SDL examples, but I can in another patch if it'd be helpful.)