### PR TITLE
stb_vorbis.c: Fix floor1 inverse_db_table indexing

### DIFF
--- a/src/loaders/vorbis.c
+++ b/src/loaders/vorbis.c
@@ -3172,7 +3172,7 @@ static int do_floor(vorb *f, Mapping *map, int i, int n, float *target, YTYPE *f
       if (lx < n2) {
          // optimization of: draw_line(target, lx,ly, n,ly, n2);
          for (j=lx; j < n2; ++j)
-            LINE_OP(target[j], inverse_db_table[ly]);
+            LINE_OP(target[j], inverse_db_table[ly&255]);
          CHECK(f);
       }
    }


### PR DESCRIPTION
<!-- Please provide a description of your changes here.
     You may copy this from the commit text. -->

CVE-2019-13220 fix added y&255 mask in draw_line(). However, do_floor()
has an inline optimization equivalent to draw_line(target,lx,ly,n,ly,n2)
without the same mask.
draw_line() uses inverse_db_table[y&255], but this doesn't. If bad input
causes ly to exceed 255, this can read past the end of inverse_db_table.
c.f.: https://github.com/nothings/stb/issues/1934.
Description from mainstream PR https://github.com/nothings/stb/pull/1973

## Licensing

<!-- Check all applicable checkboxes using 'x'. -->

- [ ] I hereby assign my copyright for this contribution to the libxmp
      development team under the MIT license (where applicable).
- [x] I have read CONTRIBUTING.md and my contribution was made following
      the policies specified in that document. None of my contribution was
      created using LLMs or other generative "AI" software.

<!-- Please add any licensing notes here per CONTRIBUTING.md,
     including disclosure of potentially unclean code. -->

[ This is a third party's patch to third party code as noted above, ]
