### PR TITLE
Fix loading Startrekker modules from memory.

### DIFF
--- a/docs/Changelog
+++ b/docs/Changelog
@@ -1,6 +1,10 @@
 Stable versions
 ---------------
 
+4.7.2 (?):
+	Changes by Alice Rowan:
+	- Fix loading Startrekker modules from memory/handle/callbacks.
+
 4.7.1 (20260704):
 	Changes by Alice Rowan:
 	- Add xmp_set_player(ctx, XMP_PLAYER_DEFPAN, 50) to relevant examples

--- a/src/loaders/flt_load.c
+++ b/src/loaders/flt_load.c
@@ -334,7 +334,7 @@ static int flt_load(struct module_data *m, HIO_HANDLE * f, const int start)
 	struct libxmp_path sp;
 	size_t sp_length;
 	char buf[16];
-	HIO_HANDLE *nt;
+	HIO_HANDLE *nt = NULL;
 	int am_synth;
 
 	LOAD_INIT();
@@ -342,20 +342,19 @@ static int flt_load(struct module_data *m, HIO_HANDLE * f, const int start)
 	/* See if we have the synth parameters file */
 	am_synth = 0;
 	libxmp_path_init(&sp);
-	if (libxmp_path_join(&sp, m->dirname, m->basename) != 0) {
-		return -1;
-	}
-	sp_length = sp.length;
+	if (libxmp_path_join(&sp, m->dirname, m->basename) == 0) {
+		sp_length = sp.length;
 
-	nt = flt_check_sample_file(&sp, sp_length, ".NT");
-	if (nt == NULL) {
-		nt = flt_check_sample_file(&sp, sp_length, ".nt");
-	}
-	if (nt == NULL) {
-		nt = flt_check_sample_file(&sp, sp_length, ".AS");
-	}
-	if (nt == NULL) {
-		nt = flt_check_sample_file(&sp, sp_length, ".as");
+		nt = flt_check_sample_file(&sp, sp_length, ".NT");
+		if (nt == NULL) {
+			nt = flt_check_sample_file(&sp, sp_length, ".nt");
+		}
+		if (nt == NULL) {
+			nt = flt_check_sample_file(&sp, sp_length, ".AS");
+		}
+		if (nt == NULL) {
+			nt = flt_check_sample_file(&sp, sp_length, ".as");
+		}
 	}
 	libxmp_path_free(&sp);
 

--- a/test-dev/test_loader_flt8.c
+++ b/test-dev/test_loader_flt8.c
@@ -5,6 +5,8 @@ TEST(test_loader_flt8)
 	xmp_context opaque;
 	struct xmp_module_info info;
 	FILE *f;
+	void *buffer;
+	long size;
 	int ret;
 
 	f = fopen("data/format_flt8.data", "r");
@@ -17,6 +19,23 @@ TEST(test_loader_flt8)
 
 	ret = compare_module(info.mod, f);
 	fail_unless(ret == 0, "format not correctly loaded");
+
+	xmp_release_module(opaque);
+
+	/* This format supports optional external files.
+	 * Failing to open an external file should not cause a load failure.
+	 */
+	read_file_to_memory("data/m/Gidion_Graveland.mod", &buffer, &size);
+	fail_unless(buffer != NULL, "read file to memory");
+	ret = xmp_load_module_from_memory(opaque, buffer, size);
+	free(buffer);
+	fail_unless(ret == 0, "module load (memory)");
+
+	xmp_get_module_info(opaque, &info);
+
+	rewind(f);
+	ret = compare_module(info.mod, f);
+	fail_unless(ret == 0, "format not correctly loaded (memory)");
 
 	xmp_release_module(opaque);
 	xmp_free_context(opaque);


### PR DESCRIPTION
`libxmp_path_join` fails when either argument is `NULL`, which accidentally broke this loader for memory/handle/callbacks loads, which set `m->dirname` and `m->basename` to `NULL`.

## Licensing

- [x] I hereby assign my copyright for this contribution to the libxmp
      development team under the MIT license (where applicable).
- [x] I have read CONTRIBUTING.md and my contribution was made following
      the policies specified in that document. None of my contribution was
      created using LLMs or other generative "AI" software.