### PR TITLE
cmake: Do a build+link check for pipe, wait, fork, execvp, and dup2

### DIFF
--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -262,7 +262,7 @@ jobs:
         run: brew install autoconf
       - name: CMake configure for Intel
         run: |
-          cmake . -DCMAKE_BUILD_TYPE=Release -DWITH_UNIT_TESTS=ON -B build
+          cmake . -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES="x86_64" -DWITH_UNIT_TESTS=ON -B build
       - name: CMake build for Intel
         run: |
           cmake --build build --target all -- -j 4
@@ -276,6 +276,18 @@ jobs:
       - name: CMake build for M1
         run: |
           cmake --build build-m1 --target all
+      - name: CMake configure for iOS
+        run: |
+          cmake . -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_ARCHITECTURES="arm64" -DCMAKE_BUILD_TYPE=Release -DWITH_UNIT_TESTS=OFF -B build-ios
+      - name: CMake build for iOS
+        run: |
+          cmake --build build-ios --target all
+      - name: CMake configure for tvOS
+        run: |
+          cmake . -DCMAKE_SYSTEM_NAME=tvOS -DCMAKE_OSX_ARCHITECTURES="arm64" -DCMAKE_BUILD_TYPE=Release -DWITH_UNIT_TESTS=OFF -B build-tvos
+      - name: CMake build for tvOS
+        run: |
+          cmake --build build-tvos --target all
       - name: Create and run Autotools configure script
         run: |
           autoconf

--- a/Makefile.lnx
+++ b/Makefile.lnx
@@ -27,6 +27,6 @@ CFLAGS += -wcd=303
 # -5r  :  Pentium register calling conventions.
 CFLAGS += -5s
 CFLAGS += -I"$(%WATCOM)/lh"
-CFLAGS += -DHAVE_PIPE -DHAVE_FORK -DHAVE_EXECVP -DHAVE_FORK
+CFLAGS += -DHAVE_PIPE -DHAVE_FORK -DHAVE_EXECVP -DHAVE_WAIT -DHAVE_DUP2
 
 !include watcom.mif

--- a/cmake/libxmp-checks.cmake
+++ b/cmake/libxmp-checks.cmake
@@ -144,16 +144,28 @@ cmake_pop_check_state()
 xmp_check_function(popen "stdio.h" HAVE_POPEN)
 xmp_check_function(fnmatch "fnmatch.h" HAVE_FNMATCH)
 xmp_check_function(umask "sys/stat.h" HAVE_UMASK)
-xmp_check_function(wait "sys/wait.h" HAVE_WAIT)
 xmp_check_function(mkstemp "stdlib.h" HAVE_MKSTEMP)
 
 check_include_file(unistd.h HAVE_UNISTD_H)
+check_include_file(sys/wait.h HAVE_SYS_WAIT_H)
 
-if(HAVE_UNISTD_H)
-    xmp_check_function(pipe "unistd.h" HAVE_PIPE)
-    xmp_check_function(fork "unistd.h" HAVE_FORK)
-    xmp_check_function(execvp "unistd.h" HAVE_EXECVP)
-    xmp_check_function(dup2 "unistd.h" HAVE_DUP2)
+if(HAVE_UNISTD_H AND HAVE_SYS_WAIT_H)
+    check_c_source_compiles("#include <unistd.h>
+                             int fds[2];
+                             int main(void) { return pipe(fds) < 0; }" HAVE_PIPE)
+    check_c_source_compiles("#include <unistd.h>
+                             #include <sys/wait.h>
+                             int status;
+                             int main(void) { wait(&status); return 0; }" HAVE_WAIT)
+    check_c_source_compiles("#include <unistd.h>
+                             pid_t pid;
+                             int main(void) { pid = fork(); return 0; }" HAVE_FORK)
+    check_c_source_compiles("#include <unistd.h>
+                             int main(int argc, char** argv) { execvp(argv[0],(char* const*)argv);
+                             return argc; }" HAVE_EXECVP)
+    check_c_source_compiles("#include <unistd.h>
+                             int fds[2];
+                             int main(void) { dup2(fds[1],STDOUT_FILENO); return 0; }" HAVE_DUP2)
 endif()
 
 if(AMIGA)


### PR DESCRIPTION
Also add iOS and tvOS workflows to CI

Fixes https://github.com/libxmp/libxmp/issues/1020

<!-- Please provide a description of your changes here.
     You may copy this from the commit text. -->

## Licensing

<!-- Check all applicable checkboxes using 'x'. -->

- [x] I hereby assign my copyright for this contribution to the libxmp
      development team under the MIT license (where applicable).
- [x] I have read CONTRIBUTING.md and my contribution was made following
      the policies specified in that document. None of my contribution was
      created using LLMs or other generative "AI" software.
