### PR TITLE
flt_load.c: Remove use of addressof operator on an array

### DIFF
--- a/src/loaders/flt_load.c
+++ b/src/loaders/flt_load.c
@@ -222,7 +222,7 @@ static int read_am_instrument(struct module_data *m, HIO_HANDLE *nt, int i)
 	uint8 buf[30];
 	int8 am_noise[1024];
 
-	memset(&buf, 0, sizeof(buf));
+	memset(buf, 0, sizeof(buf));
 
 	hio_seek(nt, 144 + i * 120 + 2 + 4, SEEK_SET);
 	/* Allow partial/missing AM instruments (GTS/fa.worse face.mod). */


### PR DESCRIPTION
Fixes W007 warning from Watcom C++:

```
src/loaders/flt_load.c(225): Warning! W007: col(16) '&array' may not produce intended result
```

Why do we not have an equivalent warning option for this in gcc?...
